### PR TITLE
colw/improve delegation modal

### DIFF
--- a/changes/colw_improve-delegation-modal
+++ b/changes/colw_improve-delegation-modal
@@ -1,0 +1,2 @@
+[Fixed] [#2568](https://github.com/cosmos/lunie/pull/2568) Do not add stake to total when redelegating @colw
+[Changed] [#2568](https://github.com/cosmos/lunie/pull/2568) Show amount of source stake available to delegate or redelgate @colw

--- a/src/components/staking/DelegationModal.vue
+++ b/src/components/staking/DelegationModal.vue
@@ -42,6 +42,16 @@
         type="number"
         placeholder="Amount"
       />
+      <span v-if="!isRedelegation()" class="form-message">
+        Available to Delegate:
+        {{ getFromBalance() }}
+        {{ num.viewDenom(denom) }}s
+      </span>
+      <span v-else-if="isRedelegation()" class="form-message">
+        Available to Redelegate:
+        {{ getFromBalance() }}
+        {{ num.viewDenom(denom) }}s
+      </span>
       <TmFormMsg
         v-if="balance === 0"
         :msg="`doesn't have any ${num.viewDenom(denom)}s`"
@@ -139,6 +149,9 @@ export default {
     },
     isRedelegation() {
       return this.from !== this.session.address
+    },
+    getFromBalance() {
+      return atoms(this.balance)
     },
     async simulateDelegation() {
       return await this.$store.dispatch(`simulateDelegation`, {

--- a/src/components/staking/DelegationModal.vue
+++ b/src/components/staking/DelegationModal.vue
@@ -6,7 +6,7 @@
     :simulate-fn="simulateForm"
     :validate="validateForm"
     :amount="amount"
-    title="Delegate"
+    :title="isRedelegation() ? 'Redelegate' : 'Delegate'"
     class="delegation-modal"
     submission-error-prefix="Delegating failed"
     @close="clear"
@@ -136,6 +136,9 @@ export default {
 
       this.selectedIndex = 0
       this.amount = null
+    },
+    isRedelegation() {
+      return this.from !== this.session.address
     },
     async simulateDelegation() {
       return await this.$store.dispatch(`simulateDelegation`, {

--- a/src/components/staking/DelegationModal.vue
+++ b/src/components/staking/DelegationModal.vue
@@ -5,7 +5,7 @@
     :submit-fn="submitForm"
     :simulate-fn="simulateForm"
     :validate="validateForm"
-    :amount="amount"
+    :amount="isRedelegation() ? 0 : amount"
     :title="isRedelegation() ? 'Redelegate' : 'Delegate'"
     class="delegation-modal"
     submission-error-prefix="Delegating failed"

--- a/src/components/staking/PageValidator.vue
+++ b/src/components/staking/PageValidator.vue
@@ -169,7 +169,6 @@
       <UndelegationModal
         ref="undelegationModal"
         :maximum="Number(myBond)"
-        :from-options="delegationTargetOptions()"
         :to="session.signedIn ? session.address : ``"
         :validator="validator"
         :denom="bondDenom"

--- a/src/components/staking/UndelegationModal.vue
+++ b/src/components/staking/UndelegationModal.vue
@@ -85,10 +85,6 @@ export default {
       type: Number,
       required: true
     },
-    fromOptions: {
-      type: Array,
-      required: true
-    },
     to: {
       type: String,
       required: true

--- a/test/unit/specs/components/staking/__snapshots__/DelegationModal.spec.js.snap
+++ b/test/unit/specs/components/staking/__snapshots__/DelegationModal.spec.js.snap
@@ -54,6 +54,16 @@ exports[`DelegationModal should display the delegation modal form 1`] = `
       type="number"
     />
      
+    <span
+      class="form-message"
+    >
+      
+      Available to Delegate:
+      1000
+      STAKEs
+    
+    </span>
+     
     <!---->
   </tmformgroup-stub>
 </actionmodal-stub>

--- a/test/unit/specs/components/staking/__snapshots__/PageValidator.spec.js.snap
+++ b/test/unit/specs/components/staking/__snapshots__/PageValidator.spec.js.snap
@@ -316,7 +316,6 @@ exports[`PageValidator shows a validator profile information errors signing info
      
     <undelegationmodal-stub
       denom="STAKE"
-      fromoptions="[object Object]"
       maximum="0"
       to="cosmos15ky9du8a2wlstz6fpx3p4mqpjyrm5ctpesxxn9"
       validator="[object Object]"
@@ -641,7 +640,6 @@ exports[`PageValidator shows a validator profile information if user has signed 
      
     <undelegationmodal-stub
       denom="STAKE"
-      fromoptions="[object Object]"
       maximum="0"
       to="cosmos15ky9du8a2wlstz6fpx3p4mqpjyrm5ctpesxxn9"
       validator="[object Object]"
@@ -966,7 +964,6 @@ exports[`PageValidator shows a validator profile information if user hasn't sign
      
     <undelegationmodal-stub
       denom="STAKE"
-      fromoptions=""
       maximum="0"
       to=""
       validator="[object Object]"

--- a/test/unit/specs/components/staking/__snapshots__/UndelegationModal.spec.js.snap
+++ b/test/unit/specs/components/staking/__snapshots__/UndelegationModal.spec.js.snap
@@ -4,6 +4,7 @@ exports[`UndelegationModal should display undelegation modal form 1`] = `
 <actionmodal-stub
   amount="0"
   class="undelegation-modal"
+  fromoptions="[object Object]"
   id="undelegation-modal"
   simulatefn="function () { [native code] }"
   submissionerrorprefix="Undelegating failed"


### PR DESCRIPTION
**Description:**

Increase clarity for Delegating and Redelegating 

- Change title to `Redelgation` if choosing a source other than your own.
- Show available stake to shift, either your own balance, or the current stake in the other validator.

TODO: Clear error message when changing source.

![delegation-modal](https://user-images.githubusercontent.com/360865/57522028-f56a2500-7321-11e9-914a-12a00f534f2e.gif)

Thank you! 🚀

---

For contributor:

- [x] Added changes entries. Run `yarn changelog` for a guided process.
- [x] Reviewed `Files changed` in the github PR explorer
- [x] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI
