### PR TITLE
WIP colw/Enter key to progress modal form

### DIFF
--- a/changes/colw_2234-enter-submits-action-modal
+++ b/changes/colw_2234-enter-submits-action-modal
@@ -1,0 +1,1 @@
+[Fixed] [#2234](https://github.com/cosmos/lunie/issues/2234) Enter key progresses action modal through submission @colw

--- a/src/components/common/ActionModal.vue
+++ b/src/components/common/ActionModal.vue
@@ -1,6 +1,12 @@
 <template>
   <transition v-if="show" name="slide-fade">
-    <div v-focus-last class="action-modal" tabindex="0" @keyup.esc="close">
+    <div
+      v-focus-last
+      class="action-modal"
+      tabindex="0"
+      @keyup.esc="close"
+      @keyup.enter.prevent="validateChangeStep"
+    >
       <div class="action-modal-header">
         <span class="action-modal-title">
           {{ requiresSignIn ? `Sign in required` : title }}
@@ -30,6 +36,7 @@
         >
           <span class="input-suffix">{{ viewDenom(bondDenom) }}</span>
           <TmField
+            v-focus
             id="gas-price"
             v-model="gasPrice"
             step="0.000000001"


### PR DESCRIPTION
Closes #2234 

**Description:**

Pressing enter key will progress Transaction Modal towards submission.


Thank you! 🚀

---

For contributor:

- [x] Added changes entries. Run `yarn changelog` for a guided process.
- [x] Reviewed `Files changed` in the github PR explorer
- [ ] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI
