### PR TITLE
Benji/2165 show end voting period

### DIFF
--- a/changes/Benji_2165-show-end-voting-period
+++ b/changes/Benji_2165-show-end-voting-period
@@ -1,0 +1,1 @@
+[Added] [#2165](https://github.com/cosmos/lunie/issues/2165) Shows end date and time for Governance proposals @thebkr7

--- a/src/components/governance/PageProposal.vue
+++ b/src/components/governance/PageProposal.vue
@@ -204,18 +204,20 @@ export default {
         return false
       }
     },
-    votingStartedAgo({ proposal} = this) {
+    votingStartedAgo({ proposal } = this) {
       return moment(new Date(proposal.voting_start_time)).fromNow()
     },
     proposalStatus({ proposal, depositEndsIn, votingStartedAgo } = this) {
-      if (proposal.proposal_status === 'DepositPeriod') {
+      if (proposal.proposal_status === "DepositPeriod") {
         return `Deposit period ends ${depositEndsIn}`
-      } else if (proposal.proposal_status === 'VotingPeriod') {
+      } else if (proposal.proposal_status === "VotingPeriod") {
         return `Voting started ${votingStartedAgo}`
-      } else if (proposal.proposal_status === 'Rejected') {
-        return 'Rejected'
-      } else if (proposal.proposal_status === 'Passed') {
-        return 'Passed'
+      } else if (proposal.proposal_status === "Rejected") {
+        return "Rejected"
+      } else if (proposal.proposal_status === "Passed") {
+        return "Passed"
+      } else {
+        return false
       }
     },
     depositEndsIn({ proposal } = this) {

--- a/src/components/governance/PageProposal.vue
+++ b/src/components/governance/PageProposal.vue
@@ -58,17 +58,8 @@
 
           <dl class="info_dl colored_dl">
             <dt>Proposal Status</dt>
-            <dd v-if="proposal.proposal_status === 'DepositPeriod'">
-              {{ `Deposit period ends ${depositEndsIn}.` }}
-            </dd>
-            <dd v-if="proposal.proposal_status === 'VotingPeriod'">
-              {{ `Voting started ${votingStartedAgo}.` }}
-            </dd>
-            <dd v-if="proposal.proposal_status === 'Rejected'">
-              Rejected
-            </dd>
-            <dd v-if="proposal.proposal_status === 'Passed'">
-              Passed
+            <dd>
+              {{ proposalStatus }}
             </dd>
           </dl>
           <dl v-if="displayEndDate" class="info_dl colored_dl">
@@ -213,8 +204,19 @@ export default {
         return false
       }
     },
-    votingStartedAgo({ proposal } = this) {
+    votingStartedAgo({ proposal} = this) {
       return moment(new Date(proposal.voting_start_time)).fromNow()
+    },
+    proposalStatus({ proposal, depositEndsIn, votingStartedAgo } = this) {
+      if (proposal.proposal_status === 'DepositPeriod') {
+        return `Deposit period ends ${depositEndsIn}`
+      } else if (proposal.proposal_status === 'VotingPeriod') {
+        return `Voting started ${votingStartedAgo}`
+      } else if (proposal.proposal_status === 'Rejected') {
+        return 'Rejected'
+      } else if (proposal.proposal_status === 'Passed') {
+        return 'Passed'
+      }
     },
     depositEndsIn({ proposal } = this) {
       return moment(new Date(proposal.deposit_end_time)).fromNow()

--- a/src/components/governance/PageProposal.vue
+++ b/src/components/governance/PageProposal.vue
@@ -68,7 +68,7 @@
           </dl>
 
           <dl class="info_dl colored_dl">
-            <dt>End Date</dt>
+            <dt>Voting End Date</dt>
             <dd>{{ endDate }}</dd>
           </dl>
         </div>

--- a/src/components/governance/PageProposal.vue
+++ b/src/components/governance/PageProposal.vue
@@ -177,6 +177,7 @@ export default {
       `connected`,
       `wallet`,
       `votes`,
+      `governanceParameters`,
       `session`
     ]),
     proposal({ proposals, proposalId } = this) {
@@ -194,10 +195,11 @@ export default {
     endDate({ proposal } = this) {
       return moment(proposal.voting_end_time).format("MMMM Do YYYY, HH:mm")
     },
-    displayEndDate({ proposal } = this) {
+    displayEndDate({ proposal, governanceParameters } = this) {
       if (
         proposal.proposal_status !== "DepositPeriod" &&
-        proposal.total_deposit[0].amount >= 521000000
+        proposal.total_deposit[0].amount >=
+          Number(governanceParameters.parameters.deposit.min_deposit[0].amount)
       ) {
         return true
       } else {

--- a/src/components/governance/PageProposal.vue
+++ b/src/components/governance/PageProposal.vue
@@ -57,12 +57,6 @@
           </dl>
 
           <dl class="info_dl colored_dl">
-            <dt>End Date</dt>
-            <dd>{{ endDate }}</dd>
-          </dl>
-        </div>
-        <div class="row">
-          <dl class="info_dl colored_dl">
             <dt>Proposal Status</dt>
             <dd>
               {{
@@ -73,6 +67,12 @@
             </dd>
           </dl>
 
+          <dl class="info_dl colored_dl">
+            <dt>End Date</dt>
+            <dd>{{ endDate }}</dd>
+          </dl>
+        </div>
+        <div class="row">
           <dl class="info_dl colored_dl">
             <dt>Deposit Count</dt>
             <dd>{{ `${totalDeposit.amount} ${totalDeposit.denom}` }}</dd>
@@ -197,7 +197,7 @@ export default {
       return moment(new Date(proposal.submit_time)).fromNow()
     },
     endDate({ proposal } = this) {
-      return moment(proposal.voting_end_time).format("MMMM Do YYYY, H:mm")
+      return moment(proposal.voting_end_time).format("MMMM Do YYYY, HH:mm")
     },
     votingStartedAgo({ proposal } = this) {
       return moment(new Date(proposal.voting_start_time)).fromNow()

--- a/src/components/governance/PageProposal.vue
+++ b/src/components/governance/PageProposal.vue
@@ -51,10 +51,22 @@
           </div>
         </div>
         <div class="row">
+
+
+
+
           <dl class="info_dl colored_dl">
             <dt>Submitted</dt>
             <dd>{{ submittedAgo }}</dd>
           </dl>
+
+          <dl class="info_dl colored_dl">
+            <dt>End Date</dt>
+            <dd>{{ endDate }}</dd>
+          </dl>
+
+
+
           <dl class="info_dl colored_dl">
             <dt>Proposal Status</dt>
             <dd>
@@ -189,6 +201,16 @@ export default {
     submittedAgo({ proposal } = this) {
       return moment(new Date(proposal.submit_time)).fromNow()
     },
+
+
+
+    endDate({ proposal } = this) {
+      return moment(proposal.end_time).format("dddd, MMMM Do YYYY, h:mm:ss a")
+    },
+
+
+
+    
     votingStartedAgo({ proposal } = this) {
       return moment(new Date(proposal.voting_start_time)).fromNow()
     },

--- a/src/components/governance/PageProposal.vue
+++ b/src/components/governance/PageProposal.vue
@@ -51,10 +51,6 @@
           </div>
         </div>
         <div class="row">
-
-
-
-
           <dl class="info_dl colored_dl">
             <dt>Submitted</dt>
             <dd>{{ submittedAgo }}</dd>
@@ -64,9 +60,8 @@
             <dt>End Date</dt>
             <dd>{{ endDate }}</dd>
           </dl>
-
-
-
+        </div>
+        <div class="row">
           <dl class="info_dl colored_dl">
             <dt>Proposal Status</dt>
             <dd>
@@ -201,16 +196,9 @@ export default {
     submittedAgo({ proposal } = this) {
       return moment(new Date(proposal.submit_time)).fromNow()
     },
-
-
-
     endDate({ proposal } = this) {
-      return moment(proposal.end_time).format("dddd, MMMM Do YYYY, h:mm:ss a")
+      return moment(proposal.voting_end_time).format("MMMM Do YYYY, H:mm")
     },
-
-
-
-    
     votingStartedAgo({ proposal } = this) {
       return moment(new Date(proposal.voting_start_time)).fromNow()
     },

--- a/src/components/governance/PageProposal.vue
+++ b/src/components/governance/PageProposal.vue
@@ -58,12 +58,17 @@
 
           <dl class="info_dl colored_dl">
             <dt>Proposal Status</dt>
-            <dd>
-              {{
-                proposal.proposal_status === `DepositPeriod`
-                  ? `Deposit period ends ${depositEndsIn}.`
-                  : `Voting started ${votingStartedAgo}.`
-              }}
+            <dd v-if="proposal.proposal_status === 'DepositPeriod'">
+              {{ `Deposit period ends ${depositEndsIn}.` }}
+            </dd>
+            <dd v-if="proposal.proposal_status === 'VotingPeriod'">
+              {{ `Voting started ${votingStartedAgo}.` }}
+            </dd>
+            <dd v-if="proposal.proposal_status === 'Rejected'">
+              Rejected
+            </dd>
+            <dd v-if="proposal.proposal_status === 'Passed'">
+              Passed
             </dd>
           </dl>
           <dl v-if="displayEndDate" class="info_dl colored_dl">

--- a/src/components/governance/PageProposal.vue
+++ b/src/components/governance/PageProposal.vue
@@ -66,17 +66,10 @@
               }}
             </dd>
           </dl>
-
           <dl v-if="displayEndDate" class="info_dl colored_dl">
             <dt>Voting End Date</dt>
             <dd>{{ endDate }}</dd>
           </dl>
-
-
-
-
-
-
         </div>
       </div>
 
@@ -206,10 +199,13 @@ export default {
       return moment(proposal.voting_end_time).format("MMMM Do YYYY, HH:mm")
     },
     displayEndDate({ proposal } = this) {
-      if (proposal.proposal_status !== "DepositPeriod" && proposal.total_deposit[0].amount >= 521000000) {
-        return true;
+      if (
+        proposal.proposal_status !== "DepositPeriod" &&
+        proposal.total_deposit[0].amount >= 521000000
+      ) {
+        return true
       } else {
-        return false;
+        return false
       }
     },
     votingStartedAgo({ proposal } = this) {

--- a/src/components/governance/PageProposal.vue
+++ b/src/components/governance/PageProposal.vue
@@ -67,11 +67,20 @@
             </dd>
           </dl>
 
-          <dl class="info_dl colored_dl">
+          <dl v-if="displayEndDate" class="info_dl colored_dl">
             <dt>Voting End Date</dt>
             <dd>{{ endDate }}</dd>
           </dl>
+
+
+
+
+
+
         </div>
+      </div>
+
+      <div class="page-profile__section">
         <div class="row">
           <dl class="info_dl colored_dl">
             <dt>Deposit Count</dt>
@@ -85,9 +94,6 @@
             <dd>{{ num.shortDecimals(num.atoms(totalVotes)) }}</dd>
           </dl>
         </div>
-      </div>
-
-      <div class="page-profile__section">
         <div v-if="proposal.proposal_status === 'VotingPeriod'" class="row">
           <dl class="info_dl colored_dl">
             <dt>Yes</dt>
@@ -198,6 +204,13 @@ export default {
     },
     endDate({ proposal } = this) {
       return moment(proposal.voting_end_time).format("MMMM Do YYYY, HH:mm")
+    },
+    displayEndDate({ proposal } = this) {
+      if (proposal.proposal_status !== "DepositPeriod" && proposal.total_deposit[0].amount >= 521000000) {
+        return true;
+      } else {
+        return false;
+      }
     },
     votingStartedAgo({ proposal } = this) {
       return moment(new Date(proposal.voting_start_time)).fromNow()

--- a/test/unit/specs/components/governance/PageProposal.spec.js
+++ b/test/unit/specs/components/governance/PageProposal.spec.js
@@ -16,7 +16,7 @@ describe(`PageProposal`, () => {
   let wrapper, $store
 
   const getters = {
-    depositDenom: governanceParameters.deposit.min_deposit[0].denom,
+    depositDenom: governanceParameters.parameters.deposit.min_deposit[0].denom,
     proposals: { proposals, tallies },
     connected: true,
     governanceParameters: { ...governanceParameters, loaded: true },

--- a/test/unit/specs/components/governance/PageProposal.spec.js
+++ b/test/unit/specs/components/governance/PageProposal.spec.js
@@ -113,6 +113,12 @@ describe(`PageProposal`, () => {
     )
   })
 
+  it(`should return the time the vote ends`, () => {
+    expect(wrapper.vm.endDate).toEqual(
+      moment(proposal.voting_end_time).format("MMMM Do YYYY, HH:mm")
+    )
+  })
+
   it(`should return the time when deposits end`, () => {
     expect(wrapper.vm.depositEndsIn).toEqual(
       moment(new Date(proposal.deposit_end_time)).fromNow()

--- a/test/unit/specs/components/governance/__snapshots__/PageProposal.spec.js.snap
+++ b/test/unit/specs/components/governance/__snapshots__/PageProposal.spec.js.snap
@@ -88,7 +88,7 @@ exports[`PageProposal renders votes in HTML when voting is open 1`] = `
         class="info_dl colored_dl"
       >
         <dt>
-          End Date
+          Voting End Date
         </dt>
          
         <dd>
@@ -315,7 +315,7 @@ exports[`PageProposal should display proposal page if user has signed in 1`] = `
         class="info_dl colored_dl"
       >
         <dt>
-          End Date
+          Voting End Date
         </dt>
          
         <dd>
@@ -542,7 +542,7 @@ exports[`PageProposal should display proposal page should default tally to 0 if 
         class="info_dl colored_dl"
       >
         <dt>
-          End Date
+          Voting End Date
         </dt>
          
         <dd>

--- a/test/unit/specs/components/governance/__snapshots__/PageProposal.spec.js.snap
+++ b/test/unit/specs/components/governance/__snapshots__/PageProposal.spec.js.snap
@@ -77,11 +77,17 @@ exports[`PageProposal renders votes in HTML when voting is open 1`] = `
           Proposal Status
         </dt>
          
+        <!---->
+         
         <dd>
           
             Voting started in 2 days.
           
         </dd>
+         
+        <!---->
+         
+        <!---->
       </dl>
        
       <dl
@@ -304,11 +310,17 @@ exports[`PageProposal should display proposal page if user has signed in 1`] = `
           Proposal Status
         </dt>
          
+        <!---->
+         
         <dd>
           
             Voting started in 2 days.
           
         </dd>
+         
+        <!---->
+         
+        <!---->
       </dl>
        
       <dl
@@ -531,11 +543,17 @@ exports[`PageProposal should display proposal page should default tally to 0 if 
           Proposal Status
         </dt>
          
+        <!---->
+         
         <dd>
           
             Voting started in 2 days.
           
         </dd>
+         
+        <!---->
+         
+        <!---->
       </dl>
        
       <dl

--- a/test/unit/specs/components/governance/__snapshots__/PageProposal.spec.js.snap
+++ b/test/unit/specs/components/governance/__snapshots__/PageProposal.spec.js.snap
@@ -88,6 +88,22 @@ exports[`PageProposal renders votes in HTML when voting is open 1`] = `
         class="info_dl colored_dl"
       >
         <dt>
+          End Date
+        </dt>
+         
+        <dd>
+          January 5th 1970, 00:00
+        </dd>
+      </dl>
+    </div>
+     
+    <div
+      class="row"
+    >
+      <dl
+        class="info_dl colored_dl"
+      >
+        <dt>
           Deposit Count
         </dt>
          
@@ -299,6 +315,22 @@ exports[`PageProposal should display proposal page if user has signed in 1`] = `
         class="info_dl colored_dl"
       >
         <dt>
+          End Date
+        </dt>
+         
+        <dd>
+          January 5th 1970, 00:00
+        </dd>
+      </dl>
+    </div>
+     
+    <div
+      class="row"
+    >
+      <dl
+        class="info_dl colored_dl"
+      >
+        <dt>
           Deposit Count
         </dt>
          
@@ -506,6 +538,22 @@ exports[`PageProposal should display proposal page should default tally to 0 if 
         </dd>
       </dl>
        
+      <dl
+        class="info_dl colored_dl"
+      >
+        <dt>
+          End Date
+        </dt>
+         
+        <dd>
+          January 5th 1970, 00:00
+        </dd>
+      </dl>
+    </div>
+     
+    <div
+      class="row"
+    >
       <dl
         class="info_dl colored_dl"
       >

--- a/test/unit/specs/components/governance/__snapshots__/PageProposal.spec.js.snap
+++ b/test/unit/specs/components/governance/__snapshots__/PageProposal.spec.js.snap
@@ -96,7 +96,11 @@ exports[`PageProposal renders votes in HTML when voting is open 1`] = `
         </dd>
       </dl>
     </div>
-     
+  </div>
+   
+  <div
+    class="page-profile__section"
+  >
     <div
       class="row"
     >
@@ -124,11 +128,7 @@ exports[`PageProposal renders votes in HTML when voting is open 1`] = `
         </dd>
       </dl>
     </div>
-  </div>
-   
-  <div
-    class="page-profile__section"
-  >
+     
     <div
       class="row"
     >
@@ -323,7 +323,11 @@ exports[`PageProposal should display proposal page if user has signed in 1`] = `
         </dd>
       </dl>
     </div>
-     
+  </div>
+   
+  <div
+    class="page-profile__section"
+  >
     <div
       class="row"
     >
@@ -351,11 +355,7 @@ exports[`PageProposal should display proposal page if user has signed in 1`] = `
         </dd>
       </dl>
     </div>
-  </div>
-   
-  <div
-    class="page-profile__section"
-  >
+     
     <div
       class="row"
     >
@@ -550,7 +550,11 @@ exports[`PageProposal should display proposal page should default tally to 0 if 
         </dd>
       </dl>
     </div>
-     
+  </div>
+   
+  <div
+    class="page-profile__section"
+  >
     <div
       class="row"
     >
@@ -578,11 +582,7 @@ exports[`PageProposal should display proposal page should default tally to 0 if 
         </dd>
       </dl>
     </div>
-  </div>
-   
-  <div
-    class="page-profile__section"
-  >
+     
     <div
       class="row"
     >

--- a/test/unit/specs/components/governance/__snapshots__/PageProposal.spec.js.snap
+++ b/test/unit/specs/components/governance/__snapshots__/PageProposal.spec.js.snap
@@ -77,17 +77,11 @@ exports[`PageProposal renders votes in HTML when voting is open 1`] = `
           Proposal Status
         </dt>
          
-        <!---->
-         
         <dd>
           
-            Voting started in 2 days.
+            Voting started in 2 days
           
         </dd>
-         
-        <!---->
-         
-        <!---->
       </dl>
        
       <dl
@@ -310,17 +304,11 @@ exports[`PageProposal should display proposal page if user has signed in 1`] = `
           Proposal Status
         </dt>
          
-        <!---->
-         
         <dd>
           
-            Voting started in 2 days.
+            Voting started in 2 days
           
         </dd>
-         
-        <!---->
-         
-        <!---->
       </dl>
        
       <dl
@@ -543,17 +531,11 @@ exports[`PageProposal should display proposal page should default tally to 0 if 
           Proposal Status
         </dt>
          
-        <!---->
-         
         <dd>
           
-            Voting started in 2 days.
+            Voting started in 2 days
           
         </dd>
-         
-        <!---->
-         
-        <!---->
       </dl>
        
       <dl

--- a/test/unit/specs/store/json/parameters.js
+++ b/test/unit/specs/store/json/parameters.js
@@ -7,21 +7,23 @@ export const stakingParameters = {
 }
 
 export const governanceParameters = {
-  deposit: {
-    min_deposit: [
-      {
-        denom: `STAKE`,
-        amount: `10.0000000000`
-      }
-    ],
-    max_deposit_period: `86400000000000`
-  },
-  tallying: {
-    threshold: `0.5000000000`,
-    veto: `0.3340000000`,
-    quorum: `0.3340000000`
-  },
-  voting: {
-    voting_period: `86400000000000`
+  parameters: {
+    deposit: {
+      min_deposit: [
+        {
+          denom: `STAKE`,
+          amount: `10.0000000000`
+        }
+      ],
+      max_deposit_period: `86400000000000`
+    },
+    tallying: {
+      threshold: `0.5000000000`,
+      veto: `0.3340000000`,
+      quorum: `0.3340000000`
+    },
+    voting: {
+      voting_period: `86400000000000`
+    }
   }
 }


### PR DESCRIPTION
Closes #2165 

Adds a div showing when the voting for a proposal in Governance ends and re-organizes time-specific elements.

Fixing that the end time for proposals was not showing.

Before:
![image](https://user-images.githubusercontent.com/11528441/59072377-55f07180-8890-11e9-9c41-638907965bfb.png)

After:
![image](https://user-images.githubusercontent.com/11528441/59072437-86381000-8890-11e9-9804-e58c3fc1f567.png)


Thank you! 🚀

---

For contributor:

- [ ] Added changes entries. Run `yarn changelog` for a guided process.
- [x] Reviewed `Files changed` in the github PR explorer
- [x] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI
