### PR TITLE
automatic release created for v1.0.0-beta.55

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [1.0.0-beta.55] - 2019-05-02
+
+### Fixed
+
+- [#2519](https://github.com/cosmos/lunie/pull/2519) Cover outage by moving to nylira nodes @faboweb
+
 ## [1.0.0-beta.54] - 2019-05-02
 
 ### Added

--- a/changes/fabo_switch-to-nylira-nodes
+++ b/changes/fabo_switch-to-nylira-nodes
@@ -1,1 +1,0 @@
-[Fixed] [#2519](https://github.com/cosmos/lunie/pull/2519) Cover outage by moving to nylira nodes @faboweb

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lunie",
   "productName": "lunie",
-  "version": "1.0.0-beta.54",
+  "version": "1.0.0-beta.55",
   "description": "Lunie is the user interface for the Cosmos Hub.",
   "author": "Lunie International Software Systems Inc. <hello@lunie.io>",
   "license": "Apache-2.0",


### PR DESCRIPTION
### Fixed

- [#2519](https://github.com/cosmos/lunie/pull/2519) Cover outage by moving to nylira nodes @faboweb
