### PR TITLE
Benji/2157 Create Proposal button prompts login when logged out

### DIFF
--- a/changes/Benji_2157-Create-proposal-btn-triggers-signin
+++ b/changes/Benji_2157-Create-proposal-btn-triggers-signin
@@ -1,0 +1,2 @@
+[Changed] [#2157](https://github.com/cosmos/lunie/issues/2157) Don't hide the create proposal button if signed out @thebkr7
+[Changed] [#2684](https://github.com/cosmos/lunie/pull/2684) Don't hide the error on action modals after a timeout @faboweb

--- a/src/components/common/ActionModal.vue
+++ b/src/components/common/ActionModal.vue
@@ -389,10 +389,6 @@ export default {
       } catch ({ message }) {
         this.submissionError = `${this.submissionErrorPrefix}: ${message}.`
         track(`event`, `failed-submit`, this.title, message)
-
-        setTimeout(() => {
-          this.submissionError = null
-        }, 5000)
       }
     },
     async connectLedger() {

--- a/src/components/governance/PageGovernance.vue
+++ b/src/components/governance/PageGovernance.vue
@@ -1,22 +1,12 @@
 <template>
   <TmPage :tabs="tabs" class="governance" data-title="Governance">
     <TmBtn
-      v-if="session.signedIn"
       id="propose-btn"
       slot="header-buttons"
       :disabled="!connected"
       :value="connected ? 'Create Proposal' : 'Connecting...'"
       color="primary"
       @click.native="onPropose"
-    />
-    <TmBtn
-      v-else-if="!session.signedIn"
-      id="propose-btn"
-      slot="header-buttons"
-      :disabled="!connected"
-      :value="connected ? 'Create Proposal' : 'Connecting...'"
-      color="primary"
-      @click.native="onProposeLoggedOut"
     />
     <ModalPropose ref="modalPropose" :denom="depositDenom" />
     <router-view />
@@ -59,9 +49,6 @@ export default {
   methods: {
     onPropose() {
       this.$refs.modalPropose.open()
-    },
-    onProposeLoggedOut() {
-      this.$store.commit(`toggleSessionModal`, true)
     }
   }
 }

--- a/src/components/governance/PageGovernance.vue
+++ b/src/components/governance/PageGovernance.vue
@@ -9,6 +9,15 @@
       color="primary"
       @click.native="onPropose"
     />
+    <TmBtn
+      v-else-if="!session.signedIn"
+      id="propose-btn"
+      slot="header-buttons"
+      :disabled="!connected"
+      :value="connected ? 'Create Proposal' : 'Connecting...'"
+      color="primary"
+      @click.native="onProposeLoggedOut"
+    />
     <ModalPropose ref="modalPropose" :denom="depositDenom" />
     <router-view />
   </TmPage>
@@ -50,6 +59,9 @@ export default {
   methods: {
     onPropose() {
       this.$refs.modalPropose.open()
+    },
+    onProposeLoggedOut() {
+      this.$store.commit(`toggleSessionModal`, true);
     }
   }
 }

--- a/src/components/governance/PageGovernance.vue
+++ b/src/components/governance/PageGovernance.vue
@@ -61,7 +61,7 @@ export default {
       this.$refs.modalPropose.open()
     },
     onProposeLoggedOut() {
-      this.$store.commit(`toggleSessionModal`, true);
+      this.$store.commit(`toggleSessionModal`, true)
     }
   }
 }

--- a/test/unit/specs/components/common/ActionModal.spec.js
+++ b/test/unit/specs/components/common/ActionModal.spec.js
@@ -64,25 +64,6 @@ describe(`ActionModal`, () => {
     expect(self.submissionError).toEqual(`PREFIX: some kind of error message.`)
   })
 
-  it(`should clear the submissionError after a timeout if the function is rejected`, async () => {
-    jest.useFakeTimers()
-
-    const submitFn = jest
-      .fn()
-      .mockRejectedValue(new Error(`some kind of error message`))
-    const $store = { dispatch: jest.fn() }
-    const self = {
-      $store,
-      submitFn,
-      submissionErrorPrefix: `PREFIX`,
-      connectLedger: () => {}
-    }
-    await ActionModal.methods.submit.call(self)
-
-    jest.runAllTimers()
-    expect(self.submissionError).toEqual(null)
-  })
-
   it(`should default to submissionError being null`, () => {
     expect(wrapper.vm.submissionError).toBe(null)
   })


### PR DESCRIPTION
Closes #2157

**Description:**

Now even logged out users can see the Create Proposal button inside the governance tab. It will prompt logged out users to log in.

Before:
![image](https://user-images.githubusercontent.com/11528441/58991060-61bb3580-87b5-11e9-8b08-bf1935e354ad.png)

After:
![image](https://user-images.githubusercontent.com/11528441/58991127-7e576d80-87b5-11e9-968a-9f27ac911402.png)

Then (onClick): 
![image](https://user-images.githubusercontent.com/11528441/58991184-9dee9600-87b5-11e9-8a3d-68723def55d9.png)


Thank you! 🚀

---

For contributor:

- [ ] Added changes entries. Run `yarn changelog` for a guided process.
- [x] Reviewed `Files changed` in the github PR explorer
- [x] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI
