### PR TITLE
Fabo/fixed sign in loading order

### DIFF
--- a/app/src/renderer/vuex/modules/session.js
+++ b/app/src/renderer/vuex/modules/session.js
@@ -161,10 +161,10 @@ export default () => {
         account: accountAddress,
         optin: errorCollection
       })
-      dispatch(`loadPersistedState`)
+      await dispatch(`loadPersistedState`)
       commit(`toggleSessionModal`, false)
       dispatch(`loadErrorCollection`, accountAddress)
-      dispatch(`initializeWallet`, { address: accountAddress })
+      await dispatch(`initializeWallet`, { address: accountAddress })
       dispatch(`persistSession`, { localKeyPairName, address: accountAddress, sessionType })
 
       state.externals.track(`event`, `session`, `sign-in`, sessionType)

--- a/changes/fabo_fix-signin-state-loading-order
+++ b/changes/fabo_fix-signin-state-loading-order
@@ -1,0 +1,1 @@
+[Fixed] [#2441](https://github.com/cosmos/lunie/pull/2441) Fixed account cache restoration @faboweb


### PR DESCRIPTION
When signing in, sometimes the cache would overwrite the actual balance, there the balance would be wrong.

**Description:**

<!-- Briefly describe what you're adding or fixing with this PR -->

Thank you! 🚀

---

For contributor:

- [ ] Added changes entries. Run `yarn changelog` for a guided process.
- [ ] Reviewed `Files changed` in the github PR explorer
- [ ] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI
