### PR TITLE
Colw/2557 fix undelegate subtotal

### DIFF
--- a/changes/colw_2557-fix-undelegate-subtotal
+++ b/changes/colw_2557-fix-undelegate-subtotal
@@ -1,0 +1,1 @@
+[Fixed] [#2557](https://github.com/cosmos/lunie/pull/2557) Do not add undelegation amount to transaction subtotal @colw

--- a/src/components/staking/UndelegationModal.vue
+++ b/src/components/staking/UndelegationModal.vue
@@ -5,7 +5,7 @@
     :submit-fn="submitForm"
     :simulate-fn="simulateForm"
     :validate="validateForm"
-    :amount="amount"
+    :amount="0"
     title="Undelegate"
     class="undelegation-modal"
     submission-error-prefix="Undelegating failed"

--- a/test/unit/specs/components/staking/__snapshots__/UndelegationModal.spec.js.snap
+++ b/test/unit/specs/components/staking/__snapshots__/UndelegationModal.spec.js.snap
@@ -2,6 +2,7 @@
 
 exports[`UndelegationModal should display undelegation modal form 1`] = `
 <actionmodal-stub
+  amount="0"
   class="undelegation-modal"
   id="undelegation-modal"
   simulatefn="function () { [native code] }"


### PR DESCRIPTION
Closes #2557

**Description:**

Undelegating ATOMS were added to the subtotal. Whereas only network fees should be tallied for the transaction invoice.

<img width="564" alt="Screenshot 2019-05-09 at 13 09 31" src="https://user-images.githubusercontent.com/360865/57449439-31d34d80-725c-11e9-9cd5-40fa0630bda8.png">


Thank you! 🚀

---

For contributor:

- [x] Added changes entries. Run `yarn changelog` for a guided process.
- [x] Reviewed `Files changed` in the github PR explorer
- [ ] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI
