### PR TITLE
automatic release created for v1.0.0-beta.61

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [1.0.0-beta.61] - 2019-05-07
+
+### Fixed
+
+- [#2542](https://github.com/cosmos/lunie/pull/2542) Do not run style lint on dist folder @colw
+- [#2543](https://github.com/cosmos/lunie/pull/2543) Switch code coverage to live-server @colw
+
 ## [1.0.0-beta.60] - 2019-05-05
 
 ### Fixed

--- a/changes/colw_lint-ignore-dist-css
+++ b/changes/colw_lint-ignore-dist-css
@@ -1,1 +1,0 @@
-[Fixed] [#2542](https://github.com/cosmos/lunie/pull/2542) Do not run style lint on dist folder @colw

--- a/changes/colw_switch-coverage-to-live-server
+++ b/changes/colw_switch-coverage-to-live-server
@@ -1,1 +1,0 @@
-[Fixed] [#2543](https://github.com/cosmos/lunie/pull/2543) Switch code coverage to live-server @colw

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lunie",
   "productName": "lunie",
-  "version": "1.0.0-beta.60",
+  "version": "1.0.0-beta.61",
   "description": "Lunie is the user interface for the Cosmos Hub.",
   "author": "Lunie International Software Systems Inc. <hello@lunie.io>",
   "license": "Apache-2.0",


### PR DESCRIPTION
### Fixed

- [#2542](https://github.com/cosmos/lunie/pull/2542) Do not run style lint on dist folder @colw
- [#2543](https://github.com/cosmos/lunie/pull/2543) Switch code coverage to live-server @colw
