### PR TITLE
colw/2446 validate delegation total

### DIFF
--- a/changes/colw_2446-validate-delegation-total
+++ b/changes/colw_2446-validate-delegation-total
@@ -1,0 +1,1 @@
+[Fixed] [#2446](https://github.com/cosmos/lunie/issues/2446) Validate total invoice amount, including network fees. @colw

--- a/src/components/common/ActionModal.vue
+++ b/src/components/common/ActionModal.vue
@@ -63,6 +63,13 @@
           :gas-estimate="Number(gasEstimate)"
           :gas-price="Number(gasPrice)"
         />
+        <TmFormMsg
+          v-if="$v.totalInvoice.$invalid"
+          name="Total"
+          type="between"
+          min="0"
+          :max="atoms(balance)"
+        />
       </div>
       <div v-else-if="step === `sign`" class="action-modal-form">
         <TmFormGroup
@@ -140,6 +147,7 @@
                 v-else-if="step !== `sign`"
                 color="primary"
                 value="Next"
+                :disabled="step === `fees` && $v.totalInvoice.$invalid"
                 @click.native="validateChangeStep"
               />
               <TmBtn
@@ -246,6 +254,11 @@ export default {
     balance() {
       return this.liquidAtoms
     },
+    totalInvoice() {
+      return (
+        Number(this.amount) + Number(this.gasPrice) * Number(this.gasEstimate)
+      )
+    },
     isValidChildForm() {
       // here we trigger the validation of the child form
       if (this.validate) {
@@ -318,6 +331,9 @@ export default {
           return
         case feeStep:
           if (!this.isValidInput(`gasPrice`)) {
+            return
+          }
+          if (!this.isValidInput(`totalInvoice`)) {
             return
           }
           this.step = signStep
@@ -396,6 +412,9 @@ export default {
         ),
         // we don't use SMALLEST as min gas price because it can be a fraction of uatom
         // min is 0 because we support sending 0 fees
+        between: between(0, atoms(this.balance))
+      },
+      totalInvoice: {
         between: between(0, atoms(this.balance))
       }
     }

--- a/src/components/common/ActionModal.vue
+++ b/src/components/common/ActionModal.vue
@@ -64,7 +64,7 @@
           :gas-price="Number(gasPrice)"
         />
         <TmFormMsg
-          v-if="$v.totalInvoice.$invalid"
+          v-if="$v.invoiceTotal.$invalid"
           name="Total"
           type="between"
           min="0"
@@ -147,7 +147,7 @@
                 v-else-if="step !== `sign`"
                 color="primary"
                 value="Next"
-                :disabled="step === `fees` && $v.totalInvoice.$invalid"
+                :disabled="step === `fees` && $v.invoiceTotal.$invalid"
                 @click.native="validateChangeStep"
               />
               <TmBtn
@@ -254,7 +254,7 @@ export default {
     balance() {
       return this.liquidAtoms
     },
-    totalInvoice() {
+    invoiceTotal() {
       return (
         Number(this.amount) + Number(this.gasPrice) * Number(this.gasEstimate)
       )
@@ -333,7 +333,7 @@ export default {
           if (!this.isValidInput(`gasPrice`)) {
             return
           }
-          if (!this.isValidInput(`totalInvoice`)) {
+          if (!this.isValidInput(`invoiceTotal`)) {
             return
           }
           this.step = signStep
@@ -414,7 +414,7 @@ export default {
         // min is 0 because we support sending 0 fees
         between: between(0, atoms(this.balance))
       },
-      totalInvoice: {
+      invoiceTotal: {
         between: between(0, atoms(this.balance))
       }
     }

--- a/test/unit/specs/components/common/ActionModal.spec.js
+++ b/test/unit/specs/components/common/ActionModal.spec.js
@@ -280,14 +280,14 @@ describe(`ActionModal`, () => {
     describe(`success`, () => {
       it(`when the total invoice amount is less than the balance`, () => {
         wrapper.setProps({ amount: 1210 })
-        expect(wrapper.vm.isValidInput(`totalInvoice`)).toBe(true)
+        expect(wrapper.vm.isValidInput(`invoiceTotal`)).toBe(true)
       })
     })
 
     describe(`fails`, () => {
       it(`when the total invoice amount is more than the balance`, () => {
         wrapper.setProps({ amount: 1211 })
-        expect(wrapper.vm.isValidInput(`totalInvoice`)).toBe(false)
+        expect(wrapper.vm.isValidInput(`invoiceTotal`)).toBe(false)
       })
     })
   })

--- a/test/unit/specs/components/common/ActionModal.spec.js
+++ b/test/unit/specs/components/common/ActionModal.spec.js
@@ -271,7 +271,7 @@ describe(`ActionModal`, () => {
     })
   })
 
-  describe(`validates total price deos not exceed available atoms`, () => {
+  describe(`validates total price does not exceed available atoms`, () => {
     beforeEach(() => {
       wrapper.setData({ gasPrice: 10 })
       wrapper.setData({ gasEstimate: 2 })

--- a/test/unit/specs/components/common/ActionModal.spec.js
+++ b/test/unit/specs/components/common/ActionModal.spec.js
@@ -271,6 +271,27 @@ describe(`ActionModal`, () => {
     })
   })
 
+  describe(`validates total price deos not exceed available atoms`, () => {
+    beforeEach(() => {
+      wrapper.setData({ gasPrice: 10 })
+      wrapper.setData({ gasEstimate: 2 })
+    })
+
+    describe(`success`, () => {
+      it(`when the total invoice amount is less than the balance`, () => {
+        wrapper.setProps({ amount: 1210 })
+        expect(wrapper.vm.isValidInput(`totalInvoice`)).toBe(true)
+      })
+    })
+
+    describe(`fails`, () => {
+      it(`when the total invoice amount is more than the balance`, () => {
+        wrapper.setProps({ amount: 1211 })
+        expect(wrapper.vm.isValidInput(`totalInvoice`)).toBe(false)
+      })
+    })
+  })
+
   describe(`simulate`, () => {
     it(`should simulate transaction to get estimated gas`, async () => {
       const self = {

--- a/test/unit/specs/components/common/__snapshots__/ActionModal.spec.js.snap
+++ b/test/unit/specs/components/common/__snapshots__/ActionModal.spec.js.snap
@@ -101,6 +101,8 @@ exports[`ActionModal should show the action modal when user has logged in with l
       gasestimate="0"
       gasprice="2.5e-8"
     />
+     
+    <!---->
   </div>
    
   <div
@@ -291,6 +293,8 @@ exports[`ActionModal should show the action modal when user has logged in with l
       gasestimate="0"
       gasprice="2.5e-8"
     />
+     
+    <!---->
   </div>
    
   <div


### PR DESCRIPTION
Closes #2446 

**Description:**

Action Modal should now validate the total amount invoiced, including the network fees.

There will be an error displayed and the 'Next' button will be disabled if the value is incorrect.

<img width="586" alt="Screenshot 2019-05-06 at 19 40 53" src="https://user-images.githubusercontent.com/360865/57243640-ec820680-7036-11e9-8dc5-bee117f25e4e.png">

Thank you! 🚀

---

For contributor:

- [x] Added changes entries. Run `yarn changelog` for a guided process.
- [x] Reviewed `Files changed` in the github PR explorer
- [ ] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI
