### PR TITLE
colw/2657 display full transaction atoms

### DIFF
--- a/changes/colw_2657-display-full-transaction-atoms
+++ b/changes/colw_2657-display-full-transaction-atoms
@@ -1,0 +1,1 @@
+[Fixed] [#2657](https://github.com/cosmos/lunie/issues/2657) Display full transaction value and network fee, do not truncate. @colw

--- a/src/components/transactions/LiBankTransaction.vue
+++ b/src/components/transactions/LiBankTransaction.vue
@@ -8,7 +8,7 @@
   >
     <template v-if="address === ''">
       <div slot="caption">
-        Sent <b>{{ txAmount | toAtoms | shortDecimals }}</b>
+        Sent <b>{{ txAmount | toAtoms | prettyLong }}</b>
         <span>{{ txDenom | viewDenom }}</span>
       </div>
       <span slot="details">
@@ -20,7 +20,7 @@
     </template>
     <template v-else-if="sent">
       <div slot="caption">
-        Sent <b>{{ txAmount | toAtoms | shortDecimals }}</b>
+        Sent <b>{{ txAmount | toAtoms | prettyLong }}</b>
         <span>{{ txDenom | viewDenom }}</span>
       </div>
       <span slot="details">
@@ -34,7 +34,7 @@
     </template>
     <template v-else>
       <div slot="caption">
-        Received <b>{{ txAmount | toAtoms | shortDecimals }}</b>
+        Received <b>{{ txAmount | toAtoms | prettyLong }}</b>
         <span>{{ txDenom | viewDenom }}</span>
       </div>
       <span slot="details">
@@ -47,11 +47,7 @@
 <script>
 import ShortBech32 from "common/ShortBech32"
 import LiTransaction from "./LiTransaction"
-import {
-  atoms as toAtoms,
-  viewDenom,
-  shortDecimals
-} from "../../scripts/num.js"
+import { atoms as toAtoms, viewDenom, prettyLong } from "../../scripts/num.js"
 
 export default {
   name: `li-bank-transaction`,
@@ -62,7 +58,7 @@ export default {
   filters: {
     toAtoms,
     viewDenom,
-    shortDecimals
+    prettyLong
   },
   props: {
     tx: {

--- a/src/components/transactions/LiGovTransaction.vue
+++ b/src/components/transactions/LiGovTransaction.vue
@@ -9,7 +9,7 @@
     <template v-if="txType === `cosmos-sdk/MsgSubmitProposal`">
       <div slot="caption">
         Submitted {{ tx.proposal_type.toLowerCase() }} proposal
-        <b>{{ initialDeposit.amount | toAtoms | shortDecimals }}</b>
+        <b>{{ initialDeposit.amount | toAtoms | prettyLong }}</b>
         <span>{{ initialDeposit.denom | viewDenom }}</span>
       </div>
       <div slot="details">
@@ -20,7 +20,7 @@
       <div slot="caption">
         Deposited
         <template>
-          <b>{{ deposit.amount | toAtoms | shortDecimals }}</b>
+          <b>{{ deposit.amount | toAtoms | prettyLong }}</b>
           <span>{{ deposit.denom | viewDenom }}</span>
         </template>
       </div>
@@ -45,19 +45,15 @@
 
 <script>
 import LiTransaction from "./LiTransaction"
-import {
-  atoms as toAtoms,
-  viewDenom,
-  shortDecimals
-} from "../../scripts/num.js"
+import { atoms as toAtoms, prettyLong, viewDenom } from "../../scripts/num.js"
 
 export default {
   name: `li-gov-transaction`,
   components: { LiTransaction },
   filters: {
     toAtoms,
-    viewDenom,
-    shortDecimals
+    prettyLong,
+    viewDenom
   },
   props: {
     tx: {

--- a/src/components/transactions/LiTransaction.vue
+++ b/src/components/transactions/LiTransaction.vue
@@ -20,7 +20,7 @@
       </div>
       <div class="li-tx__content__right">
         <div>
-          Network Fee:&nbsp;<b>{{ fees.amount | toAtoms | shortDecimals }}</b>
+          Network Fee:&nbsp;<b>{{ fees.amount | toAtoms }}</b>
           <span>{{ fees.denom | viewDenom }}</span>
         </div>
         <div class="li-tx__content__block">
@@ -35,18 +35,13 @@
 
 <script>
 import moment from "moment"
-import {
-  atoms as toAtoms,
-  viewDenom,
-  shortDecimals
-} from "../../scripts/num.js"
+import { atoms as toAtoms, viewDenom } from "../../scripts/num.js"
 
 export default {
   name: `li-transaction`,
   filters: {
     toAtoms,
-    viewDenom,
-    shortDecimals
+    viewDenom
   },
   props: {
     color: {

--- a/src/scripts/num.js
+++ b/src/scripts/num.js
@@ -34,6 +34,13 @@ export function pretty(number = 0) {
   }).format(Math.round(number * 100) / 100)
 }
 
+export function prettyLong(number = 0) {
+  return new Intl.NumberFormat(language, {
+    maximumFractionDigits: 20,
+    useGrouping: true
+  }).format(number)
+}
+
 // pretty print long decimals not in scientific notation
 export function prettyDecimals(number = 0) {
   let longDecimals = new Intl.NumberFormat(language, {
@@ -108,6 +115,7 @@ export default {
   fullDecimals,
   pretty,
   prettyInt,
+  prettyLong,
   percent,
   percentInt,
   prettyDecimals

--- a/test/unit/specs/components/transactions/__snapshots__/LiTransaction.spec.js.snap
+++ b/test/unit/specs/components/transactions/__snapshots__/LiTransaction.spec.js.snap
@@ -51,7 +51,7 @@ exports[`LiTransaction should show a network fee 1`] = `
         
         Network Fee: 
         <b>
-          0.003
+          0.003421
         </b>
          
         <span>
@@ -203,7 +203,7 @@ exports[`LiTransaction should show a transaction item 1`] = `
         
         Network Fee: 
         <b>
-          0.003
+          0.003421
         </b>
          
         <span>

--- a/test/unit/specs/scripts/num.spec.js
+++ b/test/unit/specs/scripts/num.spec.js
@@ -21,6 +21,10 @@ describe(`number helper`, () => {
     expect(num.percentInt(0.2612)).toBe(`26%`)
   })
 
+  it(`should format numbers showing many decimals and separator`, () => {
+    expect(num.prettyLong(1001950.123456789)).toBe(`1,001,950.123456789`)
+  })
+
   it(`should format percent with decimals`, () => {
     expect(num.percent(0.2612)).toBe(`26.12%`)
   })


### PR DESCRIPTION
Closes #2657 

**Description:**

Show full decimal amount

<img width="294" alt="Screenshot 2019-05-27 at 14 35 19" src="https://user-images.githubusercontent.com/360865/58420094-b14e8280-808c-11e9-987d-72c07a69b5eb.png">

Thank you! 🚀

---

For contributor:

- [x] Added changes entries. Run `yarn changelog` for a guided process.
- [x] Reviewed `Files changed` in the github PR explorer
- [x] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI
