### PR TITLE
colw/refactor network fee display

### DIFF
--- a/changes/colw_refactor-netowrk-fee-display
+++ b/changes/colw_refactor-netowrk-fee-display
@@ -1,0 +1,1 @@
+[Changed] [#2618](https://github.com/cosmos/lunie/pull/2618) Refactor Transaction view to reduce code repetition @colw

--- a/src/components/transactions/LiAnyTransaction.vue
+++ b/src/components/transactions/LiAnyTransaction.vue
@@ -107,10 +107,16 @@ export default {
   },
   computed: {
     fees() {
-      return (
-        this.transaction.tx.value.fee.amount &&
-        this.transaction.tx.value.fee.amount[0]
-      )
+      if (
+        this.transaction.tx.value.fee &&
+        this.transaction.tx.value.fee.amount
+      ) {
+        return this.transaction.tx.value.fee.amount[0]
+      }
+      return {
+        amount: "0",
+        denom: this.bondingDenom
+      }
     }
   },
   methods: {

--- a/src/components/transactions/LiBankTransaction.vue
+++ b/src/components/transactions/LiBankTransaction.vue
@@ -1,5 +1,11 @@
 <template>
-  <LiTransaction :color="`#ED553B`" :time="time" :block="block" :memo="memo">
+  <LiTransaction
+    :color="`#ED553B`"
+    :time="time"
+    :block="block"
+    :memo="memo"
+    :fees="fees"
+  >
     <template v-if="address === ''">
       <div slot="caption">
         Sent <b>{{ txAmount | toAtoms | shortDecimals }}</b>
@@ -11,10 +17,6 @@
           <ShortBech32 :address="receiver" />
         </template>
       </span>
-      <div slot="fees">
-        Network Fee:&nbsp;<b>{{ feeAmount | toAtoms | shortDecimals }}</b>
-        <span>{{ feeDenom | viewDenom }}</span>
-      </div>
     </template>
     <template v-else-if="sent">
       <div slot="caption">
@@ -29,10 +31,6 @@
           To <ShortBech32 :address="receiver" />
         </template>
       </span>
-      <div slot="fees">
-        Network Fee:&nbsp;<b>{{ feeAmount | toAtoms | shortDecimals }}</b>
-        <span>{{ feeDenom | viewDenom }}</span>
-      </div>
     </template>
     <template v-else>
       <div slot="caption">
@@ -42,10 +40,6 @@
       <span slot="details">
         From &nbsp; <ShortBech32 :address="sender" />
       </span>
-      <div slot="fees">
-        Network Fee:&nbsp;<b>{{ feeAmount | toAtoms | shortDecimals }}</b>
-        <span>{{ feeDenom | viewDenom }}</span>
-      </div>
     </template>
   </LiTransaction>
 </template>
@@ -115,12 +109,6 @@ export default {
     },
     txDenom() {
       return this.tx.amount[0].denom
-    },
-    feeAmount() {
-      return this.fees ? this.fees.amount : 0
-    },
-    feeDenom() {
-      return this.fees ? this.fees.denom : this.txDenom
     }
   }
 }

