### PR TITLE
Fabo/readd insecure flag

### DIFF
--- a/changes/fabo_temporary-readded-of-insecure-flag
+++ b/changes/fabo_temporary-readded-of-insecure-flag
@@ -1,0 +1,1 @@
+[Added] [#2517](https://github.com/cosmos/lunie/pull/2517) Readded the insecure flag to allow users to access their local wallets @faboweb

--- a/src/scripts/boot.js
+++ b/src/scripts/boot.js
@@ -105,6 +105,9 @@ export const startApp = async (
   if (urlParams.rpc) {
     store.commit(`setRpcUrl`, urlParams.rpc)
   }
+  if (urlParams.insecure) {
+    store.commit(`setInsecureMode`)
+  }
 
   store.dispatch(`showInitialScreen`)
   store

--- a/src/scripts/url.js
+++ b/src/scripts/url.js
@@ -2,7 +2,7 @@ export function getURLParams(window, env = process.env.NODE_ENV) {
   const queries = window.location.search.slice(1).split(`&`)
   const parameters = queries.reduce((config, current) => {
     const [name, value] = current.split(`=`)
-    if ([`stargate`, `rpc`, `experimental`].includes(name)) {
+    if ([`stargate`, `rpc`, `experimental`, `insecure`].includes(name)) {
       return {
         ...config,
         [name]: value


### PR DESCRIPTION
because of the temporary checkin of the insecure mode users have created local wallets. I will readd the insecure flag so users can extract their tokens. if anyone asks, show them the flag. let's remove the flag again in like 2 weeks.

<!-- Briefly describe what you're adding or fixing with this PR -->

Thank you! 🚀

---

For contributor:

- [ ] Added changes entries. Run `yarn changelog` for a guided process.
- [ ] Reviewed `Files changed` in the github PR explorer
- [ ] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI
