### PR TITLE
colw/Display correct atom for banking transactions

### DIFF
--- a/changes/colw_fix-stake-atom-display
+++ b/changes/colw_fix-stake-atom-display
@@ -1,0 +1,1 @@
+[Fixed] [#2614](https://github.com/cosmos/lunie/pull/2614) Dispaly correct atom value for banking transactions @colw

--- a/src/components/transactions/LiBankTransaction.vue
+++ b/src/components/transactions/LiBankTransaction.vue
@@ -2,72 +2,49 @@
   <LiTransaction :color="`#ED553B`" :time="time" :block="block" :memo="memo">
     <template v-if="address === ''">
       <div slot="caption">
-        Sent<b>{{ coins.amount }}</b>
-        <span>{{ num.viewDenom(coins.denom) }}</span>
+        Sent <b>{{ txAmount | toAtoms | shortDecimals }}</b>
+        <span>{{ txDenom | viewDenom }}</span>
       </div>
       <span slot="details">
         <template>
-          From
-          <ShortBech32 :address="sender" /> to
+          From <ShortBech32 :address="sender" /> to
           <ShortBech32 :address="receiver" />
         </template>
       </span>
       <div slot="fees">
-        Network Fee:&nbsp;<b>{{ convertedFees ? convertedFees.amount : 0 }}</b>
-        <span>
-          {{
-            convertedFees
-              ? num.viewDenom(convertedFees.denom)
-              : num.viewDenom(bondingDenom)
-          }}
-        </span>
+        Network Fee:&nbsp;<b>{{ feeAmount | toAtoms | shortDecimals }}</b>
+        <span>{{ feeDenom | viewDenom }}</span>
       </div>
     </template>
     <template v-else-if="sent">
       <div slot="caption">
-        Sent
-        <b>{{ coins.amount }}</b>
-        <span>{{ num.viewDenom(coins.denom) }}</span>
+        Sent <b>{{ txAmount | toAtoms | shortDecimals }}</b>
+        <span>{{ txDenom | viewDenom }}</span>
       </div>
       <span slot="details">
         <template v-if="sentSelf">
           To yourself!
         </template>
         <template v-else>
-          To
-          <ShortBech32 :address="receiver" />
+          To <ShortBech32 :address="receiver" />
         </template>
       </span>
       <div slot="fees">
-        Network Fee:&nbsp;<b>{{ convertedFees ? convertedFees.amount : 0 }}</b>
-        <span>
-          {{
-            convertedFees
-              ? num.viewDenom(convertedFees.denom)
-              : num.viewDenom(bondingDenom)
-          }}
-        </span>
+        Network Fee:&nbsp;<b>{{ feeAmount | toAtoms | shortDecimals }}</b>
+        <span>{{ feeDenom | viewDenom }}</span>
       </div>
     </template>
     <template v-else>
       <div slot="caption">
-        Received
-        <b>{{ coins.amount }}</b>
-        <span>{{ num.viewDenom(coins.denom) }}</span>
+        Received <b>{{ txAmount | toAtoms | shortDecimals }}</b>
+        <span>{{ txDenom | viewDenom }}</span>
       </div>
       <span slot="details">
-        From &nbsp;
-        <ShortBech32 :address="sender" />
+        From &nbsp; <ShortBech32 :address="sender" />
       </span>
       <div slot="fees">
-        Network Fee:&nbsp;<b>{{ convertedFees ? convertedFees.amount : 0 }}</b>
-        <span>
-          {{
-            convertedFees
-              ? num.viewDenom(convertedFees.denom)
-              : num.viewDenom(bondingDenom)
-          }}
-        </span>
+        Network Fee:&nbsp;<b>{{ feeAmount | toAtoms | shortDecimals }}</b>
+        <span>{{ feeDenom | viewDenom }}</span>
       </div>
     </template>
   </LiTransaction>
@@ -76,13 +53,18 @@
 <script>
 import ShortBech32 from "common/ShortBech32"
 import LiTransaction from "./LiTransaction"
-import num from "../../scripts/num.js"
+import { atoms, viewDenom, shortDecimals } from "../../scripts/num.js"
 
 export default {
   name: `li-bank-transaction`,
   components: {
     ShortBech32,
     LiTransaction
+  },
+  filters: {
+    toAtoms: atoms,
+    viewDenom: viewDenom,
+    shortDecimals: shortDecimals
   },
   props: {
     tx: {
@@ -114,9 +96,6 @@ export default {
       default: null
     }
   },
-  data: () => ({
-    num
-  }),
   computed: {
     // TODO: sum relevant inputs/outputs
     sentSelf() {
@@ -128,14 +107,20 @@ export default {
     sender() {
       return this.tx.from_address
     },
-    coins() {
-      return this.tx.amount.map(num.createDisplayCoin)[0]
-    },
-    convertedFees() {
-      return this.fees ? num.createDisplayCoin(this.fees) : undefined
-    },
     receiver() {
       return this.tx.to_address
+    },
+    txAmount() {
+      return this.tx.amount[0].amount
+    },
+    txDenom() {
+      return this.tx.amount[0].denom
+    },
+    feeAmount() {
+      return this.fees ? this.fees.amount : 0
+    },
+    feeDenom() {
+      return this.fees ? this.fees.denom : this.txDenom
     }
   }
 }

--- a/test/unit/specs/components/transactions/__snapshots__/LiBankTransaction.spec.js.snap
+++ b/test/unit/specs/components/transactions/__snapshots__/LiBankTransaction.spec.js.snap
@@ -9,8 +9,7 @@ exports[`LiBankTransaction should show a bank transaction without fees 1`] = `
 >
   <div>
     
-      Sent
-      
+      Sent 
     <b>
       12,340
     </b>
@@ -34,9 +33,7 @@ exports[`LiBankTransaction should show a bank transaction without fees 1`] = `
     </b>
      
     <span>
-      
-        ATOM
-      
+      ATOM
     </span>
   </div>
 </litransaction-stub>
@@ -51,7 +48,7 @@ exports[`LiBankTransaction should show bank transaction when user hasn't signed 
 >
   <div>
     
-      Sent
+      Sent 
     <b>
       12,340
     </b>
@@ -63,8 +60,7 @@ exports[`LiBankTransaction should show bank transaction when user hasn't signed 
    
   <span>
     
-        From
-        
+        From 
     <shortbech32-stub
       address="A"
     />
@@ -83,9 +79,7 @@ exports[`LiBankTransaction should show bank transaction when user hasn't signed 
     </b>
      
     <span>
-      
-        ATOM
-      
+      ATOM
     </span>
   </div>
 </litransaction-stub>
@@ -100,8 +94,7 @@ exports[`LiBankTransaction should show incoming transactions 1`] = `
 >
   <div>
     
-      Received
-      
+      Received 
     <b>
       12,340
     </b>
@@ -113,8 +106,7 @@ exports[`LiBankTransaction should show incoming transactions 1`] = `
    
   <span>
     
-      From  
-      
+      From   
     <shortbech32-stub
       address="A"
     />
@@ -128,9 +120,7 @@ exports[`LiBankTransaction should show incoming transactions 1`] = `
     </b>
      
     <span>
-      
-        ATOM
-      
+      ATOM
     </span>
   </div>
 </litransaction-stub>
@@ -145,8 +135,7 @@ exports[`LiBankTransaction should show outgoing transactions 1`] = `
 >
   <div>
     
-      Sent
-      
+      Sent 
     <b>
       12,340
     </b>
@@ -158,8 +147,7 @@ exports[`LiBankTransaction should show outgoing transactions 1`] = `
    
   <span>
     
-        To
-        
+        To 
     <shortbech32-stub
       address="A"
     />
@@ -173,9 +161,7 @@ exports[`LiBankTransaction should show outgoing transactions 1`] = `
     </b>
      
     <span>
-      
-        ATOM
-      
+      ATOM
     </span>
   </div>
 </litransaction-stub>
@@ -190,8 +176,7 @@ exports[`LiBankTransaction should show outgoing transactions send to herself 1`]
 >
   <div>
     
-      Sent
-      
+      Sent 
     <b>
       12,340
     </b>
@@ -215,9 +200,7 @@ exports[`LiBankTransaction should show outgoing transactions send to herself 1`]
     </b>
      
     <span>
-      
-        ATOM
-      
+      ATOM
     </span>
   </div>
 </litransaction-stub>


### PR DESCRIPTION
**Description:**

Atom value was not displaying correctly in banking transactions.

A good excuse to clean up some template code.

Before:
<img width="835" alt="Screenshot 2019-05-17 at 17 30 17" src="https://user-images.githubusercontent.com/360865/57939100-d5120b80-78c9-11e9-8e43-4fb00dd928c1.png">

After:
<img width="842" alt="Screenshot 2019-05-17 at 17 30 04" src="https://user-images.githubusercontent.com/360865/57939110-dba08300-78c9-11e9-9a97-c34e222f17e2.png">

Snapshots changed, but it's only redundant spacing.

Thank you! 🚀

---

For contributor:

- [x] Added changes entries. Run `yarn changelog` for a guided process.
- [x] Reviewed `Files changed` in the github PR explorer
- [x] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI
