### PR TITLE
Add white-space: normal to circle—default class

### DIFF
--- a/changes/miguel_2615-step-component-withdraw-style-fix
+++ b/changes/miguel_2615-step-component-withdraw-style-fix
@@ -1,0 +1,1 @@
+[Fixed] [#2617](https://github.com/cosmos/lunie/pull/2617) Add white-space: normal to circle—default class @migueog

--- a/src/components/common/StepComponent.vue
+++ b/src/components/common/StepComponent.vue
@@ -48,6 +48,7 @@ export default {
   display: flex;
   flex-direction: column;
   justify-content: center;
+  white-space: normal;
 }
 
 .circle--default {


### PR DESCRIPTION
Closes #2615 

**Description:**

<!-- Briefly describe what you're adding or fixing with this PR -->
The fix for this issue is to add `white-space: normal` to override an inherited style. 

Seems that the other modals were not affected because their parent isn't `TmPageHeader`.

https://vue-loader.vuejs.org/guide/scoped-css.html#child-component-root-elements 

Thank you! 🚀

---

For contributor:

- [ ] Added changes entries. Run `yarn changelog` for a guided process.
- [ ] Reviewed `Files changed` in the github PR explorer
- [ ] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI
