### PR TITLE
colw/2189 Close modal on escape key press

### DIFF
--- a/changes/colw_2189-close-modal-on-esc
+++ b/changes/colw_2189-close-modal-on-esc
@@ -1,0 +1,1 @@
+[Added] [#2189](https://github.com/cosmos/lunie/issues/2189) Escape key will close modal @colw

--- a/src/components/common/ActionModal.vue
+++ b/src/components/common/ActionModal.vue
@@ -1,6 +1,6 @@
 <template>
   <transition v-if="show" name="slide-fade">
-    <div class="action-modal" tabindex="0" @keyup.esc="close">
+    <div v-focus-last class="action-modal" tabindex="0" @keyup.esc="close">
       <div class="action-modal-header">
         <img
           class="icon action-modal-atom"

--- a/src/components/common/ActionModal.vue
+++ b/src/components/common/ActionModal.vue
@@ -1,6 +1,6 @@
 <template>
   <transition v-if="show" name="slide-fade">
-    <div class="action-modal">
+    <div class="action-modal" tabindex="0" @keyup.esc="close">
       <div class="action-modal-header">
         <img
           class="icon action-modal-atom"

--- a/src/components/common/TmModal.vue
+++ b/src/components/common/TmModal.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    v-focus
+    v-focus-last
     class="tm-modal"
     tabindex="0"
     @click.self="close()"

--- a/src/components/common/TmModal.vue
+++ b/src/components/common/TmModal.vue
@@ -1,5 +1,11 @@
 <template>
-  <div class="tm-modal" @click.self="close()">
+  <div
+    v-focus
+    class="tm-modal"
+    tabindex="0"
+    @click.self="close()"
+    @keyup.esc="close()"
+  >
     <main class="tm-modal-main">
       <slot name="main" />
     </main>

--- a/src/directives/index.js
+++ b/src/directives/index.js
@@ -1,0 +1,14 @@
+export const focusElement = {
+  inserted: el => {
+    el.focus()
+  }
+}
+
+// Directive to Focus an element, but only if a child does not have focus
+export const focusParentLast = {
+  inserted: el => {
+    if (!el.contains(document.activeElement)) {
+      el.focus()
+    }
+  }
+}

--- a/src/scripts/boot.js
+++ b/src/scripts/boot.js
@@ -19,6 +19,7 @@ import _Store from "../vuex/store"
 import * as urlHelpers from "scripts/url.js"
 import _config from "src/config"
 import { enableGoogleAnalytics } from "scripts/google-analytics"
+import { focusElement, focusParentLast } from "../directives"
 const _enableGoogleAnalytics = enableGoogleAnalytics
 
 export const routeGuard = store => (to, from, next) => {
@@ -55,13 +56,8 @@ export const startApp = async (
   Vue.use(Vuelidate)
   Vue.use(VueClipboard)
 
-  // directive to focus form fields
-  /* istanbul ignore next */
-  Vue.directive(`focus`, {
-    inserted: function(el) {
-      el.focus()
-    }
-  })
+  Vue.directive(`focus`, focusElement)
+  Vue.directive(`focus-last`, focusParentLast)
 
   // add error handlers in production
   if (env.NODE_ENV === `production`) {

--- a/test/unit/specs/App.spec.js
+++ b/test/unit/specs/App.spec.js
@@ -89,7 +89,7 @@ describe(`App Start`, () => {
   it(`Check the calls on VUE`, async () => {
     const { Vue } = await start()
 
-    expect(Vue.directive).toHaveBeenCalledTimes(1)
+    expect(Vue.directive).toHaveBeenCalledTimes(2)
     expect(Vue.use).toHaveBeenCalledTimes(4)
   })
 

--- a/test/unit/specs/components/common/ActionModal.spec.js
+++ b/test/unit/specs/components/common/ActionModal.spec.js
@@ -1,9 +1,11 @@
 import { shallowMount, createLocalVue } from "@vue/test-utils"
 import Vuelidate from "vuelidate"
 import ActionModal from "src/components/common/ActionModal"
+import { focusParentLast } from "directives"
 
 const localVue = createLocalVue()
 localVue.use(Vuelidate)
+localVue.directive("focus-last", focusParentLast)
 
 describe(`ActionModal`, () => {
   let wrapper, $store

--- a/test/unit/specs/components/common/ActionModal.spec.js
+++ b/test/unit/specs/components/common/ActionModal.spec.js
@@ -205,6 +205,11 @@ describe(`ActionModal`, () => {
       wrapper.vm.close()
       expect(wrapper.vm.step).toBe(`txDetails`)
     })
+
+    it(`should close on escape key press`, () => {
+      wrapper.trigger("keyup.esc")
+      expect(wrapper.isEmpty()).toBe(true)
+    })
   })
 
   describe(`validates child form`, () => {

--- a/test/unit/specs/components/common/TmModal.spec.js
+++ b/test/unit/specs/components/common/TmModal.spec.js
@@ -1,5 +1,9 @@
-import { shallowMount } from "@vue/test-utils"
+import { shallowMount, createLocalVue } from "@vue/test-utils"
 import TmModal from "common/TmModal"
+import { focusElement } from "directives"
+
+let localVue = createLocalVue()
+localVue.directive("focus", focusElement)
 
 describe(`TmModal`, () => {
   let wrapper
@@ -8,6 +12,7 @@ describe(`TmModal`, () => {
   beforeEach(() => {
     mockCloseFn = jest.fn()
     wrapper = shallowMount(TmModal, {
+      localVue,
       propsData: {
         close: mockCloseFn
       }
@@ -20,6 +25,7 @@ describe(`TmModal`, () => {
 
   it(`should use slots`, () => {
     wrapper = shallowMount(TmModal, {
+      localVue,
       slots: {
         title: `<div class="hello" />`,
         footer: `<div class="world" />`

--- a/test/unit/specs/components/common/TmModal.spec.js
+++ b/test/unit/specs/components/common/TmModal.spec.js
@@ -3,11 +3,13 @@ import TmModal from "common/TmModal"
 
 describe(`TmModal`, () => {
   let wrapper
+  let mockCloseFn
 
   beforeEach(() => {
+    mockCloseFn = jest.fn()
     wrapper = shallowMount(TmModal, {
       propsData: {
-        close: jest.fn()
+        close: mockCloseFn
       }
     })
   })
@@ -23,10 +25,15 @@ describe(`TmModal`, () => {
         footer: `<div class="world" />`
       },
       propsData: {
-        close: jest.fn()
+        close: mockCloseFn
       }
     })
     expect(wrapper.find(`custom-title`)).toBeDefined()
     expect(wrapper.find(`custom-footer`)).toBeDefined()
+  })
+
+  it(`should close with escape key`, () => {
+    wrapper.trigger("keyup.esc")
+    expect(mockCloseFn).toBeCalled()
   })
 })

--- a/test/unit/specs/components/common/TmModal.spec.js
+++ b/test/unit/specs/components/common/TmModal.spec.js
@@ -1,9 +1,9 @@
 import { shallowMount, createLocalVue } from "@vue/test-utils"
 import TmModal from "common/TmModal"
-import { focusElement } from "directives"
+import { focusParentLast } from "directives"
 
 let localVue = createLocalVue()
-localVue.directive("focus", focusElement)
+localVue.directive("focus-last", focusParentLast)
 
 describe(`TmModal`, () => {
   let wrapper

--- a/test/unit/specs/components/common/__snapshots__/ActionModal.spec.js.snap
+++ b/test/unit/specs/components/common/__snapshots__/ActionModal.spec.js.snap
@@ -4,6 +4,7 @@ exports[`ActionModal should show the action modal when user has logged in with l
 <div
   class="action-modal"
   name="slide-fade"
+  tabindex="0"
 >
   <div
     class="action-modal-header"
@@ -60,6 +61,7 @@ exports[`ActionModal should show the action modal when user has logged in with l
 <div
   class="action-modal"
   name="slide-fade"
+  tabindex="0"
 >
   <div
     class="action-modal-header"
@@ -124,6 +126,7 @@ exports[`ActionModal should show the action modal when user has logged in with l
 <div
   class="action-modal"
   name="slide-fade"
+  tabindex="0"
 >
   <div
     class="action-modal-header"
@@ -191,6 +194,7 @@ exports[`ActionModal should show the action modal when user has logged in with l
 <div
   class="action-modal"
   name="slide-fade"
+  tabindex="0"
 >
   <div
     class="action-modal-header"
@@ -247,6 +251,7 @@ exports[`ActionModal should show the action modal when user has logged in with l
 <div
   class="action-modal"
   name="slide-fade"
+  tabindex="0"
 >
   <div
     class="action-modal-header"
@@ -311,6 +316,7 @@ exports[`ActionModal should show the action modal when user has logged in with l
 <div
   class="action-modal"
   name="slide-fade"
+  tabindex="0"
 >
   <div
     class="action-modal-header"
@@ -383,6 +389,7 @@ exports[`ActionModal should show the action modal when user hasn't logged in 1`]
 <div
   class="action-modal"
   name="slide-fade"
+  tabindex="0"
 >
   <div
     class="action-modal-header"

--- a/test/unit/specs/components/common/__snapshots__/TmModal.spec.js.snap
+++ b/test/unit/specs/components/common/__snapshots__/TmModal.spec.js.snap
@@ -3,6 +3,7 @@
 exports[`TmModal has the expected html structure 1`] = `
 <div
   class="tm-modal"
+  tabindex="0"
 >
   <main
     class="tm-modal-main"

--- a/test/unit/specs/directives/directives.spec.js
+++ b/test/unit/specs/directives/directives.spec.js
@@ -1,0 +1,57 @@
+import { mount, createLocalVue } from "@vue/test-utils"
+import { focusElement, focusParentLast } from "directives"
+
+let localVue = createLocalVue()
+localVue.directive("focus", focusElement)
+localVue.directive("focus-last", focusParentLast)
+
+const mountOptions = {
+  localVue,
+  attachToDocument: true
+}
+
+describe("Focus element", () => {
+  let wrapper
+
+  const component = {
+    template: `<div tabindex="0" v-focus><input /></div>`
+  }
+
+  it("will focus correct element", () => {
+    wrapper = mount(component, mountOptions)
+    let focusedElement = wrapper.find("div").element
+    expect(focusedElement).toEqual(document.activeElement)
+  })
+
+  afterEach(() => {
+    wrapper.destroy()
+  })
+})
+
+describe("Focus Parent Element", () => {
+  let wrapper
+
+  const componentInputFocused = {
+    template: `<div tabindex="0" v-focus-last><input v-focus/></div>`
+  }
+
+  const componentParentFocused = {
+    template: `<div tabindex="0" v-focus-last><input /></div>`
+  }
+
+  it("will not focus parent element", () => {
+    wrapper = mount(componentInputFocused, mountOptions)
+    let focusedElement = wrapper.find("input").element
+    expect(focusedElement).toEqual(document.activeElement)
+  })
+
+  it("will focus parent element", () => {
+    wrapper = mount(componentParentFocused, mountOptions)
+    let focusedElement = wrapper.find("div").element
+    expect(focusedElement).toEqual(document.activeElement)
+  })
+
+  afterEach(() => {
+    wrapper.destroy()
+  })
+})


### PR DESCRIPTION
Closes #2189 

**Description:**

Ability to close modal by pressing the escape key

I created the directive `v-focus-last` to ensure that the modal will have focus when it pops up, and hence can use the escape key. Usually most modals have inputs which obtain focus, and thus the escape key press bubbles up, but it's not always the case. It's not the most elegant solution, but takes responsibility of focus away from the content if they they are not interested.

---

For contributor:

- [x] Added changes entries. Run `yarn changelog` for a guided process.
- [x] Reviewed `Files changed` in the github PR explorer
- [ ] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI
