### PR TITLE
Miguel/2591 li bank transaction from detail is missing a space

### DIFF
--- a/changes/miguel_2591-LiBankTransaction-From-detail-is-missing-a-space
+++ b/changes/miguel_2591-LiBankTransaction-From-detail-is-missing-a-space
@@ -1,0 +1,1 @@
+[Fixed] [#2592](https://github.com/cosmos/lunie/issues/2592) Add a &nbsp; to LiBankTransaction so that there is a space between From and the address @migueog

--- a/src/components/transactions/LiBankTransaction.vue
+++ b/src/components/transactions/LiBankTransaction.vue
@@ -56,7 +56,7 @@
         <span>{{ num.viewDenom(coins.denom) }}</span>
       </div>
       <span slot="details">
-        From
+        From &nbsp;
         <ShortBech32 :address="sender" />
       </span>
       <div slot="fees">

--- a/test/unit/specs/components/transactions/__snapshots__/LiBankTransaction.spec.js.snap
+++ b/test/unit/specs/components/transactions/__snapshots__/LiBankTransaction.spec.js.snap
@@ -113,7 +113,7 @@ exports[`LiBankTransaction should show incoming transactions 1`] = `
    
   <span>
     
-      From
+      From  
       
     <shortbech32-stub
       address="A"


### PR DESCRIPTION
Closes #2591 

**Description:**

<!-- Briefly describe what you're adding or fixing with this PR -->

Add a `&nbsp;` to LiBankTransaction so that there is a space between `From` and the address

Thank you! 🚀

---

For contributor:

- [x] Added changes entries. Run `yarn changelog` for a guided process.
- [x] Reviewed `Files changed` in the github PR explorer
- [ ] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI
