### PR TITLE
Benji/2234 Allows enter key to submit ActionModal when input field is highlighted

### DIFF
--- a/src/components/common/ActionModal.vue
+++ b/src/components/common/ActionModal.vue
@@ -112,6 +112,7 @@
             v-model="password"
             type="password"
             placeholder="Password"
+            @keyup.enter.native="validateChangeStep"
           />
           <TmFormMsg
             v-if="$v.password.$error && !$v.password.required"


### PR DESCRIPTION
Closes #2234 

**Description:**

Adds functionality so that when the password input field is selected the enter button can be used to send the transaction rather than having to click Submit

Thank you! 🚀

---

For contributor:

- [ ] Added changes entries. Run `yarn changelog` for a guided process.
- [x] Reviewed `Files changed` in the github PR explorer
- [ ] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI
