### PR TITLE
colw/Refactor Proposal tally display code

### DIFF
--- a/changes/colw_2430-fix-proposal-tally-sum
+++ b/changes/colw_2430-fix-proposal-tally-sum
@@ -1,0 +1,1 @@
+[Fixed] [#2430](https://github.com/cosmos/lunie/issues/2430) Ensure proposal tallies sum to 100 percent @colw

--- a/src/components/governance/LiProposal.vue
+++ b/src/components/governance/LiProposal.vue
@@ -49,14 +49,12 @@
 <script>
 import BigNumber from "bignumber.js"
 import { mapGetters } from "vuex"
-import { percentInt } from "../../scripts/num.js"
+import { percent } from "../../scripts/num.js"
 export default {
   name: `li-proposal`,
   filters: {
     percentOrPending: function(value, totalValue, pending) {
-      return pending
-        ? `--`
-        : percentInt(totalValue === 0 ? 0 : value / totalValue)
+      return pending ? `--` : percent(totalValue === 0 ? 0 : value / totalValue)
     }
   },
   props: {

--- a/src/components/governance/LiProposal.vue
+++ b/src/components/governance/LiProposal.vue
@@ -49,13 +49,11 @@
 <script>
 import BigNumber from "bignumber.js"
 import { mapGetters } from "vuex"
-import { percent } from "../../scripts/num.js"
+import { percentOrPending } from "../../filters"
 export default {
   name: `li-proposal`,
   filters: {
-    percentOrPending: function(value, totalValue, pending) {
-      return pending ? `--` : percent(totalValue === 0 ? 0 : value / totalValue)
-    }
+    percentOrPending
   },
   props: {
     proposal: {

--- a/src/filters/index.js
+++ b/src/filters/index.js
@@ -1,0 +1,5 @@
+import { percent } from "../scripts/num.js"
+
+export const percentOrPending = function(value, totalValue, pending) {
+  return pending ? `--` : percent(totalValue === 0 ? 0 : value / totalValue)
+}

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,0 +1,39 @@
+// This will take an object and for each (k,v) will return
+// v rounded such that the sum of all v is 100.
+export const roundObjectPercentages = o => {
+  // This algorithm workson integers and we want 2 decimal places.
+  // So round up first.
+  let asArray = Object.entries(o).map(v => {
+    v[1] = v[1] * 100
+    return v
+  })
+
+  // Calculate difference from 100%
+  var margin =
+    10000 -
+    asArray.reduce(function(acc, x) {
+      return acc + Math.round(x[1])
+    }, 0)
+
+  const cmp = (a, b) => {
+    return b[1] - Math.round(a[1]) - a[1]
+  }
+
+  // Sort and distribute difference amongst values
+  asArray.sort(cmp)
+  const result = asArray.map(function(x, i) {
+    const rounded = [
+      x[0],
+      (Math.round(x[1]) + (margin > i) - (i >= asArray.length + margin)) / 100.0
+    ]
+    return rounded
+  })
+
+  // Turn the array back into the original data structure layout
+  const resultObject = {}
+  result.forEach(x => {
+    resultObject[x[0]] = x[1]
+  })
+
+  return resultObject
+}

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,11 +1,11 @@
 // This will take an object and for each (k,v) will return
 // v rounded such that the sum of all v is 100.
-export const roundObjectPercentages = o => {
+export const roundObjectPercentages = dataMap => {
   // This algorithm workson integers and we want 2 decimal places.
   // So round up first.
-  let asArray = Object.entries(o).map(v => {
-    v[1] = v[1] * 100
-    return v
+  let asArray = Object.entries(dataMap).map(keyValue => {
+    keyValue[1] = keyValue[1] * 100
+    return keyValue
   })
 
   // Calculate difference from 100%

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,31 +1,40 @@
 // This will take an object and for each (k,v) will return
 // v rounded such that the sum of all v is 100.
+
+// Used the following as a reference:
+// https://stackoverflow.com/questions/13483430/how-to-make-rounded-percentages-add-up-to-100
+// Note: We pass an object, and want to keep the (key, value) association.
+
 export const roundObjectPercentages = dataMap => {
   // This algorithm workson integers and we want 2 decimal places.
   // So round up first.
+  const scale = 100
   let asArray = Object.entries(dataMap).map(([key, value]) => {
-    const newValue = value * 100
-    return [key, newValue]
+    return [key, value * scale]
   })
 
   const sumRounded = (acc, x) => {
     return acc + Math.round(x[1])
   }
 
-  // Calculate difference from 100%
-  const scale = 100
-  var margin = scale * 100 - asArray.reduce(sumRounded, 0)
+  // The leftOver is the difference beween 100 and
+  // the sum of the rounded values.
+  var leftOver = scale * 100 - asArray.reduce(sumRounded, 0)
 
+  //
   const cmpNumberValue = (a, b) => {
     return b[1] - Math.round(a[1]) - a[1]
   }
 
-  // Sort and distribute difference amongst values
+  // Here we distribute the leftOver as evenly as possible amongst the rounded values.
+  // The values are sorted first.
   asArray.sort(cmpNumberValue)
   const result = asArray.map(function(x, i) {
+    // Note: leftOver can be negative.
     const rounded = [
       x[0],
-      (Math.round(x[1]) + (margin > i) - (i >= asArray.length + margin)) / 100.0
+      (Math.round(x[1]) + (leftOver > i) - (i >= asArray.length + leftOver)) /
+        100.0
     ]
     return rounded
   })

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -3,24 +3,25 @@
 export const roundObjectPercentages = dataMap => {
   // This algorithm workson integers and we want 2 decimal places.
   // So round up first.
-  let asArray = Object.entries(dataMap).map(keyValue => {
-    keyValue[1] = keyValue[1] * 100
-    return keyValue
+  let asArray = Object.entries(dataMap).map(([key, value]) => {
+    const newValue = value * 100
+    return [key, newValue]
   })
 
-  // Calculate difference from 100%
-  var margin =
-    10000 -
-    asArray.reduce(function(acc, x) {
-      return acc + Math.round(x[1])
-    }, 0)
+  const sumRounded = (acc, x) => {
+    return acc + Math.round(x[1])
+  }
 
-  const cmp = (a, b) => {
+  // Calculate difference from 100%
+  const scale = 100
+  var margin = scale * 100 - asArray.reduce(sumRounded, 0)
+
+  const cmpNumberValue = (a, b) => {
     return b[1] - Math.round(a[1]) - a[1]
   }
 
   // Sort and distribute difference amongst values
-  asArray.sort(cmp)
+  asArray.sort(cmpNumberValue)
   const result = asArray.map(function(x, i) {
     const rounded = [
       x[0],

--- a/test/unit/specs/components/governance/LiProposal.spec.js
+++ b/test/unit/specs/components/governance/LiProposal.spec.js
@@ -100,6 +100,28 @@ describe(`LiProposal`, () => {
     })
   })
 
+  describe(`DepositPeriod`, () => {
+    it(`should return true when status is DepositPeriod`, () => {
+      wrapper.setProps({
+        proposal: {
+          ...proposal,
+          proposal_status: `DepositPeriod`
+        }
+      })
+      expect(wrapper.vm.isDepositPeriod).toEqual(true)
+    })
+
+    it(`should return false when status is not DepositPeriod`, () => {
+      wrapper.setProps({
+        proposal: {
+          ...proposal,
+          proposal_status: `anything else`
+        }
+      })
+      expect(wrapper.vm.isDepositPeriod).toEqual(false)
+    })
+  })
+
   it(`should not truncate the description or add an ellipsis`, () => {
     expect(wrapper.vm.description).toEqual(`Proposal description`)
   })

--- a/test/unit/specs/components/governance/__snapshots__/LiProposal.spec.js.snap
+++ b/test/unit/specs/components/governance/__snapshots__/LiProposal.spec.js.snap
@@ -45,7 +45,7 @@ exports[`LiProposal has the expected html structure 1`] = `
     class="li-proposal__value yes"
   >
     
-    84.60%
+    84.6%
   
   </td>
    
@@ -120,7 +120,7 @@ exports[`LiProposal should survive the tally result not being present yet 1`] = 
     class="li-proposal__value yes"
   >
     
-    0.00%
+    0.01%
   
   </td>
    
@@ -128,7 +128,7 @@ exports[`LiProposal should survive the tally result not being present yet 1`] = 
     class="li-proposal__value no"
   >
     
-    0.00%
+    0.01%
   
   </td>
    
@@ -136,7 +136,7 @@ exports[`LiProposal should survive the tally result not being present yet 1`] = 
     class="li-proposal__value no_with_veto"
   >
     
-    0.00%
+    0.01%
   
   </td>
    
@@ -144,7 +144,7 @@ exports[`LiProposal should survive the tally result not being present yet 1`] = 
     class="li-proposal__value abstain"
   >
     
-    0.00%
+    0.01%
   
   </td>
 </tr>

--- a/test/unit/specs/components/governance/__snapshots__/LiProposal.spec.js.snap
+++ b/test/unit/specs/components/governance/__snapshots__/LiProposal.spec.js.snap
@@ -45,7 +45,7 @@ exports[`LiProposal has the expected html structure 1`] = `
     class="li-proposal__value yes"
   >
     
-    85%
+    84.60%
   
   </td>
    
@@ -53,7 +53,7 @@ exports[`LiProposal has the expected html structure 1`] = `
     class="li-proposal__value no"
   >
     
-    4%
+    4.23%
   
   </td>
    
@@ -61,7 +61,7 @@ exports[`LiProposal has the expected html structure 1`] = `
     class="li-proposal__value no_with_veto"
   >
     
-    2%
+    1.69%
   
   </td>
    
@@ -69,7 +69,7 @@ exports[`LiProposal has the expected html structure 1`] = `
     class="li-proposal__value abstain"
   >
     
-    9%
+    9.48%
   
   </td>
 </tr>
@@ -120,7 +120,7 @@ exports[`LiProposal should survive the tally result not being present yet 1`] = 
     class="li-proposal__value yes"
   >
     
-    0%
+    0.00%
   
   </td>
    
@@ -128,7 +128,7 @@ exports[`LiProposal should survive the tally result not being present yet 1`] = 
     class="li-proposal__value no"
   >
     
-    0%
+    0.00%
   
   </td>
    
@@ -136,7 +136,7 @@ exports[`LiProposal should survive the tally result not being present yet 1`] = 
     class="li-proposal__value no_with_veto"
   >
     
-    0%
+    0.00%
   
   </td>
    
@@ -144,7 +144,7 @@ exports[`LiProposal should survive the tally result not being present yet 1`] = 
     class="li-proposal__value abstain"
   >
     
-    0%
+    0.00%
   
   </td>
 </tr>

--- a/test/unit/specs/components/governance/__snapshots__/TableProposals.spec.js.snap
+++ b/test/unit/specs/components/governance/__snapshots__/TableProposals.spec.js.snap
@@ -159,7 +159,7 @@ exports[`TableProposals has the expected html structure 1`] = `
           class="li-proposal__value no_with_veto"
         >
           
-    62.50%
+    62.5%
   
         </td>
          
@@ -167,7 +167,7 @@ exports[`TableProposals has the expected html structure 1`] = `
           class="li-proposal__value abstain"
         >
           
-    12.50%
+    12.5%
   
         </td>
       </tr>
@@ -211,7 +211,7 @@ exports[`TableProposals has the expected html structure 1`] = `
           class="li-proposal__value yes"
         >
           
-    --
+    0.01%
   
         </td>
          
@@ -219,7 +219,7 @@ exports[`TableProposals has the expected html structure 1`] = `
           class="li-proposal__value no"
         >
           
-    --
+    0.01%
   
         </td>
          
@@ -227,7 +227,7 @@ exports[`TableProposals has the expected html structure 1`] = `
           class="li-proposal__value no_with_veto"
         >
           
-    --
+    0.01%
   
         </td>
          
@@ -235,7 +235,7 @@ exports[`TableProposals has the expected html structure 1`] = `
           class="li-proposal__value abstain"
         >
           
-    --
+    0.01%
   
         </td>
       </tr>
@@ -279,7 +279,7 @@ exports[`TableProposals has the expected html structure 1`] = `
           class="li-proposal__value yes"
         >
           
-    0.00%
+    0.01%
   
         </td>
          
@@ -287,7 +287,7 @@ exports[`TableProposals has the expected html structure 1`] = `
           class="li-proposal__value no"
         >
           
-    0.00%
+    0.01%
   
         </td>
          
@@ -295,7 +295,7 @@ exports[`TableProposals has the expected html structure 1`] = `
           class="li-proposal__value no_with_veto"
         >
           
-    0.00%
+    0.01%
   
         </td>
          
@@ -303,7 +303,7 @@ exports[`TableProposals has the expected html structure 1`] = `
           class="li-proposal__value abstain"
         >
           
-    0.00%
+    0.01%
   
         </td>
       </tr>
@@ -351,7 +351,7 @@ exports[`TableProposals has the expected html structure 1`] = `
           class="li-proposal__value yes"
         >
           
-    84.60%
+    84.6%
   
         </td>
          
@@ -543,7 +543,7 @@ exports[`TableProposals should filter the proposals 1`] = `
           class="li-proposal__value no_with_veto"
         >
           
-    62.50%
+    62.5%
   
         </td>
          
@@ -551,7 +551,7 @@ exports[`TableProposals should filter the proposals 1`] = `
           class="li-proposal__value abstain"
         >
           
-    12.50%
+    12.5%
   
         </td>
       </tr>
@@ -595,7 +595,7 @@ exports[`TableProposals should filter the proposals 1`] = `
           class="li-proposal__value yes"
         >
           
-    --
+    0.01%
   
         </td>
          
@@ -603,7 +603,7 @@ exports[`TableProposals should filter the proposals 1`] = `
           class="li-proposal__value no"
         >
           
-    --
+    0.01%
   
         </td>
          
@@ -611,7 +611,7 @@ exports[`TableProposals should filter the proposals 1`] = `
           class="li-proposal__value no_with_veto"
         >
           
-    --
+    0.01%
   
         </td>
          
@@ -619,7 +619,7 @@ exports[`TableProposals should filter the proposals 1`] = `
           class="li-proposal__value abstain"
         >
           
-    --
+    0.01%
   
         </td>
       </tr>
@@ -663,7 +663,7 @@ exports[`TableProposals should filter the proposals 1`] = `
           class="li-proposal__value yes"
         >
           
-    0.00%
+    0.01%
   
         </td>
          
@@ -671,7 +671,7 @@ exports[`TableProposals should filter the proposals 1`] = `
           class="li-proposal__value no"
         >
           
-    0.00%
+    0.01%
   
         </td>
          
@@ -679,7 +679,7 @@ exports[`TableProposals should filter the proposals 1`] = `
           class="li-proposal__value no_with_veto"
         >
           
-    0.00%
+    0.01%
   
         </td>
          
@@ -687,7 +687,7 @@ exports[`TableProposals should filter the proposals 1`] = `
           class="li-proposal__value abstain"
         >
           
-    0.00%
+    0.01%
   
         </td>
       </tr>
@@ -735,7 +735,7 @@ exports[`TableProposals should filter the proposals 1`] = `
           class="li-proposal__value yes"
         >
           
-    84.60%
+    84.6%
   
         </td>
          

--- a/test/unit/specs/components/governance/__snapshots__/TableProposals.spec.js.snap
+++ b/test/unit/specs/components/governance/__snapshots__/TableProposals.spec.js.snap
@@ -143,7 +143,7 @@ exports[`TableProposals has the expected html structure 1`] = `
           class="li-proposal__value yes"
         >
           
-    6%
+    6.25%
   
         </td>
          
@@ -151,7 +151,7 @@ exports[`TableProposals has the expected html structure 1`] = `
           class="li-proposal__value no"
         >
           
-    19%
+    18.75%
   
         </td>
          
@@ -159,7 +159,7 @@ exports[`TableProposals has the expected html structure 1`] = `
           class="li-proposal__value no_with_veto"
         >
           
-    63%
+    62.50%
   
         </td>
          
@@ -167,7 +167,7 @@ exports[`TableProposals has the expected html structure 1`] = `
           class="li-proposal__value abstain"
         >
           
-    13%
+    12.50%
   
         </td>
       </tr>
@@ -279,7 +279,7 @@ exports[`TableProposals has the expected html structure 1`] = `
           class="li-proposal__value yes"
         >
           
-    0%
+    0.00%
   
         </td>
          
@@ -287,7 +287,7 @@ exports[`TableProposals has the expected html structure 1`] = `
           class="li-proposal__value no"
         >
           
-    0%
+    0.00%
   
         </td>
          
@@ -295,7 +295,7 @@ exports[`TableProposals has the expected html structure 1`] = `
           class="li-proposal__value no_with_veto"
         >
           
-    0%
+    0.00%
   
         </td>
          
@@ -303,7 +303,7 @@ exports[`TableProposals has the expected html structure 1`] = `
           class="li-proposal__value abstain"
         >
           
-    0%
+    0.00%
   
         </td>
       </tr>
@@ -351,7 +351,7 @@ exports[`TableProposals has the expected html structure 1`] = `
           class="li-proposal__value yes"
         >
           
-    85%
+    84.60%
   
         </td>
          
@@ -359,7 +359,7 @@ exports[`TableProposals has the expected html structure 1`] = `
           class="li-proposal__value no"
         >
           
-    4%
+    4.23%
   
         </td>
          
@@ -367,7 +367,7 @@ exports[`TableProposals has the expected html structure 1`] = `
           class="li-proposal__value no_with_veto"
         >
           
-    2%
+    1.69%
   
         </td>
          
@@ -375,7 +375,7 @@ exports[`TableProposals has the expected html structure 1`] = `
           class="li-proposal__value abstain"
         >
           
-    9%
+    9.48%
   
         </td>
       </tr>
@@ -527,7 +527,7 @@ exports[`TableProposals should filter the proposals 1`] = `
           class="li-proposal__value yes"
         >
           
-    6%
+    6.25%
   
         </td>
          
@@ -535,7 +535,7 @@ exports[`TableProposals should filter the proposals 1`] = `
           class="li-proposal__value no"
         >
           
-    19%
+    18.75%
   
         </td>
          
@@ -543,7 +543,7 @@ exports[`TableProposals should filter the proposals 1`] = `
           class="li-proposal__value no_with_veto"
         >
           
-    63%
+    62.50%
   
         </td>
          
@@ -551,7 +551,7 @@ exports[`TableProposals should filter the proposals 1`] = `
           class="li-proposal__value abstain"
         >
           
-    13%
+    12.50%
   
         </td>
       </tr>
@@ -663,7 +663,7 @@ exports[`TableProposals should filter the proposals 1`] = `
           class="li-proposal__value yes"
         >
           
-    0%
+    0.00%
   
         </td>
          
@@ -671,7 +671,7 @@ exports[`TableProposals should filter the proposals 1`] = `
           class="li-proposal__value no"
         >
           
-    0%
+    0.00%
   
         </td>
          
@@ -679,7 +679,7 @@ exports[`TableProposals should filter the proposals 1`] = `
           class="li-proposal__value no_with_veto"
         >
           
-    0%
+    0.00%
   
         </td>
          
@@ -687,7 +687,7 @@ exports[`TableProposals should filter the proposals 1`] = `
           class="li-proposal__value abstain"
         >
           
-    0%
+    0.00%
   
         </td>
       </tr>
@@ -735,7 +735,7 @@ exports[`TableProposals should filter the proposals 1`] = `
           class="li-proposal__value yes"
         >
           
-    85%
+    84.60%
   
         </td>
          
@@ -743,7 +743,7 @@ exports[`TableProposals should filter the proposals 1`] = `
           class="li-proposal__value no"
         >
           
-    4%
+    4.23%
   
         </td>
          
@@ -751,7 +751,7 @@ exports[`TableProposals should filter the proposals 1`] = `
           class="li-proposal__value no_with_veto"
         >
           
-    2%
+    1.69%
   
         </td>
          
@@ -759,7 +759,7 @@ exports[`TableProposals should filter the proposals 1`] = `
           class="li-proposal__value abstain"
         >
           
-    9%
+    9.48%
   
         </td>
       </tr>

--- a/test/unit/specs/filters/filters.spec.js
+++ b/test/unit/specs/filters/filters.spec.js
@@ -1,0 +1,19 @@
+import { percentOrPending } from "filters"
+
+describe(`PercentOrPending Filter`, () => {
+  it(`should return '--' when pending is true`, () => {
+    expect(percentOrPending(1234, 1234, true)).toBe(`--`)
+  })
+
+  it(`should return 0% percentage when not pending`, () => {
+    expect(percentOrPending(0, 100, false)).toBe(`0.00%`)
+  })
+
+  it(`should return correct percentage when not pending`, () => {
+    expect(percentOrPending(5, 25, false)).toBe(`20.00%`)
+  })
+
+  it(`should return 100% percentage when not pending`, () => {
+    expect(percentOrPending(1234, 1234, false)).toBe(`100.00%`)
+  })
+})

--- a/test/unit/specs/utils/utils.spec.js
+++ b/test/unit/specs/utils/utils.spec.js
@@ -1,0 +1,40 @@
+import { roundObjectPercentages } from "utils"
+
+const tally = {
+  yes: 13.626332,
+  no: 47.989636,
+  abstain: 9.596008,
+  no_with_veto: 28.788024
+}
+
+const tally2 = {
+  yes: 96.11111,
+  no: 1.3224,
+  abstain: 1.2555,
+  no_with_veto: 1.31099
+}
+
+const tally3 = {
+  yes: 95.12123,
+  no: 0,
+  abstain: 0,
+  no_with_veto: 4.87877
+}
+
+const sum = (a, b) => a + b
+const getValues = dataMap => Object.values(dataMap)
+const sumOfValues = x => getValues(x).reduce(sum, 0)
+
+describe(`roundObjectPercentages`, () => {
+  it(`should sum to 100`, () => {
+    expect(sumOfValues(roundObjectPercentages(tally))).toBe(100)
+  })
+
+  it(`should sum another to 100`, () => {
+    expect(sumOfValues(roundObjectPercentages(tally2))).toBe(100)
+  })
+
+  it(`should sum again to 100`, () => {
+    expect(sumOfValues(roundObjectPercentages(tally3))).toBe(100)
+  })
+})


### PR DESCRIPTION
Closes #2430 

**Description:**

Proposal integer tallies do not sum to 100%, so we need to mask this by either rounding up/down numbers, or displaying more decimal places so the original problem is less obvious.

The solution here will display percentages rounded to 2 decimals places:

<img width="1307" alt="Screenshot 2019-05-07 at 21 03 54" src="https://user-images.githubusercontent.com/360865/57325992-b19dd280-710b-11e9-9425-cedaea39f8b5.png">

Code changes:
- Add convenience method for checking DepositPeriod status
- Add filter method for percentages
- Replace individual tally methods with filtering
- Replace if structure with switch
- Replace `percentInt` with `percent` (default 2 decimal places)

Thank you! 🚀

---

For contributor:

- [x] Added changes entries. Run `yarn changelog` for a guided process.
- [x] Reviewed `Files changed` in the github PR explorer
- [x] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI
