### PR TITLE
automatic release created for v1.0.0-beta.43

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [1.0.0-beta.43] - 2019-04-16
+
+### Added
+
+- [#2449](https://github.com/cosmos/lunie/pull/2449) added new circle ci badge to readme @jbibla
+
+### Fixed
+
+- [#2435](https://github.com/cosmos/lunie/issues/2435) Fixed fee display for sending tokens @faboweb
+- [#2435](https://github.com/cosmos/lunie/issues/2435) Fixed fee denom not being correct and therefor sending not working @faboweb
+- [#2441](https://github.com/cosmos/lunie/pull/2441) Fixed account cache restoration @faboweb
+- [#2431](https://github.com/cosmos/lunie/issues/2431) check for ledger on submit to avoid action modal failures @jbibla
+- [#2449](https://github.com/cosmos/lunie/issues/2449) explore mode should not ask for password in action modals @jbibla
+- [#0](https://github.com/cosmos/lunie/issues/0) tm connected network still included the word testnet in the language @jbibla
+- [#2445](https://github.com/cosmos/lunie/issues/2445) page validator label should be ATOM not uatom @jbibla
+- [#2448](https://github.com/cosmos/lunie/issues/2448) proposal description is awkward @jbibla
+- [#2353](https://github.com/cosmos/lunie/issues/2353) cleaned up many styling issues and resolved scroll issue @jbibla
+
 ## [1.0.0-beta.42] - 2019-04-08
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [1.0.0-beta.42] - 2019-04-08
+
+### Fixed
+
+- [#2435](https://github.com/cosmos/lunie/issues/2435) Fixed fee display for sending tokens @faboweb
+- [#2435](https://github.com/cosmos/lunie/issues/2435) Fixed fee denom not being correct and therefor sending not working @faboweb
+- [#2441](https://github.com/cosmos/lunie/pull/2441) Fixed account cache restoration @faboweb
+
 ## [1.0.0-beta.41] - 2019-04-08
 
 ### Fixed

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,3 @@
-Tendermint Basecoin UI
-License: Apache2.0
-
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/
@@ -189,7 +186,7 @@ License: Apache2.0
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2017 All in Bits, Inc
+   Copyright 2019 Lunie International Software Systems Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/app/src/renderer/components/common/ActionModal.vue
+++ b/app/src/renderer/components/common/ActionModal.vue
@@ -231,7 +231,7 @@ export default {
     uatoms
   }),
   computed: {
-    ...mapGetters([`connected`, `session`, `bondDenom`, `wallet`]),
+    ...mapGetters([`connected`, `session`, `bondDenom`, `wallet`, `ledger`]),
     requiresSignIn() {
       return !this.session.signedIn
     },
@@ -344,7 +344,12 @@ export default {
       }
     },
     async submit() {
+      this.submissionError = null
       track(`event`, `submit`, this.title, this.selectedSignMethod)
+
+      if (!this.ledger.isConnected || !this.ledger.cosmosApp) {
+        await this.connectLedger()
+      }
 
       try {
         await this.submitFn(
@@ -362,7 +367,14 @@ export default {
           this.submissionError = null
         }, 5000)
       }
-    }
+    },
+    async connectLedger() {
+      try {
+        await this.$store.dispatch(`connectLedgerApp`)
+      } catch (error) {
+        this.submissionError = `${this.submissionErrorPrefix}: ${error}.`
+      }
+    },
   },
   validations() {
     return {

--- a/app/src/renderer/vuex/modules/ledger.js
+++ b/app/src/renderer/vuex/modules/ledger.js
@@ -64,7 +64,7 @@ export default () => {
         case `U2F: Timeout`:
           throw new Error(`No Ledger found`)
         case `Cosmos app does not seem to be open`:
-          throw new Error(`Cosmos app is not open`)
+          throw new Error(`Cosmos app is not open on the Ledger`)
         case `Unknown error code`: // TODO: create error for screensaver mode
           throw new Error(`Ledger's screensaver mode is on`)
         case `No errors`:

--- a/changes/fabo_2435-fix-sending-on-testnet
+++ b/changes/fabo_2435-fix-sending-on-testnet
@@ -1,2 +1,0 @@
-[Fixed] [#2435](https://github.com/cosmos/lunie/issues/2435) Fixed fee display for sending tokens @faboweb
-[Fixed] [#2435](https://github.com/cosmos/lunie/issues/2435) Fixed fee denom not being correct and therefor sending not working @faboweb

--- a/changes/fabo_fix-signin-state-loading-order
+++ b/changes/fabo_fix-signin-state-loading-order
@@ -1,1 +1,0 @@
-[Fixed] [#2441](https://github.com/cosmos/lunie/pull/2441) Fixed account cache restoration @faboweb

--- a/changes/jordan_2431-ledger-error
+++ b/changes/jordan_2431-ledger-error
@@ -1,1 +1,0 @@
-[Fixed] [#2431](https://github.com/cosmos/lunie/issues/2431) check for ledger on submit to avoid action modal failures @jbibla

--- a/changes/jordan_2431-ledger-error
+++ b/changes/jordan_2431-ledger-error
@@ -1,0 +1,1 @@
+[Fixed] [#2431](https://github.com/cosmos/lunie/issues/2431) check for ledger on submit to avoid action modal failures @jbibla

--- a/changes/jordan_2449-password
+++ b/changes/jordan_2449-password
@@ -1,5 +1,0 @@
-[Added] [#2449](https://github.com/cosmos/lunie/pull/2449) added new circle ci badge to readme @jbibla
-[Fixed] [#2449](https://github.com/cosmos/lunie/issues/2449) explore mode should not ask for password in action modals @jbibla
-[Fixed] [#0](https://github.com/cosmos/lunie/issues/0) tm connected network still included the word testnet in the language @jbibla
-[Fixed] [#2445](https://github.com/cosmos/lunie/issues/2445) page validator label should be ATOM not uatom @jbibla
-[Fixed] [#2448](https://github.com/cosmos/lunie/issues/2448) proposal description is awkward @jbibla

--- a/changes/jordan_cleanup-and-about-page
+++ b/changes/jordan_cleanup-and-about-page
@@ -1,1 +1,0 @@
-[Fixed] [#2353](https://github.com/cosmos/lunie/issues/2353) cleaned up many styling issues and resolved scroll issue @jbibla

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lunie",
   "productName": "lunie",
-  "version": "1.0.0-beta.42",
+  "version": "1.0.0-beta.43",
   "description": "Lunie is a web based user interface for the Cosmos Hub.",
   "author": "All In Bits, Inc <hello@tendermint.com>",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lunie",
   "productName": "lunie",
-  "version": "1.0.0-beta.41",
+  "version": "1.0.0-beta.42",
   "description": "Lunie is a web based user interface for the Cosmos Hub.",
   "author": "All In Bits, Inc <hello@tendermint.com>",
   "license": "Apache-2.0",


### PR DESCRIPTION
### Added

- [#2449](https://github.com/cosmos/lunie/pull/2449) added new circle ci badge to readme @jbibla

### Fixed

- [#2435](https://github.com/cosmos/lunie/issues/2435) Fixed fee display for sending tokens @faboweb
- [#2435](https://github.com/cosmos/lunie/issues/2435) Fixed fee denom not being correct and therefor sending not working @faboweb
- [#2441](https://github.com/cosmos/lunie/pull/2441) Fixed account cache restoration @faboweb
- [#2449](https://github.com/cosmos/lunie/issues/2449) explore mode should not ask for password in action modals @jbibla
- [#0](https://github.com/cosmos/lunie/issues/0) tm connected network still included the word testnet in the language @jbibla
- [#2445](https://github.com/cosmos/lunie/issues/2445) page validator label should be ATOM not uatom @jbibla
- [#2448](https://github.com/cosmos/lunie/issues/2448) proposal description is awkward @jbibla
- [#2353](https://github.com/cosmos/lunie/issues/2353) cleaned up many styling issues and resolved scroll issue @jbibla
