### PR TITLE
automatic release created for v1.0.0-beta.72

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [1.0.0-beta.72] - 2019-05-19
+
+### Fixed
+
+- [#2628](https://github.com/cosmos/lunie/pull/2628) Fix issue with productive bundling in downstream cosmos-js library @faboweb
+
 ## [1.0.0-beta.71] - 2019-05-18
 
 ### Fixed

--- a/changes/fabo_fix-bundling-error
+++ b/changes/fabo_fix-bundling-error
@@ -1,1 +1,0 @@
-[Fixed] [#2628](https://github.com/cosmos/lunie/pull/2628) Fix issue with productive bundling in downstream cosmos-js library @faboweb

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lunie",
   "productName": "lunie",
-  "version": "1.0.0-beta.71",
+  "version": "1.0.0-beta.72",
   "description": "Lunie is the user interface for the Cosmos Hub.",
   "author": "Lunie International Software Systems Inc. <hello@lunie.io>",
   "license": "Apache-2.0",


### PR DESCRIPTION
### Fixed

- [#2628](https://github.com/cosmos/lunie/pull/2628) Fix issue with productive bundling in downstream cosmos-js library @faboweb