--- a/src/components/transactions/LiBankTransaction.vue
+++ b/src/components/transactions/LiBankTransaction.vue
@@ -67,7 +67,7 @@ export default {
     },
     fees: {
       type: Object,
-      default: null
+      required: true
     },
     address: {
       type: String,

--- a/src/components/transactions/LiBankTransaction.vue
+++ b/src/components/transactions/LiBankTransaction.vue
@@ -47,7 +47,7 @@
 <script>
 import ShortBech32 from "common/ShortBech32"
 import LiTransaction from "./LiTransaction"
-import { atoms, viewDenom, shortDecimals } from "../../scripts/num.js"
+import { atoms as toAtoms, viewDenom, shortDecimals } from "../../scripts/num.js"
 
 export default {
   name: `li-bank-transaction`,
@@ -56,9 +56,9 @@ export default {
     LiTransaction
   },
   filters: {
-    toAtoms: atoms,
-    viewDenom: viewDenom,
-    shortDecimals: shortDecimals
+    toAtoms,
+    viewDenom,
+    shortDecimals
   },
   props: {
     tx: {

--- a/src/components/transactions/LiBankTransaction.vue
+++ b/src/components/transactions/LiBankTransaction.vue
@@ -47,7 +47,11 @@
 <script>
 import ShortBech32 from "common/ShortBech32"
 import LiTransaction from "./LiTransaction"
-import { atoms as toAtoms, viewDenom, shortDecimals } from "../../scripts/num.js"
+import {
+  atoms as toAtoms,
+  viewDenom,
+  shortDecimals
+} from "../../scripts/num.js"
 
 export default {
   name: `li-bank-transaction`,

--- a/src/components/transactions/LiDistributionTransaction.vue
+++ b/src/components/transactions/LiDistributionTransaction.vue
@@ -37,7 +37,6 @@
 
 <script>
 import LiTransaction from "./LiTransaction"
-import num from "../../scripts/num.js"
 
 export default {
   name: `li-distribution-transaction`,
@@ -81,7 +80,6 @@ export default {
     }
   },
   data: () => ({
-    num,
     MsgWithdrawValidatorCommission: `cosmos-sdk/MsgWithdrawValidatorCommission`,
     MsgSetWithdrawAddress: `cosmos-sdk/MsgSetWithdrawAddress`,
     MsgWithdrawDelegationReward: `cosmos-sdk/MsgWithdrawDelegationReward`

--- a/src/components/transactions/LiDistributionTransaction.vue
+++ b/src/components/transactions/LiDistributionTransaction.vue
@@ -1,5 +1,11 @@
 <template>
-  <LiTransaction :color="`#F2B134`" :time="time" :block="block" :memo="memo">
+  <LiTransaction
+    :color="`#F2B134`"
+    :time="time"
+    :block="block"
+    :memo="memo"
+    :fees="fees"
+  >
     <template v-if="txType === MsgWithdrawDelegationReward">
       <div slot="caption">
         Withdrawal
@@ -9,28 +15,12 @@
           {{ moniker(tx.validator_address) }}
         </router-link>
       </div>
-      <div slot="fees">
-        Network Fee:&nbsp;<b>{{ convertedFees ? convertedFees.amount : 0 }}</b>
-        <span>
-          {{
-            convertedFees ? convertedFees.denom : num.viewDenom(bondingDenom)
-          }}
-        </span>
-      </div>
     </template>
     <template v-else-if="txType === MsgSetWithdrawAddress">
       <div slot="caption">
         Update withdraw address
       </div>
       <div slot="details">To {{ tx.withdraw_address }}</div>
-      <div slot="fees">
-        Network Fee:&nbsp;<b>{{ convertedFees ? convertedFees.amount : 0 }}</b>
-        <span>
-          {{
-            convertedFees ? convertedFees.denom : num.viewDenom(bondingDenom)
-          }}
-        </span>
-      </div>
     </template>
     <template v-else-if="txType === MsgWithdrawValidatorCommission">
       <div slot="caption">
@@ -40,14 +30,6 @@
         From<router-link :to="`${url}/${tx.validator_address}`">
           {{ moniker(tx.validator_address) }}
         </router-link>
-      </div>
-      <div slot="fees">
-        Network Fee:&nbsp;<b>{{ convertedFees ? convertedFees.amount : 0 }}</b>
-        <span>
-          {{
-            convertedFees ? convertedFees.denom : num.viewDenom(bondingDenom)
-          }}
-        </span>
       </div>
     </template>
   </LiTransaction>
@@ -104,11 +86,6 @@ export default {
     MsgSetWithdrawAddress: `cosmos-sdk/MsgSetWithdrawAddress`,
     MsgWithdrawDelegationReward: `cosmos-sdk/MsgWithdrawDelegationReward`
   }),
-  computed: {
-    convertedFees() {
-      return this.fees ? num.createDisplayCoin(this.fees) : undefined
-    }
-  },
   methods: {
     moniker(validatorAddr) {
       const validator = this.validators.find(

--- a/src/components/transactions/LiDistributionTransaction.vue
+++ b/src/components/transactions/LiDistributionTransaction.vue
@@ -49,7 +49,7 @@ export default {
     },
     fees: {
       type: Object,
-      default: null
+      required: true
     },
     url: {
       type: String,

--- a/src/components/transactions/LiGovTransaction.vue
+++ b/src/components/transactions/LiGovTransaction.vue
@@ -57,7 +57,7 @@ export default {
     },
     fees: {
       type: Object,
-      default: null
+      required: true
     },
     url: {
       type: String,

--- a/src/components/transactions/LiGovTransaction.vue
+++ b/src/components/transactions/LiGovTransaction.vue
@@ -1,5 +1,11 @@
 <template>
-  <LiTransaction :color="`#15CFCC`" :time="time" :block="block" :memo="memo">
+  <LiTransaction
+    :color="`#15CFCC`"
+    :time="time"
+    :block="block"
+    :memo="memo"
+    :fees="fees"
+  >
     <template v-if="txType === `cosmos-sdk/MsgSubmitProposal`">
       <div slot="caption">
         Submitted {{ tx.proposal_type.toLowerCase() }} proposal
@@ -8,16 +14,6 @@
       </div>
       <div slot="details">
         Title:&nbsp;<i>{{ tx.title }}</i>
-      </div>
-      <div slot="fees">
-        Network Fee:&nbsp;<b>{{ convertedFees ? convertedFees.amount : 0 }}</b>
-        <span>
-          {{
-            convertedFees
-              ? viewDenom(convertedFees.denom)
-              : viewDenom(bondingDenom)
-          }}
-        </span>
       </div>
     </template>
     <template v-else-if="txType === `cosmos-sdk/MsgDeposit`">
@@ -34,12 +30,6 @@
           Proposal &#35;{{ tx.proposal_id }}
         </router-link>
       </div>
-      <div slot="fees">
-        Network Fee:&nbsp;<b>{{ convertedFees ? convertedFees.amount : 0 }}</b>
-        <span>
-          {{ fees ? viewDenom(convertedFees.denom) : viewDenom(bondingDenom) }}
-        </span>
-      </div>
     </template>
     <template v-else-if="txType === `cosmos-sdk/MsgVote`">
       <div slot="caption">Voted&nbsp;{{ tx.option }}</div>
@@ -48,16 +38,6 @@
         <router-link :to="`${url}/${tx.proposal_id}`">
           Proposal &#35;{{ tx.proposal_id }}
         </router-link>
-      </div>
-      <div slot="fees">
-        Network Fee:&nbsp;<b>{{ convertedFees ? convertedFees.amount : 0 }}</b>
-        <span>
-          {{
-            convertedFees
-              ? viewDenom(convertedFees.denom)
-              : viewDenom(bondingDenom)
-          }}
-        </span>
       </div>
     </template>
   </LiTransaction>
@@ -114,9 +94,6 @@ export default {
     },
     deposit() {
       return num.createDisplayCoin(this.tx.amount[0])
-    },
-    convertedFees() {
-      return this.fees ? num.createDisplayCoin(this.fees) : undefined
     }
   }
 }

--- a/src/components/transactions/LiGovTransaction.vue
+++ b/src/components/transactions/LiGovTransaction.vue
@@ -45,15 +45,15 @@
 
 <script>
 import LiTransaction from "./LiTransaction"
-import { atoms, viewDenom, shortDecimals } from "../../scripts/num.js"
+import { atoms as toAtoms, viewDenom, shortDecimals } from "../../scripts/num.js"
 
 export default {
   name: `li-gov-transaction`,
   components: { LiTransaction },
   filters: {
-    toAtoms: atoms,
-    viewDenom: viewDenom,
-    shortDecimals: shortDecimals
+    toAtoms,
+    viewDenom,
+    shortDecimals
   },
   props: {
     tx: {

--- a/src/components/transactions/LiGovTransaction.vue
+++ b/src/components/transactions/LiGovTransaction.vue
@@ -9,8 +9,8 @@
     <template v-if="txType === `cosmos-sdk/MsgSubmitProposal`">
       <div slot="caption">
         Submitted {{ tx.proposal_type.toLowerCase() }} proposal
-        <b>{{ initialDeposit.amount }}</b>
-        <span>{{ viewDenom(initialDeposit.denom) }}</span>
+        <b>{{ initialDeposit.amount | toAtoms | shortDecimals }}</b>
+        <span>{{ initialDeposit.denom | viewDenom }}</span>
       </div>
       <div slot="details">
         Title:&nbsp;<i>{{ tx.title }}</i>
@@ -20,8 +20,8 @@
       <div slot="caption">
         Deposited
         <template>
-          <b>{{ deposit.amount }}</b>
-          <span>{{ viewDenom(deposit.denom) }}</span>
+          <b>{{ deposit.amount | toAtoms | shortDecimals }}</b>
+          <span>{{ deposit.denom | viewDenom }}</span>
         </template>
       </div>
       <div slot="details">
@@ -45,11 +45,16 @@
 
 <script>
 import LiTransaction from "./LiTransaction"
-import num, { atoms, viewDenom } from "../../scripts/num.js"
+import { atoms, viewDenom, shortDecimals } from "../../scripts/num.js"
 
 export default {
   name: `li-gov-transaction`,
   components: { LiTransaction },
+  filters: {
+    toAtoms: atoms,
+    viewDenom: viewDenom,
+    shortDecimals: shortDecimals
+  },
   props: {
     tx: {
       type: Object,
@@ -90,10 +95,10 @@ export default {
   }),
   computed: {
     initialDeposit() {
-      return num.createDisplayCoin(this.tx.initial_deposit[0])
+      return this.tx.initial_deposit[0]
     },
     deposit() {
-      return num.createDisplayCoin(this.tx.amount[0])
+      return this.tx.amount[0]
     }
   }
 }

--- a/src/components/transactions/LiGovTransaction.vue
+++ b/src/components/transactions/LiGovTransaction.vue
@@ -45,7 +45,11 @@
 
 <script>
 import LiTransaction from "./LiTransaction"
-import { atoms as toAtoms, viewDenom, shortDecimals } from "../../scripts/num.js"
+import {
+  atoms as toAtoms,
+  viewDenom,
+  shortDecimals
+} from "../../scripts/num.js"
 
 export default {
   name: `li-gov-transaction`,
@@ -89,10 +93,6 @@ export default {
       default: null
     }
   },
-  data: () => ({
-    atoms,
-    viewDenom
-  }),
   computed: {
     initialDeposit() {
       return this.tx.initial_deposit[0]

--- a/src/components/transactions/LiStakeTransaction.vue
+++ b/src/components/transactions/LiStakeTransaction.vue
@@ -98,7 +98,7 @@
 
 <script>
 import LiTransaction from "./LiTransaction"
-import { atoms, viewDenom } from "../../scripts/num.js"
+import { atoms as toAtoms, viewDenom } from "../../scripts/num.js"
 import moment from "moment"
 
 /*
@@ -109,8 +109,8 @@ export default {
   name: `li-stake-transaction`,
   components: { LiTransaction },
   filters: {
-    toAtoms: atoms,
-    viewDenom: viewDenom
+    toAtoms,
+    viewDenom
   },
   props: {
     tx: {

--- a/src/components/transactions/LiStakeTransaction.vue
+++ b/src/components/transactions/LiStakeTransaction.vue
@@ -9,8 +9,8 @@
     <template v-if="txType === `cosmos-sdk/MsgCreateValidator`">
       <div slot="caption">
         Create validator
-        <b>{{ num.atoms(tx.amount.amount) }}</b>
-        <span>{{ value && value.denom }}</span>
+        <b>{{ tx.amount.amount | toAtoms }}</b>
+        <span>{{ value | viewDenom }}</span>
       </div>
       <div slot="details">
         Moniker:
@@ -33,8 +33,8 @@
     <template v-else-if="txType === `cosmos-sdk/MsgDelegate`">
       <div slot="caption">
         Delegated
-        <b>{{ num.atoms(tx.amount.amount) }}</b>
-        <span>{{ num.viewDenom(tx.amount.denom) }}</span>
+        <b>{{ tx.amount.amount | toAtoms }}</b>
+        <span>{{ tx.amount.denom | viewDenom }}</span>
       </div>
       <div slot="details">
         To&nbsp;
@@ -47,9 +47,9 @@
       <div slot="caption">
         Undelegated
         <b>
-          {{ num.atoms(tx.amount.amount) }}
+          {{ tx.amount.amount | toAtoms }}
         </b>
-        <span>{{ num.viewDenom(bondingDenom) }}</span>
+        <span>{{ bondingDenom | viewDenom }}</span>
         <template v-if="timeDiff">
           <span class="tx-unbonding__time-diff">
             {{ timeDiff }}
@@ -67,9 +67,9 @@
       <div slot="caption">
         Redelegated
         <b>
-          {{ num.atoms(tx.amount.amount) }}
+          {{ tx.amount.amount | toAtoms }}
         </b>
-        <span>{{ num.viewDenom(bondingDenom) }}</span>
+        <span>{{ bondingDenom | viewDenom }}</span>
       </div>
       <div slot="details">
         From&nbsp;
@@ -98,7 +98,7 @@
 
 <script>
 import LiTransaction from "./LiTransaction"
-import num from "../../scripts/num.js"
+import { atoms, viewDenom } from "../../scripts/num.js"
 import moment from "moment"
 
 /*
@@ -108,6 +108,10 @@ import moment from "moment"
 export default {
   name: `li-stake-transaction`,
   components: { LiTransaction },
+  filters: {
+    toAtoms: atoms,
+    viewDenom: viewDenom
+  },
   props: {
     tx: {
       type: Object,
@@ -150,9 +154,6 @@ export default {
       default: null
     }
   },
-  data: () => ({
-    num
-  }),
   computed: {
     timeDiff() {
       // only show time diff if still waiting to be terminated
@@ -168,7 +169,7 @@ export default {
       return `locked`
     },
     value() {
-      return this.tx.value ? num.createDisplayCoin(this.tx.value) : {}
+      return (this.tx.value && this.tx.value.denom) || ""
     }
   },
   methods: {

--- a/src/components/transactions/LiStakeTransaction.vue
+++ b/src/components/transactions/LiStakeTransaction.vue
@@ -115,7 +115,7 @@ export default {
     },
     fees: {
       type: Object,
-      default: null
+      required: true
     },
     validators: {
       type: Array,

--- a/src/components/transactions/LiStakeTransaction.vue
+++ b/src/components/transactions/LiStakeTransaction.vue
@@ -1,5 +1,11 @@
 <template>
-  <LiTransaction color="#47AB6C" :time="time" :block="block" :memo="memo">
+  <LiTransaction
+    color="#47AB6C"
+    :time="time"
+    :block="block"
+    :memo="memo"
+    :fees="fees"
+  >
     <template v-if="txType === `cosmos-sdk/MsgCreateValidator`">
       <div slot="caption">
         Create validator
@@ -12,14 +18,6 @@
           {{ moniker(tx.validator_address) }}
         </router-link>
       </div>
-      <div slot="fees">
-        Network Fee:&nbsp;<b>{{ convertedFees ? convertedFees.amount : 0 }}</b>
-        <span>
-          {{
-            convertedFees ? convertedFees.denom : num.viewDenom(bondingDenom)
-          }}
-        </span>
-      </div>
     </template>
     <template v-else-if="txType === `cosmos-sdk/MsgEditValidator`">
       <div slot="caption">
@@ -30,14 +28,6 @@
         <router-link :to="`${url}/${tx.validator_address}`">
           {{ moniker(tx.validator_address) }}
         </router-link>
-      </div>
-      <div slot="fees">
-        Network Fee:&nbsp;<b>{{ convertedFees ? convertedFees.amount : 0 }}</b>
-        <span>
-          {{
-            convertedFees ? convertedFees.denom : num.viewDenom(bondingDenom)
-          }}
-        </span>
       </div>
     </template>
     <template v-else-if="txType === `cosmos-sdk/MsgDelegate`">
@@ -51,14 +41,6 @@
         <router-link :to="`${url}/${tx.validator_address}`">
           {{ moniker(tx.validator_address) }}
         </router-link>
-      </div>
-      <div slot="fees">
-        Network Fee:&nbsp;<b>{{ convertedFees ? convertedFees.amount : 0 }}</b>
-        <span>
-          {{
-            convertedFees ? convertedFees.denom : num.viewDenom(bondingDenom)
-          }}
-        </span>
       </div>
     </template>
     <template v-else-if="txType === `cosmos-sdk/MsgUndelegate`">
@@ -80,14 +62,6 @@
           {{ moniker(tx.validator_address) }}
         </router-link>
       </div>
-      <div slot="fees">
-        Network Fee:&nbsp;<b>{{ convertedFees ? convertedFees.amount : 0 }}</b>
-        <span>
-          {{
-            convertedFees ? convertedFees.denom : num.viewDenom(bondingDenom)
-          }}
-        </span>
-      </div>
     </template>
     <template v-else-if="txType === `cosmos-sdk/MsgBeginRedelegate`">
       <div slot="caption">
@@ -107,14 +81,6 @@
           {{ moniker(tx.validator_dst_address) }}
         </router-link>
       </div>
-      <div slot="fees">
-        Network Fee:&nbsp;<b>{{ convertedFees ? convertedFees.amount : 0 }}</b>
-        <span>
-          {{
-            convertedFees ? convertedFees.denom : num.viewDenom(bondingDenom)
-          }}
-        </span>
-      </div>
     </template>
     <template v-else-if="txType === `cosmos-sdk/MsgUnjail`">
       <div slot="caption">
@@ -125,14 +91,6 @@
         <router-link :to="`${url}/${tx.address}`">
           {{ moniker(tx.address) }}
         </router-link>
-      </div>
-      <div slot="fees">
-        Network Fee:&nbsp;<b>{{ convertedFees ? convertedFees.amount : 0 }}</b>
-        <span>
-          {{
-            convertedFees ? convertedFees.denom : num.viewDenom(bondingDenom)
-          }}
-        </span>
       </div>
     </template>
   </LiTransaction>
@@ -211,9 +169,6 @@ export default {
     },
     value() {
       return this.tx.value ? num.createDisplayCoin(this.tx.value) : {}
-    },
-    convertedFees() {
-      return this.fees ? num.createDisplayCoin(this.fees) : undefined
     }
   },
   methods: {

--- a/src/components/transactions/LiTransaction.vue
+++ b/src/components/transactions/LiTransaction.vue
@@ -19,7 +19,10 @@
         </div>
       </div>
       <div class="li-tx__content__right">
-        <slot name="fees" />
+        <div>
+          Network Fee:&nbsp;<b>{{ fees.amount | toAtoms | shortDecimals }}</b>
+          <span>{{ fees.denom | viewDenom }}</span>
+        </div>
         <div class="li-tx__content__block">
           <router-link :to="{ name: `block`, params: { height: block } }">
             Block #{{ block }}&nbsp; </router-link
@@ -32,9 +35,15 @@
 
 <script>
 import moment from "moment"
+import { atoms, viewDenom, shortDecimals } from "../../scripts/num.js"
 
 export default {
   name: `li-transaction`,
+  filters: {
+    toAtoms: atoms,
+    viewDenom: viewDenom,
+    shortDecimals: shortDecimals
+  },
   props: {
     color: {
       type: String,
@@ -51,6 +60,10 @@ export default {
     memo: {
       type: String,
       default: null
+    },
+    fees: {
+      type: Object,
+      required: true
     }
   },
   computed: {

--- a/src/components/transactions/LiTransaction.vue
+++ b/src/components/transactions/LiTransaction.vue
@@ -35,14 +35,18 @@
 
 <script>
 import moment from "moment"
-import { atoms as toAtoms, viewDenom, shortDecimals } from "../../scripts/num.js"
+import {
+  atoms as toAtoms,
+  viewDenom,
+  shortDecimals
+} from "../../scripts/num.js"
 
 export default {
   name: `li-transaction`,
   filters: {
     toAtoms,
     viewDenom,
-    shortDecimals,
+    shortDecimals
   },
   props: {
     color: {

--- a/src/components/transactions/LiTransaction.vue
+++ b/src/components/transactions/LiTransaction.vue
@@ -35,14 +35,14 @@
 
 <script>
 import moment from "moment"
-import { atoms, viewDenom, shortDecimals } from "../../scripts/num.js"
+import { atoms as toAtoms, viewDenom, shortDecimals } from "../../scripts/num.js"
 
 export default {
   name: `li-transaction`,
   filters: {
-    toAtoms: atoms,
-    viewDenom: viewDenom,
-    shortDecimals: shortDecimals
+    toAtoms,
+    viewDenom,
+    shortDecimals,
   },
   props: {
     color: {

--- a/test/unit/specs/components/transactions/LiAnyTransaction.spec.js
+++ b/test/unit/specs/components/transactions/LiAnyTransaction.spec.js
@@ -61,4 +61,45 @@ describe(`LiAnyTransaction`, () => {
     })
     expect(wrapper.vm.$el).toMatchSnapshot()
   })
+
+  it(`returns default fee object when no fee present`, () => {
+    const propsNoFee = {
+      bondingDenom: "atom",
+      transaction: {
+        tx: {
+          value: {
+            fee: undefined
+          }
+        }
+      }
+    }
+    expect(LiAnyTransaction.computed.fees.call(propsNoFee)).toEqual({
+      amount: "0",
+      denom: "atom"
+    })
+  })
+
+  it(`returns correct fee object`, () => {
+    const propswithFee = {
+      bondingDenom: "othertype",
+      transaction: {
+        tx: {
+          value: {
+            fee: {
+              amount: [
+                {
+                  amount: "123",
+                  denom: "atom"
+                }
+              ]
+            }
+          }
+        }
+      }
+    }
+    expect(LiAnyTransaction.computed.fees.call(propswithFee)).toEqual({
+      amount: "123",
+      denom: "atom"
+    })
+  })
 })

--- a/test/unit/specs/components/transactions/LiBankTransaction.spec.js
+++ b/test/unit/specs/components/transactions/LiBankTransaction.spec.js
@@ -58,7 +58,10 @@ describe(`LiBankTransaction`, () => {
     wrapper.setProps({
       tx: bankTxs[2].tx.value.msg[0].value,
       address: `A`,
-      fees: null
+      fees: {
+        amount: "0",
+        denom: ""
+      }
     })
     expect(wrapper.vm.sentSelf).toBe(true)
     expect(wrapper.vm.$el).toMatchSnapshot()

--- a/test/unit/specs/components/transactions/LiDistributionTransaction.spec.js
+++ b/test/unit/specs/components/transactions/LiDistributionTransaction.spec.js
@@ -58,7 +58,10 @@ describe(`LiDistributionTransaction`, () => {
     wrapper.setProps({
       tx: distributionTxs[0].tx.value.msg[0].value,
       txType: `cosmos-sdk/MsgWithdrawDelegationReward`,
-      fees: null
+      fees: {
+        amount: "0",
+        denom: ""
+      }
     })
     expect(wrapper.vm.$el).toMatchSnapshot()
   })

--- a/test/unit/specs/components/transactions/LiStakeTransaction.spec.js
+++ b/test/unit/specs/components/transactions/LiStakeTransaction.spec.js
@@ -125,7 +125,10 @@ describe(`LiStakeTransaction`, () => {
 
     it(`without fees`, () => {
       wrapper.setProps({
-        fees: null
+        fees: {
+          amount: "0",
+          denom: ""
+        }
       })
       expect(wrapper.vm.$el).toMatchSnapshot()
     })
@@ -133,7 +136,6 @@ describe(`LiStakeTransaction`, () => {
     it(`should show unbonding delegations as ended`, () => {
       wrapper.setProps({ unbondingTime: Date.now() - 1000 })
       expect(wrapper.vm.$el).toMatchSnapshot()
-      expect(wrapper.text()).toContain(`0.003`)
     })
 
     it(`should default to ended if no unbonding delegation is present`, () => {
@@ -155,12 +157,14 @@ describe(`LiStakeTransaction`, () => {
 
     it(`with fees`, () => {
       expect(wrapper.vm.$el).toMatchSnapshot()
-      expect(wrapper.text()).toContain(`0.003`)
     })
 
     it(`without fees`, () => {
       wrapper.setProps({
-        fees: null
+        fees: {
+          amount: "0",
+          denom: ""
+        }
       })
 
       expect(wrapper.vm.$el).toMatchSnapshot()

--- a/test/unit/specs/components/transactions/LiTransaction.spec.js
+++ b/test/unit/specs/components/transactions/LiTransaction.spec.js
@@ -36,6 +36,24 @@ describe(`LiTransaction`, () => {
     ).toEqual(`00:00:42`)
   })
 
+  it(`should show a network fee`, () => {
+    expect(wrapper.text()).toContain(`0.003`)
+    expect(wrapper.vm.$el).toMatchSnapshot()
+  })
+
+  it(`should show a network fee of 0`, () => {
+    wrapper.setProps({
+      fees: {
+        amount: "0",
+        denom: "uatom"
+      }
+    })
+    // Non breaking space present before fee value
+    // eslint-disable-next-line no-irregular-whitespace
+    expect(wrapper.text()).toContain(`Network Fee: 0 ATOM`)
+    expect(wrapper.vm.$el).toMatchSnapshot()
+  })
+
   it(`Should print the datetime if we are in a different day`, () => {
     expect(
       LiTransaction.computed.date({

--- a/test/unit/specs/components/transactions/LiTransaction.spec.js
+++ b/test/unit/specs/components/transactions/LiTransaction.spec.js
@@ -7,7 +7,11 @@ describe(`LiTransaction`, () => {
     color: `#FFFFFF`,
     time: new Date(Date.now()).toISOString(),
     block: 500,
-    memo: `TESTING (Sent via Lunie)`
+    memo: `TESTING (Sent via Lunie)`,
+    fees: {
+      amount: `3421`,
+      denom: `uatom`
+    }
   }
   const day = 86400000
 

--- a/test/unit/specs/components/transactions/__snapshots__/LiBankTransaction.spec.js.snap
+++ b/test/unit/specs/components/transactions/__snapshots__/LiBankTransaction.spec.js.snap
@@ -24,18 +24,6 @@ exports[`LiBankTransaction should show a bank transaction without fees 1`] = `
         To yourself!
       
   </span>
-   
-  <div>
-    
-      Network Fee: 
-    <b>
-      0
-    </b>
-     
-    <span>
-      ATOM
-    </span>
-  </div>
 </litransaction-stub>
 `;
 
@@ -43,6 +31,7 @@ exports[`LiBankTransaction should show bank transaction when user hasn't signed 
 <litransaction-stub
   block="500"
   color="#ED553B"
+  fees="[object Object]"
   memo="TESTING (Sent via Lunie)"
   time="1970-01-01T00:00:42.000Z"
 >
@@ -70,18 +59,6 @@ exports[`LiBankTransaction should show bank transaction when user hasn't signed 
       address="B"
     />
   </span>
-   
-  <div>
-    
-      Network Fee: 
-    <b>
-      0.003
-    </b>
-     
-    <span>
-      ATOM
-    </span>
-  </div>
 </litransaction-stub>
 `;
 
@@ -89,6 +66,7 @@ exports[`LiBankTransaction should show incoming transactions 1`] = `
 <litransaction-stub
   block="500"
   color="#ED553B"
+  fees="[object Object]"
   memo="TESTING (Sent via Lunie)"
   time="1970-01-01T00:00:42.000Z"
 >
@@ -111,18 +89,6 @@ exports[`LiBankTransaction should show incoming transactions 1`] = `
       address="A"
     />
   </span>
-   
-  <div>
-    
-      Network Fee: 
-    <b>
-      0.003
-    </b>
-     
-    <span>
-      ATOM
-    </span>
-  </div>
 </litransaction-stub>
 `;
 
@@ -130,6 +96,7 @@ exports[`LiBankTransaction should show outgoing transactions 1`] = `
 <litransaction-stub
   block="500"
   color="#ED553B"
+  fees="[object Object]"
   memo="TESTING (Sent via Lunie)"
   time="1970-01-01T00:00:42.000Z"
 >
@@ -152,18 +119,6 @@ exports[`LiBankTransaction should show outgoing transactions 1`] = `
       address="A"
     />
   </span>
-   
-  <div>
-    
-      Network Fee: 
-    <b>
-      0.003
-    </b>
-     
-    <span>
-      ATOM
-    </span>
-  </div>
 </litransaction-stub>
 `;
 
@@ -171,6 +126,7 @@ exports[`LiBankTransaction should show outgoing transactions send to herself 1`]
 <litransaction-stub
   block="500"
   color="#ED553B"
+  fees="[object Object]"
   memo="TESTING (Sent via Lunie)"
   time="1970-01-01T00:00:42.000Z"
 >
@@ -191,17 +147,5 @@ exports[`LiBankTransaction should show outgoing transactions send to herself 1`]
         To yourself!
       
   </span>
-   
-  <div>
-    
-      Network Fee: 
-    <b>
-      0.003
-    </b>
-     
-    <span>
-      ATOM
-    </span>
-  </div>
 </litransaction-stub>
 `;

--- a/test/unit/specs/components/transactions/__snapshots__/LiBankTransaction.spec.js.snap
+++ b/test/unit/specs/components/transactions/__snapshots__/LiBankTransaction.spec.js.snap
@@ -4,6 +4,7 @@ exports[`LiBankTransaction should show a bank transaction without fees 1`] = `
 <litransaction-stub
   block="500"
   color="#ED553B"
+  fees="[object Object]"
   memo="TESTING (Sent via Lunie)"
   time="1970-01-01T00:00:42.000Z"
 >

--- a/test/unit/specs/components/transactions/__snapshots__/LiDistributionTransaction.spec.js.snap
+++ b/test/unit/specs/components/transactions/__snapshots__/LiDistributionTransaction.spec.js.snap
@@ -24,6 +24,7 @@ exports[`LiDistributionTransaction transaction without fees 1`] = `
 <litransaction-stub
   block="500"
   color="#F2B134"
+  fees="[object Object]"
   memo="TESTING (Sent via Lunie)"
   time="1970-01-01T00:00:42.000Z"
 >

--- a/test/unit/specs/components/transactions/__snapshots__/LiDistributionTransaction.spec.js.snap
+++ b/test/unit/specs/components/transactions/__snapshots__/LiDistributionTransaction.spec.js.snap
@@ -4,6 +4,7 @@ exports[`LiDistributionTransaction set withdraw address 1`] = `
 <litransaction-stub
   block="500"
   color="#F2B134"
+  fees="[object Object]"
   memo="TESTING (Sent via Lunie)"
   time="1970-01-01T00:00:42.000Z"
 >
@@ -15,20 +16,6 @@ exports[`LiDistributionTransaction set withdraw address 1`] = `
    
   <div>
     To cosmos18ymm350peujvq2xy9ymyqj4v34ekvnk3wydrs3
-  </div>
-   
-  <div>
-    
-      Network Fee: 
-    <b>
-      0.003
-    </b>
-     
-    <span>
-      
-        ATOM
-      
-    </span>
   </div>
 </litransaction-stub>
 `;
@@ -57,20 +44,6 @@ exports[`LiDistributionTransaction transaction without fees 1`] = `
       
     </router-link-stub>
   </div>
-   
-  <div>
-    
-      Network Fee: 
-    <b>
-      0
-    </b>
-     
-    <span>
-      
-        ATOM
-      
-    </span>
-  </div>
 </litransaction-stub>
 `;
 
@@ -78,6 +51,7 @@ exports[`LiDistributionTransaction withdraw delegation rewards 1`] = `
 <litransaction-stub
   block="500"
   color="#F2B134"
+  fees="[object Object]"
   memo="TESTING (Sent via Lunie)"
   time="1970-01-01T00:00:42.000Z"
 >
@@ -98,20 +72,6 @@ exports[`LiDistributionTransaction withdraw delegation rewards 1`] = `
       
     </router-link-stub>
   </div>
-   
-  <div>
-    
-      Network Fee: 
-    <b>
-      0.003
-    </b>
-     
-    <span>
-      
-        ATOM
-      
-    </span>
-  </div>
 </litransaction-stub>
 `;
 
@@ -119,6 +79,7 @@ exports[`LiDistributionTransaction withdraw validator commission 1`] = `
 <litransaction-stub
   block="500"
   color="#F2B134"
+  fees="[object Object]"
   memo="TESTING (Sent via Lunie)"
   time="1970-01-01T00:00:42.000Z"
 >
@@ -138,20 +99,6 @@ exports[`LiDistributionTransaction withdraw validator commission 1`] = `
         cosmos18ymm350peujvq2xy9ymyqj4v34ekvnk3wydrs3
       
     </router-link-stub>
-  </div>
-   
-  <div>
-    
-      Network Fee: 
-    <b>
-      0.003
-    </b>
-     
-    <span>
-      
-        ATOM
-      
-    </span>
   </div>
 </litransaction-stub>
 `;

--- a/test/unit/specs/components/transactions/__snapshots__/LiGovTransaction.spec.js.snap
+++ b/test/unit/specs/components/transactions/__snapshots__/LiGovTransaction.spec.js.snap
@@ -4,6 +4,7 @@ exports[`LiGovTransaction deposits 1`] = `
 <litransaction-stub
   block="500"
   color="#15CFCC"
+  fees="[object Object]"
   memo="TESTING (Sent via Lunie)"
   time="1970-01-01T00:00:42.000Z"
 >
@@ -32,20 +33,6 @@ exports[`LiGovTransaction deposits 1`] = `
       
     </router-link-stub>
   </div>
-   
-  <div>
-    
-      Network Fee: 
-    <b>
-      0.003
-    </b>
-     
-    <span>
-      
-        ATOM
-      
-    </span>
-  </div>
 </litransaction-stub>
 `;
 
@@ -53,6 +40,7 @@ exports[`LiGovTransaction proposals 1`] = `
 <litransaction-stub
   block="500"
   color="#15CFCC"
+  fees="[object Object]"
   memo="TESTING (Sent via Lunie)"
   time="1970-01-01T00:00:42.000Z"
 >
@@ -76,20 +64,6 @@ exports[`LiGovTransaction proposals 1`] = `
       Test Proposal
     </i>
   </div>
-   
-  <div>
-    
-      Network Fee: 
-    <b>
-      0.003
-    </b>
-     
-    <span>
-      
-        ATOM
-      
-    </span>
-  </div>
 </litransaction-stub>
 `;
 
@@ -97,6 +71,7 @@ exports[`LiGovTransaction votes 1`] = `
 <litransaction-stub
   block="500"
   color="#15CFCC"
+  fees="[object Object]"
   memo="TESTING (Sent via Lunie)"
   time="1970-01-01T00:00:42.000Z"
 >
@@ -115,20 +90,6 @@ exports[`LiGovTransaction votes 1`] = `
         Proposal #1
       
     </router-link-stub>
-  </div>
-   
-  <div>
-    
-      Network Fee: 
-    <b>
-      0.003
-    </b>
-     
-    <span>
-      
-        ATOM
-      
-    </span>
   </div>
 </litransaction-stub>
 `;

--- a/test/unit/specs/components/transactions/__snapshots__/LiStakeTransaction.spec.js.snap
+++ b/test/unit/specs/components/transactions/__snapshots__/LiStakeTransaction.spec.js.snap
@@ -251,6 +251,7 @@ exports[`LiStakeTransaction redelegations without fees 1`] = `
 <litransaction-stub
   block="500"
   color="#47AB6C"
+  fees="[object Object]"
   memo="TESTING (Sent via Lunie)"
   time="1970-01-01T00:00:42.000Z"
 >
@@ -424,6 +425,7 @@ exports[`LiStakeTransaction unbonding delegations without fees 1`] = `
 <litransaction-stub
   block="500"
   color="#47AB6C"
+  fees="[object Object]"
   memo="TESTING (Sent via Lunie)"
   time="1970-01-01T00:00:42.000Z"
 >

--- a/test/unit/specs/components/transactions/__snapshots__/LiStakeTransaction.spec.js.snap
+++ b/test/unit/specs/components/transactions/__snapshots__/LiStakeTransaction.spec.js.snap
@@ -4,6 +4,7 @@ exports[`LiStakeTransaction create validator with fees 1`] = `
 <litransaction-stub
   block="500"
   color="#47AB6C"
+  fees="[object Object]"
   memo="TESTING (Sent via Lunie)"
   time="1970-01-01T00:00:42.000Z"
 >
@@ -31,20 +32,6 @@ exports[`LiStakeTransaction create validator with fees 1`] = `
         cosmosvaloper1qecshyc40kshszkwrtscgmsdd8tz3n4hrj9yf2
       
     </router-link-stub>
-  </div>
-   
-  <div>
-    
-      Network Fee: 
-    <b>
-      0.003
-    </b>
-     
-    <span>
-      
-        ATOM
-      
-    </span>
   </div>
 </litransaction-stub>
 `;
@@ -81,20 +68,6 @@ exports[`LiStakeTransaction create validator without fees 1`] = `
       
     </router-link-stub>
   </div>
-   
-  <div>
-    
-      Network Fee: 
-    <b>
-      0
-    </b>
-     
-    <span>
-      
-        ATOM
-      
-    </span>
-  </div>
 </litransaction-stub>
 `;
 
@@ -102,6 +75,7 @@ exports[`LiStakeTransaction delegations with fees 1`] = `
 <litransaction-stub
   block="500"
   color="#47AB6C"
+  fees="[object Object]"
   memo="TESTING (Sent via Lunie)"
   time="1970-01-01T00:00:42.000Z"
 >
@@ -129,20 +103,6 @@ exports[`LiStakeTransaction delegations with fees 1`] = `
         mr_mounty
       
     </router-link-stub>
-  </div>
-   
-  <div>
-    
-      Network Fee: 
-    <b>
-      0.003
-    </b>
-     
-    <span>
-      
-        ATOM
-      
-    </span>
   </div>
 </litransaction-stub>
 `;
@@ -179,20 +139,6 @@ exports[`LiStakeTransaction delegations without fees 1`] = `
       
     </router-link-stub>
   </div>
-   
-  <div>
-    
-      Network Fee: 
-    <b>
-      0
-    </b>
-     
-    <span>
-      
-        ATOM
-      
-    </span>
-  </div>
 </litransaction-stub>
 `;
 
@@ -200,6 +146,7 @@ exports[`LiStakeTransaction edit validator with fees 1`] = `
 <litransaction-stub
   block="500"
   color="#47AB6C"
+  fees="[object Object]"
   memo="TESTING (Sent via Lunie)"
   time="1970-01-01T00:00:42.000Z"
 >
@@ -220,20 +167,6 @@ exports[`LiStakeTransaction edit validator with fees 1`] = `
         cosmosvaloper1qecshyc40kshszkwrtscgmsdd8tz3n4hrj9yf2
       
     </router-link-stub>
-  </div>
-   
-  <div>
-    
-      Network Fee: 
-    <b>
-      0.003
-    </b>
-     
-    <span>
-      
-        ATOM
-      
-    </span>
   </div>
 </litransaction-stub>
 `;
@@ -263,20 +196,6 @@ exports[`LiStakeTransaction edit validator without fees 1`] = `
       
     </router-link-stub>
   </div>
-   
-  <div>
-    
-      Network Fee: 
-    <b>
-      0
-    </b>
-     
-    <span>
-      
-        ATOM
-      
-    </span>
-  </div>
 </litransaction-stub>
 `;
 
@@ -284,6 +203,7 @@ exports[`LiStakeTransaction redelegations with fees 1`] = `
 <litransaction-stub
   block="500"
   color="#47AB6C"
+  fees="[object Object]"
   memo="TESTING (Sent via Lunie)"
   time="1970-01-01T00:00:42.000Z"
 >
@@ -323,20 +243,6 @@ exports[`LiStakeTransaction redelegations with fees 1`] = `
         good_greg
       
     </router-link-stub>
-  </div>
-   
-  <div>
-    
-      Network Fee: 
-    <b>
-      0.003
-    </b>
-     
-    <span>
-      
-        ATOM
-      
-    </span>
   </div>
 </litransaction-stub>
 `;
@@ -385,20 +291,6 @@ exports[`LiStakeTransaction redelegations without fees 1`] = `
       
     </router-link-stub>
   </div>
-   
-  <div>
-    
-      Network Fee: 
-    <b>
-      0
-    </b>
-     
-    <span>
-      
-        ATOM
-      
-    </span>
-  </div>
 </litransaction-stub>
 `;
 
@@ -406,6 +298,7 @@ exports[`LiStakeTransaction unbonding delegations should default to ended if no 
 <litransaction-stub
   block="500"
   color="#47AB6C"
+  fees="[object Object]"
   memo="TESTING (Sent via Lunie)"
   time="1970-01-01T00:00:42.000Z"
 >
@@ -437,20 +330,6 @@ exports[`LiStakeTransaction unbonding delegations should default to ended if no 
         mr_mounty
       
     </router-link-stub>
-  </div>
-   
-  <div>
-    
-      Network Fee: 
-    <b>
-      0.003
-    </b>
-     
-    <span>
-      
-        ATOM
-      
-    </span>
   </div>
 </litransaction-stub>
 `;
@@ -459,6 +338,7 @@ exports[`LiStakeTransaction unbonding delegations should show unbonding delegati
 <litransaction-stub
   block="500"
   color="#47AB6C"
+  fees="[object Object]"
   memo="TESTING (Sent via Lunie)"
   time="1970-01-01T00:00:42.000Z"
 >
@@ -491,20 +371,6 @@ exports[`LiStakeTransaction unbonding delegations should show unbonding delegati
       
     </router-link-stub>
   </div>
-   
-  <div>
-    
-      Network Fee: 
-    <b>
-      0.003
-    </b>
-     
-    <span>
-      
-        ATOM
-      
-    </span>
-  </div>
 </litransaction-stub>
 `;
 
@@ -512,6 +378,7 @@ exports[`LiStakeTransaction unbonding delegations with fees 1`] = `
 <litransaction-stub
   block="500"
   color="#47AB6C"
+  fees="[object Object]"
   memo="TESTING (Sent via Lunie)"
   time="1970-01-01T00:00:42.000Z"
 >
@@ -549,20 +416,6 @@ exports[`LiStakeTransaction unbonding delegations with fees 1`] = `
         mr_mounty
       
     </router-link-stub>
-  </div>
-   
-  <div>
-    
-      Network Fee: 
-    <b>
-      0.003
-    </b>
-     
-    <span>
-      
-        ATOM
-      
-    </span>
   </div>
 </litransaction-stub>
 `;
@@ -603,20 +456,6 @@ exports[`LiStakeTransaction unbonding delegations without fees 1`] = `
       
     </router-link-stub>
   </div>
-   
-  <div>
-    
-      Network Fee: 
-    <b>
-      0
-    </b>
-     
-    <span>
-      
-        ATOM
-      
-    </span>
-  </div>
 </litransaction-stub>
 `;
 
@@ -624,6 +463,7 @@ exports[`LiStakeTransaction unjail with fees 1`] = `
 <litransaction-stub
   block="500"
   color="#47AB6C"
+  fees="[object Object]"
   memo="TESTING (Sent via Lunie)"
   time="1970-01-01T00:00:42.000Z"
 >
@@ -644,20 +484,6 @@ exports[`LiStakeTransaction unjail with fees 1`] = `
         cosmosvaloper1qecshyc40kshszkwrtscgmsdd8tz3n4hrj9yf2
       
     </router-link-stub>
-  </div>
-   
-  <div>
-    
-      Network Fee: 
-    <b>
-      0.003
-    </b>
-     
-    <span>
-      
-        ATOM
-      
-    </span>
   </div>
 </litransaction-stub>
 `;
@@ -686,20 +512,6 @@ exports[`LiStakeTransaction unjail without fees 1`] = `
         cosmosvaloper1qecshyc40kshszkwrtscgmsdd8tz3n4hrj9yf2
       
     </router-link-stub>
-  </div>
-   
-  <div>
-    
-      Network Fee: 
-    <b>
-      0
-    </b>
-     
-    <span>
-      
-        ATOM
-      
-    </span>
   </div>
 </litransaction-stub>
 `;

--- a/test/unit/specs/components/transactions/__snapshots__/LiTransaction.spec.js.snap
+++ b/test/unit/specs/components/transactions/__snapshots__/LiTransaction.spec.js.snap
@@ -1,5 +1,157 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`LiTransaction should show a network fee 1`] = `
+<div
+  class="li-tx"
+>
+  <div
+    class="li-tx__icon"
+  >
+    <img
+      src="~assets/images/cosmos-logo.png"
+      style="border-color: #ffffff;"
+    />
+  </div>
+   
+  <div
+    class="li-tx__content"
+  >
+    <div
+      class="li-tx__content__left"
+    >
+      <div
+        class="li-tx__content__caption"
+      >
+        <p
+          class="li-tx__content__caption__title"
+        >
+          <span>
+            Some Caption
+          </span>
+        </p>
+      </div>
+       
+      <div
+        class="li-tx__content__information"
+      >
+        <span>
+          Some Details
+        </span>
+         
+        <span>
+            - TESTING (Sent via Lunie) 
+        </span>
+      </div>
+    </div>
+     
+    <div
+      class="li-tx__content__right"
+    >
+      <div>
+        
+        Network Fee: 
+        <b>
+          0.003
+        </b>
+         
+        <span>
+          ATOM
+        </span>
+      </div>
+       
+      <div
+        class="li-tx__content__block"
+      >
+        <router-link-stub
+          to="[object Object]"
+        >
+          
+          Block #500  
+        </router-link-stub>
+        @ 00:00:42
+      
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`LiTransaction should show a network fee of 0 1`] = `
+<div
+  class="li-tx"
+>
+  <div
+    class="li-tx__icon"
+  >
+    <img
+      src="~assets/images/cosmos-logo.png"
+      style="border-color: #ffffff;"
+    />
+  </div>
+   
+  <div
+    class="li-tx__content"
+  >
+    <div
+      class="li-tx__content__left"
+    >
+      <div
+        class="li-tx__content__caption"
+      >
+        <p
+          class="li-tx__content__caption__title"
+        >
+          <span>
+            Some Caption
+          </span>
+        </p>
+      </div>
+       
+      <div
+        class="li-tx__content__information"
+      >
+        <span>
+          Some Details
+        </span>
+         
+        <span>
+            - TESTING (Sent via Lunie) 
+        </span>
+      </div>
+    </div>
+     
+    <div
+      class="li-tx__content__right"
+    >
+      <div>
+        
+        Network Fee: 
+        <b>
+          0
+        </b>
+         
+        <span>
+          ATOM
+        </span>
+      </div>
+       
+      <div
+        class="li-tx__content__block"
+      >
+        <router-link-stub
+          to="[object Object]"
+        >
+          
+          Block #500  
+        </router-link-stub>
+        @ 00:00:42
+      
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`LiTransaction should show a transaction item 1`] = `
 <div
   class="li-tx"

--- a/test/unit/specs/components/transactions/__snapshots__/LiTransaction.spec.js.snap
+++ b/test/unit/specs/components/transactions/__snapshots__/LiTransaction.spec.js.snap
@@ -47,6 +47,17 @@ exports[`LiTransaction should show a transaction item 1`] = `
     <div
       class="li-tx__content__right"
     >
+      <div>
+        
+        Network Fee: 
+        <b>
+          0.003
+        </b>
+         
+        <span>
+          ATOM
+        </span>
+      </div>
        
       <div
         class="li-tx__content__block"


### PR DESCRIPTION
Closes #ISSUE

**Description:**

Move network fee display to common location. The goal is to reduce the surface area for currency bugs.

- Remove multiple instances of network fee code that does not change.
  - Push all network fee formatting to LiTransaction
- Pass fees object to each TransactionView component
- Maintain defaults for zero network fee:
  - Amount: 0
  - Denom: bonding denom

Notes:
 - Mark fees as required by a transaction component and adjust tests
 - Since each component now passes the fees object to the LiTransaction
  component, we don't need to test for it individually.
 - We can also mark it as required, and assume it is present since the
  parent LiAnyTransaction will construct a default each time.


Thank you! 🚀

---

For contributor:

- [ ] Added changes entries. Run `yarn changelog` for a guided process.
- [ ] Reviewed `Files changed` in the github PR explorer
- [ ] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI
