### PR TITLE
colw/add warning about undelegated tokens

### DIFF
--- a/changes/colw_2504-undelegation-warning
+++ b/changes/colw_2504-undelegation-warning
@@ -1,0 +1,1 @@
+[Added] [#2619](https://github.com/cosmos/lunie/pull/2619) Warn user of pending period when undelegating tokens. @colw

--- a/src/components/staking/UndelegationModal.vue
+++ b/src/components/staking/UndelegationModal.vue
@@ -11,6 +11,13 @@
     submission-error-prefix="Undelegating failed"
     @close="clear"
   >
+    <TmFormGroup class="action-modal-form-group">
+      <span class="form-message warning">
+        Note: Undelegated tokens will become available for use after 21 days.
+        The undelegated tokens are not usable and do not produce rewards in this
+        time.
+      </span>
+    </TmFormGroup>
     <TmFormGroup
       class="action-modal-form-group"
       field-id="from"
@@ -18,9 +25,6 @@
     >
       <TmField id="from" v-model="validator.operator_address" readonly />
     </TmFormGroup>
-    <span class="form-message">
-      Note: Undelegated tokens will become available for use after 21 days.
-    </span>
     <TmFormGroup
       :error="$v.amount.$error && $v.amount.$invalid"
       class="action-modal-form-group"
@@ -163,3 +167,9 @@ export default {
   }
 }
 </script>
+
+<style scoped>
+.form-message.warning {
+  color: var(--warning);
+}
+</style>

--- a/src/components/staking/UndelegationModal.vue
+++ b/src/components/staking/UndelegationModal.vue
@@ -12,11 +12,12 @@
     @close="clear"
   >
     <TmFormGroup class="action-modal-form-group">
-      <span class="form-message warning">
-        Note: Undelegated tokens will become available for use after 21 days.
-        The undelegated tokens are not usable and do not produce rewards in this
-        time.
-      </span>
+      <div class="form-message notice">
+        <span>
+          Undelegations take 21 days to complete and cannot be undone. Please
+          make sure you understand the rules of delegation.</span
+        >
+      </div>
     </TmFormGroup>
     <TmFormGroup
       class="action-modal-form-group"
@@ -169,7 +170,12 @@ export default {
 </script>
 
 <style scoped>
-.form-message.warning {
-  color: var(--warning);
+.form-message.notice {
+  border-radius: 2px;
+  background-color: #1c223e;
+  margin: 18px 0;
+  padding: 11px 16px;
+  font-size: var(--m);
+  font-style: normal;
 }
 </style>

--- a/src/components/staking/UndelegationModal.vue
+++ b/src/components/staking/UndelegationModal.vue
@@ -18,6 +18,9 @@
     >
       <TmField id="from" v-model="validator.operator_address" readonly />
     </TmFormGroup>
+    <span class="form-message">
+      Note: Undelegated tokens will become available for use after 21 days.
+    </span>
     <TmFormGroup
       :error="$v.amount.$error && $v.amount.$invalid"
       class="action-modal-form-group"

--- a/test/unit/specs/components/staking/__snapshots__/UndelegationModal.spec.js.snap
+++ b/test/unit/specs/components/staking/__snapshots__/UndelegationModal.spec.js.snap
@@ -25,6 +25,14 @@ exports[`UndelegationModal should display undelegation modal form 1`] = `
     />
   </tmformgroup-stub>
    
+  <span
+    class="form-message"
+  >
+    
+    Note: Undelegated tokens will become available for use after 21 days.
+  
+  </span>
+   
   <tmformgroup-stub
     class="action-modal-form-group"
     fieldid="amount"

--- a/test/unit/specs/components/staking/__snapshots__/UndelegationModal.spec.js.snap
+++ b/test/unit/specs/components/staking/__snapshots__/UndelegationModal.spec.js.snap
@@ -14,6 +14,20 @@ exports[`UndelegationModal should display undelegation modal form 1`] = `
 >
   <tmformgroup-stub
     class="action-modal-form-group"
+  >
+    <span
+      class="form-message warning"
+    >
+      
+      Note: Undelegated tokens will become available for use after 21 days.
+      The undelegated tokens are not usable and do not produce rewards in this
+      time.
+    
+    </span>
+  </tmformgroup-stub>
+   
+  <tmformgroup-stub
+    class="action-modal-form-group"
     fieldid="from"
     fieldlabel="From"
   >
@@ -24,14 +38,6 @@ exports[`UndelegationModal should display undelegation modal form 1`] = `
       value="cosmosvaladdr15ky9du8a2wlstz6fpx3p4mqpjyrm5ctplpn3au"
     />
   </tmformgroup-stub>
-   
-  <span
-    class="form-message"
-  >
-    
-    Note: Undelegated tokens will become available for use after 21 days.
-  
-  </span>
    
   <tmformgroup-stub
     class="action-modal-form-group"

--- a/test/unit/specs/components/staking/__snapshots__/UndelegationModal.spec.js.snap
+++ b/test/unit/specs/components/staking/__snapshots__/UndelegationModal.spec.js.snap
@@ -15,15 +15,15 @@ exports[`UndelegationModal should display undelegation modal form 1`] = `
   <tmformgroup-stub
     class="action-modal-form-group"
   >
-    <span
-      class="form-message warning"
+    <div
+      class="form-message notice"
     >
-      
-      Note: Undelegated tokens will become available for use after 21 days.
-      The undelegated tokens are not usable and do not produce rewards in this
-      time.
-    
-    </span>
+      <span>
+        
+        Undelegations take 21 days to complete and cannot be undone. Please
+        make sure you understand the rules of delegation.
+      </span>
+    </div>
   </tmformgroup-stub>
    
   <tmformgroup-stub


### PR DESCRIPTION
Closes #2504 

**Description:**

Add warning message to undelegation action modal, warning users of the 21 day pending period.

<img width="589" alt="Screenshot 2019-05-18 at 00 01 03" src="https://user-images.githubusercontent.com/360865/57958487-4b316500-7900-11e9-9fdb-976b30168b8c.png">

- Thoughts?
- Same for redelegating?
- We also need to warn about penalties too?

Thank you! 🚀

---

For contributor:

- [ ] Added changes entries. Run `yarn changelog` for a guided process.
- [ ] Reviewed `Files changed` in the github PR explorer
- [ ] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI
