### PR TITLE
colw/2544 fix missing footer

### DIFF
--- a/changes/colw_2554-fix-missing-footer
+++ b/changes/colw_2554-fix-missing-footer
@@ -1,0 +1,1 @@
+[Fixed] [#2554](https://github.com/cosmos/lunie/issues/2554) Add missing footer to pages linked in footer @colw

--- a/src/components/common/PageAbout.vue
+++ b/src/components/common/PageAbout.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="container">
+  <TmPage data-title="About" hide-header>
     <div class="card">
       <h1>About</h1>
       <p>
@@ -89,12 +89,17 @@
         >, or click the <i>feedback</i> button on the left.
       </p>
     </div>
-  </div>
+  </TmPage>
 </template>
 
 <script>
+import TmPage from "common/TmPage"
+
 export default {
-  name: `page-about`
+  name: `page-about`,
+  components: {
+    TmPage
+  }
 }
 </script>
 

--- a/src/components/common/PagePrivacy.vue
+++ b/src/components/common/PagePrivacy.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="container">
+  <TmPage data-title="Privacy" hide-header>
     <div class="card">
       <h1>Privacy Policy</h1>
       <p class="c3">Effective Date: March 28, 2019</p>
@@ -1021,12 +1021,17 @@
         </span>
       </p>
     </div>
-  </div>
+  </TmPage>
 </template>
 
 <script>
+import TmPage from "common/TmPage"
+
 export default {
-  name: `page-privacy`
+  name: `page-privacy`,
+  components: {
+    TmPage
+  }
 }
 </script>
 

--- a/src/components/common/PageSecurity.vue
+++ b/src/components/common/PageSecurity.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="container">
+  <TmPage data-title="Security" hide-header>
     <div class="card">
       <h1>Security</h1>
       <h2 class="c5">Coordinated Vulnerability Disclosure Policy</h2>
@@ -87,12 +87,17 @@
         makes it difficult for us to reduce harm for our users and community.
       </p>
     </div>
-  </div>
+  </TmPage>
 </template>
 
 <script>
+import TmPage from "common/TmPage"
+
 export default {
-  name: `page-security`
+  name: `page-security`,
+  components: {
+    TmPage
+  }
 }
 </script>
 

--- a/src/components/common/PageTerms.vue
+++ b/src/components/common/PageTerms.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="container">
+  <TmPage data-title="Terms" hide-header>
     <div class="card">
       <h1>Terms of Service</h1>
       <p class="c3">Effective Date: March 28, 2019</p>
@@ -1294,12 +1294,17 @@
       </p>
       <div></div>
     </div>
-  </div>
+  </TmPage>
 </template>
 
 <script>
+import TmPage from "common/TmPage"
+
 export default {
-  name: `page-terms`
+  name: `page-terms`,
+  components: {
+    TmPage
+  }
 }
 </script>
 

--- a/src/components/common/TmPage.vue
+++ b/src/components/common/TmPage.vue
@@ -26,50 +26,7 @@
       </template>
       <slot />
     </main>
-    <footer class="footer">
-      <ul class="link-list">
-        <li>
-          <router-link
-            class="app-menu-item-small"
-            to="/about"
-            exact="exact"
-            title="About"
-          >
-            About
-          </router-link>
-        </li>
-        <li>
-          <router-link
-            class="app-menu-item-small"
-            to="/terms"
-            exact="exact"
-            title="Terms"
-          >
-            Terms of Service
-          </router-link>
-        </li>
-        <li>
-          <router-link
-            class="app-menu-item-small"
-            to="/privacy"
-            exact="exact"
-            title="Privacy"
-          >
-            Privacy Policy
-          </router-link>
-        </li>
-        <li>
-          <router-link
-            class="app-menu-item-small"
-            to="/security"
-            exact="exact"
-            title="Security"
-          >
-            Security
-          </router-link>
-        </li>
-      </ul>
-    </footer>
+    <PageFooter />
   </div>
 </template>
 
@@ -84,6 +41,7 @@ import TmDataError from "common/TmDataError"
 import TmDataConnecting from "common/TmDataConnecting"
 import TmBalance from "common/TmBalance"
 import ToolBar from "common/ToolBar"
+import PageFooter from "common/TMPageFooter"
 
 export default {
   name: `tm-page`,
@@ -95,7 +53,8 @@ export default {
     TmDataLoading,
     TmDataError,
     TmDataConnecting,
-    CardSignInRequired
+    CardSignInRequired,
+    PageFooter
   },
   props: {
     hideHeader: {

--- a/src/components/common/TmPage.vue
+++ b/src/components/common/TmPage.vue
@@ -41,7 +41,7 @@ import TmDataError from "common/TmDataError"
 import TmDataConnecting from "common/TmDataConnecting"
 import TmBalance from "common/TmBalance"
 import ToolBar from "common/ToolBar"
-import PageFooter from "common/TMPageFooter"
+import PageFooter from "common/TmPageFooter"
 
 export default {
   name: `tm-page`,

--- a/src/components/common/TmPageFooter.vue
+++ b/src/components/common/TmPageFooter.vue
@@ -1,8 +1,47 @@
 <template>
-  <footer class="tm-page-footer">
-    <div class="container">
-      <slot />
-    </div>
+  <footer>
+    <ul>
+      <li>
+        <router-link
+          class="app-menu-item-small"
+          to="/about"
+          exact="exact"
+          title="About"
+        >
+          About
+        </router-link>
+      </li>
+      <li>
+        <router-link
+          class="app-menu-item-small"
+          to="/terms"
+          exact="exact"
+          title="Terms"
+        >
+          Terms of Service
+        </router-link>
+      </li>
+      <li>
+        <router-link
+          class="app-menu-item-small"
+          to="/privacy"
+          exact="exact"
+          title="Privacy"
+        >
+          Privacy Policy
+        </router-link>
+      </li>
+      <li>
+        <router-link
+          class="app-menu-item-small"
+          to="/security"
+          exact="exact"
+          title="Security"
+        >
+          Security
+        </router-link>
+      </li>
+    </ul>
   </footer>
 </template>
 
@@ -10,16 +49,32 @@
 export default { name: `tm-page-footer` }
 </script>
 
-<style>
-.tm-page-footer .container {
-  border-top: px solid var(--bc);
-  height: 3rem;
-  display: flex;
-  align-items: center;
-  padding: 0 1rem;
+<style scoped>
+footer {
+  width: 100%;
+  background: var(--app-fg);
+  padding: 0.5rem;
+  margin-top: 1rem;
 }
 
-.tm-page-footer .container:empty {
-  display: none;
+ul {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+}
+
+ul li {
+  display: inline;
+}
+
+.app-menu-item-small {
+  display: inline-block;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.25rem 0.25rem;
+  margin: 0 0.5rem;
+  color: var(--dim);
+  border-radius: 0.25rem;
+  font-size: var(--sm);
 }
 </style>

--- a/src/styles/content-page.css
+++ b/src/styles/content-page.css
@@ -73,11 +73,6 @@ ol {
   margin-bottom: 1rem;
 }
 
-.container {
-  display: flex;
-  flex-direction: column;
-}
-
 i {
   font-style: italic;
 }

--- a/test/unit/specs/components/common/__snapshots__/TmPage.spec.js.snap
+++ b/test/unit/specs/components/common/__snapshots__/TmPage.spec.js.snap
@@ -27,65 +27,7 @@ exports[`TmPage should show links to other pages 1`] = `
      
   </main>
    
-  <footer
-    class="footer"
-  >
-    <ul
-      class="link-list"
-    >
-      <li>
-        <router-link-stub
-          class="app-menu-item-small"
-          exact="exact"
-          title="About"
-          to="/about"
-        >
-          
-          About
-        
-        </router-link-stub>
-      </li>
-       
-      <li>
-        <router-link-stub
-          class="app-menu-item-small"
-          exact="exact"
-          title="Terms"
-          to="/terms"
-        >
-          
-          Terms of Service
-        
-        </router-link-stub>
-      </li>
-       
-      <li>
-        <router-link-stub
-          class="app-menu-item-small"
-          exact="exact"
-          title="Privacy"
-          to="/privacy"
-        >
-          
-          Privacy Policy
-        
-        </router-link-stub>
-      </li>
-       
-      <li>
-        <router-link-stub
-          class="app-menu-item-small"
-          exact="exact"
-          title="Security"
-          to="/security"
-        >
-          
-          Security
-        
-        </router-link-stub>
-      </li>
-    </ul>
-  </footer>
+  <pagefooter-stub />
 </div>
 `;
 
@@ -116,64 +58,6 @@ exports[`TmPage shows a page skeleton 1`] = `
      
   </main>
    
-  <footer
-    class="footer"
-  >
-    <ul
-      class="link-list"
-    >
-      <li>
-        <router-link-stub
-          class="app-menu-item-small"
-          exact="exact"
-          title="About"
-          to="/about"
-        >
-          
-          About
-        
-        </router-link-stub>
-      </li>
-       
-      <li>
-        <router-link-stub
-          class="app-menu-item-small"
-          exact="exact"
-          title="Terms"
-          to="/terms"
-        >
-          
-          Terms of Service
-        
-        </router-link-stub>
-      </li>
-       
-      <li>
-        <router-link-stub
-          class="app-menu-item-small"
-          exact="exact"
-          title="Privacy"
-          to="/privacy"
-        >
-          
-          Privacy Policy
-        
-        </router-link-stub>
-      </li>
-       
-      <li>
-        <router-link-stub
-          class="app-menu-item-small"
-          exact="exact"
-          title="Security"
-          to="/security"
-        >
-          
-          Security
-        
-        </router-link-stub>
-      </li>
-    </ul>
-  </footer>
+  <pagefooter-stub />
 </div>
 `;

--- a/test/unit/specs/components/governance/__snapshots__/PageGovernance.spec.js.snap
+++ b/test/unit/specs/components/governance/__snapshots__/PageGovernance.spec.js.snap
@@ -198,12 +198,8 @@ exports[`PageGovernance disables proposal creation if not connected 1`] = `
     <router-view-stub />
   </main>
    
-  <footer
-    class="footer"
-  >
-    <ul
-      class="link-list"
-    >
+  <footer>
+    <ul>
       <li>
         <router-link-stub
           class="app-menu-item-small"
@@ -212,8 +208,8 @@ exports[`PageGovernance disables proposal creation if not connected 1`] = `
           to="/about"
         >
           
-          About
-        
+        About
+      
         </router-link-stub>
       </li>
        
@@ -225,8 +221,8 @@ exports[`PageGovernance disables proposal creation if not connected 1`] = `
           to="/terms"
         >
           
-          Terms of Service
-        
+        Terms of Service
+      
         </router-link-stub>
       </li>
        
@@ -238,8 +234,8 @@ exports[`PageGovernance disables proposal creation if not connected 1`] = `
           to="/privacy"
         >
           
-          Privacy Policy
-        
+        Privacy Policy
+      
         </router-link-stub>
       </li>
        
@@ -251,8 +247,8 @@ exports[`PageGovernance disables proposal creation if not connected 1`] = `
           to="/security"
         >
           
-          Security
-        
+        Security
+      
         </router-link-stub>
       </li>
     </ul>
@@ -457,12 +453,8 @@ exports[`PageGovernance has the expected html structure 1`] = `
     <router-view-stub />
   </main>
    
-  <footer
-    class="footer"
-  >
-    <ul
-      class="link-list"
-    >
+  <footer>
+    <ul>
       <li>
         <router-link-stub
           class="app-menu-item-small"
@@ -471,8 +463,8 @@ exports[`PageGovernance has the expected html structure 1`] = `
           to="/about"
         >
           
-          About
-        
+        About
+      
         </router-link-stub>
       </li>
        
@@ -484,8 +476,8 @@ exports[`PageGovernance has the expected html structure 1`] = `
           to="/terms"
         >
           
-          Terms of Service
-        
+        Terms of Service
+      
         </router-link-stub>
       </li>
        
@@ -497,8 +489,8 @@ exports[`PageGovernance has the expected html structure 1`] = `
           to="/privacy"
         >
           
-          Privacy Policy
-        
+        Privacy Policy
+      
         </router-link-stub>
       </li>
        
@@ -510,8 +502,8 @@ exports[`PageGovernance has the expected html structure 1`] = `
           to="/security"
         >
           
-          Security
-        
+        Security
+      
         </router-link-stub>
       </li>
     </ul>


### PR DESCRIPTION
Closes #2544 

**Description:**

Footer was missing on misc pages linked from footer.

i.e. About, Terms, Privacy and Security.

Container margins changed slightly, as the new one is slightly indented. I don't think it's a problem.

Desktop old:

![lunie io_ (3)](https://user-images.githubusercontent.com/360865/57294071-c2782500-70c6-11e9-87bc-468b335d61c3.png)

Desktop new:

![localhost_9080_](https://user-images.githubusercontent.com/360865/57294070-c2782500-70c6-11e9-9af7-cca41e2d360f.png)



Mobile old:

<img width="487" alt="Screenshot 2019-05-07 at 12 25 04" src="https://user-images.githubusercontent.com/360865/57294082-cc9a2380-70c6-11e9-8d15-b8ec3ecb21fc.png">

Mobile new:

<img width="487" alt="Screenshot 2019-05-07 at 12 24 37" src="https://user-images.githubusercontent.com/360865/57294083-cc9a2380-70c6-11e9-834d-358811bbb826.png">


Thank you! 🚀

---

For contributor:

- [x] Added changes entries. Run `yarn changelog` for a guided process.
- [x] Reviewed `Files changed` in the github PR explorer
- [ ] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI
