### PR TITLE
Benji/2347 Adds configuration to print code coverage for Jest tests

### DIFF
--- a/changes/Benji_2347-Print-Code-Coverage
+++ b/changes/Benji_2347-Print-Code-Coverage
@@ -1,0 +1,1 @@
+[Repository] [#2347](https://github.com/cosmos/lunie/pull/2347) Updates Jest config so that the test coverage summary is printed out when run @thebkr7

--- a/jest.config.js
+++ b/jest.config.js
@@ -26,7 +26,7 @@ module.exports = {
 
   collectCoverage: true,
   coverageDirectory: `./test/unit/coverage`,
-  coverageReporters: [`lcov`, `text`], //change 'text' to 'text-summary' for summarized output
+  coverageReporters: [`lcov`, `text-summary`], //change 'text' to 'text-summary' for summarized output
   coveragePathIgnorePatterns: [
     `/node_modules/`,
     `/build/`,

--- a/jest.config.js
+++ b/jest.config.js
@@ -26,7 +26,7 @@ module.exports = {
 
   collectCoverage: true,
   coverageDirectory: `./test/unit/coverage`,
-  coverageReporters: [`lcov`, `text-summary`], //change 'text' to 'text-summary' for summarized output
+  coverageReporters: [`lcov`, `text-summary`],
   coveragePathIgnorePatterns: [
     `/node_modules/`,
     `/build/`,

--- a/jest.config.js
+++ b/jest.config.js
@@ -26,7 +26,7 @@ module.exports = {
 
   collectCoverage: true,
   coverageDirectory: `./test/unit/coverage`,
-  coverageReporters: [`lcov`],
+  coverageReporters: [`html`, `text`], //change 'text' to 'text-summary' for summarized output
   coveragePathIgnorePatterns: [
     `/node_modules/`,
     `/build/`,

--- a/jest.config.js
+++ b/jest.config.js
@@ -26,7 +26,7 @@ module.exports = {
 
   collectCoverage: true,
   coverageDirectory: `./test/unit/coverage`,
-  coverageReporters: [`html`, `text`], //change 'text' to 'text-summary' for summarized output
+  coverageReporters: [`lcov`, `text`], //change 'text' to 'text-summary' for summarized output
   coveragePathIgnorePatterns: [
     `/node_modules/`,
     `/build/`,


### PR DESCRIPTION
Closes #2347 

Modifies the Jest config file so that when running tests the code coverage is printed.

Thank you! 🚀

---

For contributor:

- [ ] Added changes entries. Run `yarn changelog` for a guided process.
- [x] Reviewed `Files changed` in the github PR explorer
- [ ] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI
