### PR TITLE
colw/2378 disable withdrawl on zero delegations

### DIFF
--- a/changes/colw_2378-disable-withdrawl-on-zero-delegations
+++ b/changes/colw_2378-disable-withdrawl-on-zero-delegations
@@ -1,0 +1,1 @@
+[Fixed] [#2378](https://github.com/cosmos/lunie/issues/2378) Do not show withdrawal button when user has no rewards avilable @colw

--- a/src/components/common/TmBalance.vue
+++ b/src/components/common/TmBalance.vue
@@ -16,6 +16,7 @@
         <h3>Rewards</h3>
         <h2>{{ rewards }}</h2>
         <TmBtn
+          v-show="rewards > 0"
           id="withdraw-btn"
           class="withdraw-rewards"
           :value="connected ? 'Withdraw' : 'Connecting...'"

--- a/test/unit/specs/components/common/__snapshots__/TmBalance.spec.js.snap
+++ b/test/unit/specs/components/common/__snapshots__/TmBalance.spec.js.snap
@@ -54,6 +54,7 @@ exports[`TmBalance has the expected html structure before adding props 1`] = `
         class="withdraw-rewards"
         id="withdraw-btn"
         size="sm"
+        style="display: none;"
         to=""
         type="link"
         value="Withdraw"

--- a/test/unit/specs/components/governance/__snapshots__/PageGovernance.spec.js.snap
+++ b/test/unit/specs/components/governance/__snapshots__/PageGovernance.spec.js.snap
@@ -96,6 +96,7 @@ exports[`PageGovernance disables proposal creation if not connected 1`] = `
                   class="withdraw-rewards"
                   exact="exact"
                   id="withdraw-btn"
+                  style="display: none;"
                   to=""
                 >
                   
@@ -365,6 +366,7 @@ exports[`PageGovernance has the expected html structure 1`] = `
                   class="withdraw-rewards"
                   exact="exact"
                   id="withdraw-btn"
+                  style="display: none;"
                   to=""
                 >
                   


### PR DESCRIPTION
Closes #2378

**Description:**

Disable option to withdraw when the user has no rewards.

![withdraw-zero](https://user-images.githubusercontent.com/360865/57783311-34d3af80-772e-11e9-9f5c-8aa89bf0f445.gif)

Thank you! 🚀

---

For contributor:

- [x] Added changes entries. Run `yarn changelog` for a guided process.
- [x] Reviewed `Files changed` in the github PR explorer
- [x] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI

