### PR TITLE
colw/Configure number of nodes to run on local test-net

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,4 +17,5 @@ testArtifacts/*
 *.key
 chromedriver.log
 src/keybase-cache.json
-certs/*
+certs/
+.env

--- a/changes/testnet-set-num-nodes
+++ b/changes/testnet-set-num-nodes
@@ -1,0 +1,1 @@
+[Added] [#2589](https://github.com/cosmos/lunie/pull/2589) Set number of nodes run on local testnet via environment variable @colw

--- a/tasks/local-testnet/docker-compose.yml
+++ b/tasks/local-testnet/docker-compose.yml
@@ -12,6 +12,7 @@ services:
     entrypoint:
       - sh
       - /etc/nodes/first.sh
+      - "${MAX_NODES:-2}"
     ports:
       - "26657:26657"
       - "9070:9070"

--- a/tasks/local-testnet/nodes/first.sh
+++ b/tasks/local-testnet/nodes/first.sh
@@ -32,9 +32,16 @@ gaiad start --home ${HOME} > /dev/null & (
   (
     gaiacli rest-server --home ${HOME} --chain-id ${NETWORK} --trust-node true --laddr tcp://0.0.0.0:${API_PORT} &
     sh /etc/nodes/faucet.sh $HOME &
-    sh /etc/nodes/secondary.sh $HOME 1 &
-    sh /etc/nodes/secondary.sh $HOME 2 &
-    sh /etc/nodes/secondary.sh $HOME 3
+
+    counter=1
+    max=$1
+    echo Starting $max nodes
+    while [ "$counter" -lt "$max" ]
+    do
+      sh /etc/nodes/secondary.sh "${HOME}" "$counter" &
+      counter=`expr "$counter" + 1`
+    done
+    sh /etc/nodes/secondary.sh "${HOME}" "$counter"
     wait
   )
 )


### PR DESCRIPTION
**Description:**

Uses MAX_NODES environment variable to set the maximum number of nodes
spun up. Default to 2 nodes if variable not present.

Use an `.env` file to set this.


Thank you! 🚀

---

For contributor:

- [x] Added changes entries. Run `yarn changelog` for a guided process.
- [x] Reviewed `Files changed` in the github PR explorer
- [ ] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI
