### PR TITLE
Fabo/fix out of gas

### DIFF
--- a/changes/fabo_fix-out-of-gas
+++ b/changes/fabo_fix-out-of-gas
@@ -1,0 +1,1 @@
+[Changed] [#2642](https://github.com/cosmos/lunie/pull/2642) We now increase the gas simulated by 1.2 as recommended by the SDK team to avoid out of gas exceptions @faboweb

--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "webpack-dev-server": "3.2.1"
   },
   "dependencies": {
-    "@lunie/cosmos-js": "0.0.14",
+    "@lunie/cosmos-js": "0.0.15",
     "@sentry/browser": "5.0.3",
     "autosize": "4.0.2",
     "axios": "0.18.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -951,10 +951,10 @@
     "@types/istanbul-reports" "^1.1.1"
     "@types/yargs" "^12.0.9"
 
-"@lunie/cosmos-js@0.0.14":
-  version "0.0.14"
-  resolved "https://registry.yarnpkg.com/@lunie/cosmos-js/-/cosmos-js-0.0.14.tgz#004402dcfebba832c8bbd2b28361fea1bc979e25"
-  integrity sha512-pHd1PQ8Th1+/cIl66oC+hsrDg4zQvxhZ3b+1rLtqzvUZ/2ZwaxYevzof5l7Y76ZtOgGahYV7cDVtScIOikKZQQ==
+"@lunie/cosmos-js@0.0.15":
+  version "0.0.15"
+  resolved "https://registry.yarnpkg.com/@lunie/cosmos-js/-/cosmos-js-0.0.15.tgz#bfd81e41554e4c539a888e172f5fa71e206f8132"
+  integrity sha512-8Y0Yad1oujCysB0P99cglcUA4920gj1Q/jczbLxUY7k/lrwftTysmm15Fz8lYOxu0Rifc8BfUoMUODClY+ErNg==
   dependencies:
     jest "^24.7.1"
 


### PR DESCRIPTION
We now increase the gas simulated by 1.2 as recommended by the SDK team to avoid out of gas exceptions

**Description:**

<!-- Briefly describe what you're adding or fixing with this PR -->

Thank you! 🚀

---

For contributor:

- [ ] Added changes entries. Run `yarn changelog` for a guided process.
- [ ] Reviewed `Files changed` in the github PR explorer
- [ ] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI
