### PR TITLE
Miguel/2538 cant sign out of mobile

### DIFF
--- a/changes/miguel_2538-cant-sign-out-of-mobile
+++ b/changes/miguel_2538-cant-sign-out-of-mobile
@@ -1,0 +1,1 @@
+[Fixed] [#2538](https://github.com/cosmos/lunie/issues/2538) Added sign out menu item to AppMenu.vue @migueog

--- a/src/components/common/AppMenu.vue
+++ b/src/components/common/AppMenu.vue
@@ -64,7 +64,12 @@
         </h2>
         <i class="material-icons">chevron_right</i>
       </router-link>
-      <a v-if="session.signedIn" id="signOut-btn" class="app-menu-item" @click="signOut()">
+      <a
+        v-if="session.signedIn"
+        id="signOut-btn"
+        class="app-menu-item"
+        @click="signOut()"
+      >
         <h2 class="app-menu-title">
           Sign out
         </h2>
@@ -91,11 +96,11 @@ export default {
     ps: {},
     desktop: false
   }),
-  mounted() {
-    this.ps = new PerfectScrollbar(this.$el.querySelector(`.app-menu-main`))
-  },
   computed: {
     ...mapGetters([`session`])
+  },
+  mounted() {
+    this.ps = new PerfectScrollbar(this.$el.querySelector(`.app-menu-main`))
   },
   methods: {
     close() {
@@ -104,7 +109,7 @@ export default {
     },
     signOut() {
       this.$store.dispatch(`signOut`)
-      this.close();
+      this.close()
       this.$router.push(`/`)
     }
   }
@@ -194,6 +199,7 @@ export default {
   .app-menu {
     width: var(--width-side);
   }
+
   .app-menu #signOut-btn {
     display: none;
   }

--- a/src/components/common/AppMenu.vue
+++ b/src/components/common/AppMenu.vue
@@ -93,8 +93,7 @@ export default {
     ConnectedNetwork
   },
   data: () => ({
-    ps: {},
-    desktop: false
+    ps: {}
   }),
   computed: {
     ...mapGetters([`session`])

--- a/src/components/common/AppMenu.vue
+++ b/src/components/common/AppMenu.vue
@@ -73,7 +73,7 @@
         <h2 class="app-menu-title">
           Sign out
         </h2>
-        <i v-tooltip.bottom.end="'Sign Out'" class="material-icons">
+        <i class="material-icons">
           exit_to_app
         </i>
       </a>
@@ -108,7 +108,6 @@ export default {
     },
     signOut() {
       this.$store.dispatch(`signOut`)
-      this.close()
       this.$router.push(`/`)
     }
   }

--- a/src/components/common/AppMenu.vue
+++ b/src/components/common/AppMenu.vue
@@ -64,6 +64,14 @@
         </h2>
         <i class="material-icons">chevron_right</i>
       </router-link>
+      <a v-if="session.signedIn" id="signOut-btn" class="app-menu-item" @click="signOut()">
+        <h2 class="app-menu-title">
+          Sign out
+        </h2>
+        <i v-tooltip.bottom.end="'Sign Out'" class="material-icons">
+          exit_to_app
+        </i>
+      </a>
     </div>
     <ConnectedNetwork />
   </menu>
@@ -73,21 +81,31 @@
 import PerfectScrollbar from "perfect-scrollbar"
 import noScroll from "no-scroll"
 import ConnectedNetwork from "common/TmConnectedNetwork"
+import { mapGetters } from "vuex"
 export default {
   name: `app-menu`,
   components: {
     ConnectedNetwork
   },
   data: () => ({
-    ps: {}
+    ps: {},
+    desktop: false
   }),
   mounted() {
     this.ps = new PerfectScrollbar(this.$el.querySelector(`.app-menu-main`))
+  },
+  computed: {
+    ...mapGetters([`session`])
   },
   methods: {
     close() {
       this.$emit(`close`)
       noScroll.off()
+    },
+    signOut() {
+      this.$store.dispatch(`signOut`)
+      this.close();
+      this.$router.push(`/`)
     }
   }
 }
@@ -175,6 +193,9 @@ export default {
 @media screen and (min-width: 1023px) {
   .app-menu {
     width: var(--width-side);
+  }
+  .app-menu #signOut-btn {
+    display: none;
   }
 }
 </style>

--- a/test/unit/specs/components/common/AppMenu.spec.js
+++ b/test/unit/specs/components/common/AppMenu.spec.js
@@ -6,7 +6,12 @@ describe(`AppMenu`, () => {
 
   beforeEach(async () => {
     $store = {
-      commit: jest.fn()
+      commit: jest.fn(),
+      getters: {
+        session: {
+          signedIn: true
+        }
+      }
     }
 
     wrapper = shallowMount(AppMenu, {
@@ -24,5 +29,12 @@ describe(`AppMenu`, () => {
   it(`can close the app menu`, () => {
     wrapper.find(`#app-menu__wallet`).trigger(`click`)
     expect(wrapper.emitted().close).toBeTruthy()
+  })
+
+  it(`call dispatch to sign the user out`, () => {
+    const $store = { dispatch: jest.fn() }
+    const self = { $store, $router: { push: jest.fn() } }
+    AppMenu.methods.signOut.call(self)
+    expect($store.dispatch).toHaveBeenCalledWith(`signOut`)
   })
 })


### PR DESCRIPTION
Closes #2538 

**Description:**

<!-- Briefly describe what you're adding or fixing with this PR -->

Added sign out menu item to `AppMenu.vue`. This will allow mobile users to sign out of their account.

Thank you! 🚀

---

For contributor:

- [ ] Added changes entries. Run `yarn changelog` for a guided process.
- [ ] Reviewed `Files changed` in the github PR explorer
- [ ] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI
