### PR TITLE
Benji/2699 validator status bug

### DIFF
--- a/changes/Benji_2699-Validator-Status-Bug
+++ b/changes/Benji_2699-Validator-Status-Bug
@@ -1,0 +1,1 @@
+[Fixed] [#2699](https://github.com/cosmos/lunie/issues/2699) Fixed the bug that was always displaying validators as active when expanded even if they were not @thebkr7

--- a/src/components/staking/PageValidator.vue
+++ b/src/components/staking/PageValidator.vue
@@ -295,11 +295,11 @@ export default {
     },
     status() {
       // status: jailed
-      if (this.validator.revoked)
+      if (this.validator.jailed)
         return `This validator has been jailed and is not currently validating`
 
       // status: inactive
-      if (parseFloat(this.validator.voting_power) === 0)
+      if (parseFloat(this.validator.status) === 0)
         return `This validator does not have enough voting power yet and is inactive`
 
       // status: active
@@ -307,10 +307,10 @@ export default {
     },
     statusColor() {
       // status: jailed
-      if (this.validator.revoked) return `red`
+      if (this.validator.jailed) return `red`
 
       // status: inactive
-      if (parseFloat(this.validator.voting_power) === 0) return `yellow`
+      if (parseFloat(this.validator.status) === 0) return `yellow`
 
       // status: active
       return `green`

--- a/test/unit/specs/components/staking/PageValidator.spec.js
+++ b/test/unit/specs/components/staking/PageValidator.spec.js
@@ -178,10 +178,10 @@ describe(`PageValidator`, () => {
       )
     })
 
-    it(`shows a validator as candidate if he has no voting_power`, () => {
+    it(`shows a validator as an inactive candidate if he has no voting_power`, () => {
       $store.getters.delegates.delegates = [
         Object.assign({}, validator, {
-          voting_power: 0
+          status: 0
         })
       ]
       expect(wrapper.vm.status).toMatchSnapshot()

--- a/test/unit/specs/components/staking/PageValidator.spec.js
+++ b/test/unit/specs/components/staking/PageValidator.spec.js
@@ -10,7 +10,7 @@ const stakingParameters = {
 const validator = {
   operator_address: `cosmosvaladdr15ky9du8a2wlstz6fpx3p4mqpjyrm5ctqzh8yqw`,
   pub_key: `cosmosvalpub1234`,
-  revoked: false,
+  jailed: false,
   tokens: `14`,
   delegator_shares: `14`,
   description: {
@@ -161,7 +161,7 @@ describe(`PageValidator`, () => {
       // Jailed
       $store.getters.delegates.delegates = [
         Object.assign({}, validator, {
-          revoked: true
+          jailed: true
         })
       ]
       expect(wrapper.vm.status).toBe(
@@ -170,7 +170,7 @@ describe(`PageValidator`, () => {
       // Is not a validator
       $store.getters.delegates.delegates = [
         Object.assign({}, validator, {
-          voting_power: 0
+          status: 0
         })
       ]
       expect(wrapper.vm.status).toBe(
@@ -187,10 +187,10 @@ describe(`PageValidator`, () => {
       expect(wrapper.vm.status).toMatchSnapshot()
     })
 
-    it(`shows that a validator is revoked`, () => {
+    it(`shows that a validator is jailed`, () => {
       $store.getters.delegates.delegates = [
         Object.assign({}, validator, {
-          revoked: true
+          jailed: true
         })
       ]
       expect(wrapper.vm.status).toMatchSnapshot()

--- a/test/unit/specs/components/staking/__snapshots__/PageValidator.spec.js.snap
+++ b/test/unit/specs/components/staking/__snapshots__/PageValidator.spec.js.snap
@@ -989,9 +989,9 @@ exports[`PageValidator shows a validator profile information if user hasn't sign
 </tmpage-stub>
 `;
 
-exports[`PageValidator shows a validator profile information shows a validator as candidate if he has no voting_power 1`] = `"This validator does not have enough voting power yet and is inactive"`;
+exports[`PageValidator shows a validator profile information shows a validator as candidate if he has no voting_power 1`] = `"This validator is actively validating"`;
 
-exports[`PageValidator shows a validator profile information shows that a validator is revoked 1`] = `"This validator has been jailed and is not currently validating"`;
+exports[`PageValidator shows a validator profile information shows that a validator is jailed 1`] = `"This validator has been jailed and is not currently validating"`;
 
 exports[`delegationTargetOptions always shows wallet in the first position 1`] = `
 Array [

--- a/test/unit/specs/components/staking/__snapshots__/PageValidator.spec.js.snap
+++ b/test/unit/specs/components/staking/__snapshots__/PageValidator.spec.js.snap
@@ -989,7 +989,7 @@ exports[`PageValidator shows a validator profile information if user hasn't sign
 </tmpage-stub>
 `;
 
-exports[`PageValidator shows a validator profile information shows a validator as candidate if he has no voting_power 1`] = `"This validator is actively validating"`;
+exports[`PageValidator shows a validator profile information shows a validator as an inactive candidate if he has no voting_power 1`] = `"This validator does not have enough voting power yet and is inactive"`;
 
 exports[`PageValidator shows a validator profile information shows that a validator is jailed 1`] = `"This validator has been jailed and is not currently validating"`;
 


### PR DESCRIPTION
Closes #2699 

**Description:**

Updated PageValidator and it's corresponding tests to follow the same pattern as LiValidator. Now validators accurately reflect their status when expanded and not only in the list view.

@faboweb I proceeded with updating this code as if "revoked" and "voting_power"  had been used accidentally instead of "jailed" and "status". If this assumption was incorrect please point me in the right direction.

Thank you! 🚀

---

For contributor:

- [x] Added changes entries. Run `yarn changelog` for a guided process.
- [x] Reviewed `Files changed` in the github PR explorer
- [ ] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI
