### PR TITLE
colw/fix-withdraw-top5

### DIFF
--- a/changes/colw_fix-withdraw-top5
+++ b/changes/colw_fix-withdraw-top5
@@ -1,0 +1,1 @@
+[Fixed] [#2702](https://github.com/cosmos/lunie/pull/2702) Withdraw correctly from the top 5 rewards @colw

--- a/src/components/staking/ModalWithdrawRewards.vue
+++ b/src/components/staking/ModalWithdrawRewards.vue
@@ -8,7 +8,7 @@
     class="modal-withdraw-rewards"
     submission-error-prefix="Withdrawal failed"
   >
-    <span v-if="!validatorAddress" class="form-message notice withdraw-limit">
+    <span class="form-message notice withdraw-limit">
       You can only withdraw rewards from your top 5 validators in a single
       transaction. This is because of a limitation with the Ledger Nano.
     </span>
@@ -42,11 +42,6 @@ export default {
     fullDecimals
   },
   props: {
-    validatorAddress: {
-      type: String,
-      required: false,
-      default: null
-    },
     rewards: {
       type: Number,
       default: 0
@@ -68,7 +63,6 @@ export default {
         gas: gasEstimate,
         gasPrice,
         denom: this.denom,
-        validatorAddress: this.validatorAddress,
         password,
         submitType
       })

--- a/src/components/staking/ModalWithdrawRewards.vue
+++ b/src/components/staking/ModalWithdrawRewards.vue
@@ -56,10 +56,10 @@ export default {
       this.$refs.actionModal.open()
     },
     async simulateForm() {
-      return await this.$store.dispatch(`simulateWithdrawAllRewards`)
+      return await this.$store.dispatch(`simulateWithdralRewards`)
     },
     async submitForm(gasEstimate, gasPrice, password, submitType) {
-      await this.$store.dispatch(`withdrawAllRewards`, {
+      await this.$store.dispatch(`withdrawRewards`, {
         gas: gasEstimate,
         gasPrice,
         denom: this.denom,

--- a/src/components/staking/PageValidator.vue
+++ b/src/components/staking/PageValidator.vue
@@ -387,11 +387,6 @@ export default {
     onUndelegation() {
       this.$refs.undelegationModal.open()
     },
-    onWithdrawal() {
-      if (this.rewards > 0) {
-        this.$refs.modalWithdrawRewards.open()
-      }
-    },
     delegationTargetOptions(
       { session, liquidAtoms, committedDelegations, $route, delegates } = this
     ) {

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -47,34 +47,3 @@ export const roundObjectPercentages = dataMap => {
 
   return resultObject
 }
-
-const cmpSecondElementDesc = (a, b) => {
-  return b[1] - a[1]
-}
-
-// Takes a num and an object made of (key, number) pairs:
-// {
-//   address1: 100,
-//   address2: 1,
-//   address3: 5,
-//   address4: 3,
-//   address5: 0,
-// }
-// …and returns a copy with the top num values:
-// getTopDelegations(3, object) =>
-// {
-//   address1: 100,
-//   address6: 99,
-//   address8: 96,
-// }
-export const getTopDelegations = (num, dataObject) => {
-  const dataListArray = Object.entries(dataObject)
-  dataListArray.sort(cmpSecondElementDesc)
-  const result = {}
-  dataListArray.slice(0, num).forEach(([add, val]) => {
-    result[add] = val
-  })
-  return result
-}
-
-export const getTop5Delegations = getTopDelegations.bind(null, 5)

--- a/src/vuex/modules/distribution.js
+++ b/src/vuex/modules/distribution.js
@@ -100,12 +100,12 @@ export default ({ node }) => {
       { gas, gasPrice, denom, password, submitType }
     ) {
       // Compares the amount in a [address1, {denom: amount}] array
-      const byDenom = denom => (a, b) => b[1][denom] - a[1][denom]
+      const byBalanceOfDenom = denom => (a, b) => b[1][denom] - a[1][denom]
 
-      const validatorList = Object.entries(getters.distribution.rewards || [])
-        .sort(byDenom(getters.bondDenom))
+      const validatorList = Object.entries(getters.distribution.rewards)
+        .sort(byBalanceOfDenom(getters.bondDenom))
         .slice(0, 5) // Just the top 5
-        .map(elt => elt[0]) // Return only the address
+        .map(([address]) => address)
 
       await dispatch(`sendTx`, {
         type: `MsgWithdrawDelegationReward`,

--- a/src/vuex/modules/distribution.js
+++ b/src/vuex/modules/distribution.js
@@ -2,7 +2,6 @@ import * as Sentry from "@sentry/browser"
 import Vue from "vue"
 import { coinsToObject } from "scripts/common.js"
 import { uatoms } from "../../scripts/num.js"
-import { getTop5Delegations } from "../../utils/"
 import { throttle } from "scripts/blocks-throttle"
 
 export default ({ node }) => {
@@ -101,17 +100,23 @@ export default ({ node }) => {
       { rootState, getters, dispatch },
       { gas, gasPrice, denom, validatorAddress, password, submitType }
     ) {
-      const top5Delegations = getTop5Delegations(getters.committedDelegations)
+      // Compares the {denom: value} portion of the array
+      const byDenom = denom => (a, b) => b[1][denom] - a[1][denom]
 
-      const validatorAddresses = validatorAddress
-        ? [validatorAddress]
-        : Object.keys(top5Delegations)
+      let validatorList = [validatorAddress]
+      if (!validatorAddress) {
+        const numRewards = 5
+        validatorList = Object.entries(getters.distribution.rewards)
+          .sort(byDenom(getters.bondDenom))
+          .slice(0, numRewards)
+          .map(elt => elt[0]) // Return only the address
+      }
 
       await dispatch(`sendTx`, {
         type: `MsgWithdrawDelegationReward`,
         txArguments: {
           toAddress: rootState.session.address,
-          validatorAddresses: validatorAddresses
+          validatorAddresses: validatorList
         },
         gas: String(gas),
         gas_prices: [

--- a/src/vuex/modules/distribution.js
+++ b/src/vuex/modules/distribution.js
@@ -91,24 +91,21 @@ export default ({ node }) => {
       return await dispatch(`simulateTx`, {
         type: `MsgWithdrawDelegationReward`,
         txArguments: {
-          toAddress: session.address,
-          validatorAddresses: []
+          toAddress: session.address
         }
       })
     },
     async withdrawAllRewards(
       { rootState, getters, dispatch },
-      { gas, gasPrice, denom, validatorAddress, password, submitType }
+      { gas, gasPrice, denom, password, submitType }
     ) {
       // Compares the amount in a [address1, {denom: amount}] array
       const byDenom = denom => (a, b) => b[1][denom] - a[1][denom]
-      let validatorList = [validatorAddress]
-      if (!validatorAddress) {
-        validatorList = Object.entries(getters.distribution.rewards)
-          .sort(byDenom(getters.bondDenom))
-          .slice(0, 5) // Just the top 5
-          .map(elt => elt[0]) // Return only the address
-      }
+
+      const validatorList = Object.entries(getters.distribution.rewards || [])
+        .sort(byDenom(getters.bondDenom))
+        .slice(0, 5) // Just the top 5
+        .map(elt => elt[0]) // Return only the address
 
       await dispatch(`sendTx`, {
         type: `MsgWithdrawDelegationReward`,

--- a/src/vuex/modules/distribution.js
+++ b/src/vuex/modules/distribution.js
@@ -100,15 +100,13 @@ export default ({ node }) => {
       { rootState, getters, dispatch },
       { gas, gasPrice, denom, validatorAddress, password, submitType }
     ) {
-      // Compares the {denom: value} portion of the array
+      // Compares the amount in a [address1, {denom: amount}] array
       const byDenom = denom => (a, b) => b[1][denom] - a[1][denom]
-
       let validatorList = [validatorAddress]
       if (!validatorAddress) {
-        const numRewards = 5
         validatorList = Object.entries(getters.distribution.rewards)
           .sort(byDenom(getters.bondDenom))
-          .slice(0, numRewards)
+          .slice(0, 5) // Just the top 5
           .map(elt => elt[0]) // Return only the address
       }
 

--- a/src/vuex/modules/distribution.js
+++ b/src/vuex/modules/distribution.js
@@ -87,7 +87,7 @@ export default ({ node }) => {
         commit(`setDistributionError`, error)
       }
     },
-    async simulateWithdrawAllRewards({ rootState: { session }, dispatch }) {
+    async simulateWithdralRewards({ rootState: { session }, dispatch }) {
       return await dispatch(`simulateTx`, {
         type: `MsgWithdrawDelegationReward`,
         txArguments: {
@@ -95,7 +95,7 @@ export default ({ node }) => {
         }
       })
     },
-    async withdrawAllRewards(
+    async withdrawRewards(
       { rootState, getters, dispatch },
       { gas, gasPrice, denom, password, submitType }
     ) {

--- a/test/unit/specs/components/staking/ModalWithdrawRewards.spec.js
+++ b/test/unit/specs/components/staking/ModalWithdrawRewards.spec.js
@@ -35,14 +35,7 @@ describe(`ModalWithdrawRewards`, () => {
   })
 
   it(`should display message when withdrawing from multiple validators`, () => {
-    wrapper.setProps({
-      validatorAddress: null
-    })
     expect(wrapper.find(`.withdraw-limit`).exists()).toBe(true)
-  })
-
-  it(`should not display message when withdrawing from single validators`, () => {
-    expect(wrapper.find(`.withdraw-limit`).exists()).toBe(false)
   })
 
   describe(`Withdraw`, () => {

--- a/test/unit/specs/components/staking/ModalWithdrawRewards.spec.js
+++ b/test/unit/specs/components/staking/ModalWithdrawRewards.spec.js
@@ -72,7 +72,6 @@ describe(`ModalWithdrawRewards`, () => {
       expect($store.dispatch).toBeCalledWith(`withdrawAllRewards`, {
         gasPrice,
         gas,
-        validatorAddress: wrapper.vm.validatorAddress,
         denom: wrapper.vm.denom,
         submitType: `ledger`,
         password: ``

--- a/test/unit/specs/components/staking/ModalWithdrawRewards.spec.js
+++ b/test/unit/specs/components/staking/ModalWithdrawRewards.spec.js
@@ -53,7 +53,7 @@ describe(`ModalWithdrawRewards`, () => {
         $store
       })
 
-      expect($store.dispatch).toHaveBeenCalledWith(`simulateWithdrawAllRewards`)
+      expect($store.dispatch).toHaveBeenCalledWith(`simulateWithdralRewards`)
       expect(res).toBe(estimate)
     })
 
@@ -69,7 +69,7 @@ describe(`ModalWithdrawRewards`, () => {
         `ledger`
       )
 
-      expect($store.dispatch).toBeCalledWith(`withdrawAllRewards`, {
+      expect($store.dispatch).toBeCalledWith(`withdrawRewards`, {
         gasPrice,
         gas,
         denom: wrapper.vm.denom,

--- a/test/unit/specs/components/staking/PageValidator.spec.js
+++ b/test/unit/specs/components/staking/PageValidator.spec.js
@@ -572,32 +572,5 @@ describe(`delegationTargetOptions`, () => {
         expect(self.$refs.undelegationModal.open).toHaveBeenCalled()
       })
     })
-
-    describe(`onWithdrawal`, () => {
-      it(`should open withdrawal modal when there are rewards`, () => {
-        const self = {
-          rewards: 1,
-          $refs: {
-            modalWithdrawRewards: {
-              open: jest.fn()
-            }
-          }
-        }
-        PageValidator.methods.onWithdrawal.call(self)
-        expect(self.$refs.modalWithdrawRewards.open).toHaveBeenCalled()
-      })
-      it(`should not open withdrawal modal when there are zero rewards`, () => {
-        const self = {
-          rewards: 0,
-          $refs: {
-            modalWithdrawRewards: {
-              open: jest.fn()
-            }
-          }
-        }
-        PageValidator.methods.onWithdrawal.call(self)
-        expect(self.$refs.modalWithdrawRewards.open).not.toHaveBeenCalled()
-      })
-    })
   })
 })

--- a/test/unit/specs/components/staking/__snapshots__/ModalWithdrawRewards.spec.js.snap
+++ b/test/unit/specs/components/staking/__snapshots__/ModalWithdrawRewards.spec.js.snap
@@ -9,8 +9,16 @@ exports[`ModalWithdrawRewards should show the withdraw rewards modal 1`] = `
   submissionerrorprefix="Withdrawal failed"
   submitfn="function () { [native code] }"
   title="Withdraw"
+  validatoraddress="cosmos1234567"
 >
-  <!---->
+  <span
+    class="form-message notice withdraw-limit"
+  >
+    
+    You can only withdraw rewards from your top 5 validators in a single
+    transaction. This is because of a limitation with the Ledger Nano.
+  
+  </span>
    
   <tmformgroup-stub
     class="action-modal-form-group"

--- a/test/unit/specs/components/staking/__snapshots__/PageValidator.spec.js.snap
+++ b/test/unit/specs/components/staking/__snapshots__/PageValidator.spec.js.snap
@@ -324,7 +324,7 @@ exports[`PageValidator shows a validator profile information errors signing info
     <modalwithdrawrewards-stub
       denom="STAKE"
       rewards="0"
-      validatoraddress="cosmosvaladdr15ky9du8a2wlstz6fpx3p4mqpjyrm5ctqzh8yqw"
+      validator-address="cosmosvaladdr15ky9du8a2wlstz6fpx3p4mqpjyrm5ctqzh8yqw"
     />
   </template>
 </tmpage-stub>
@@ -654,7 +654,7 @@ exports[`PageValidator shows a validator profile information if user has signed 
     <modalwithdrawrewards-stub
       denom="STAKE"
       rewards="0"
-      validatoraddress="cosmosvaladdr15ky9du8a2wlstz6fpx3p4mqpjyrm5ctqzh8yqw"
+      validator-address="cosmosvaladdr15ky9du8a2wlstz6fpx3p4mqpjyrm5ctqzh8yqw"
     />
   </template>
 </tmpage-stub>
@@ -983,7 +983,7 @@ exports[`PageValidator shows a validator profile information if user hasn't sign
      
     <modalwithdrawrewards-stub
       denom="STAKE"
-      validatoraddress="cosmosvaladdr15ky9du8a2wlstz6fpx3p4mqpjyrm5ctqzh8yqw"
+      validator-address="cosmosvaladdr15ky9du8a2wlstz6fpx3p4mqpjyrm5ctqzh8yqw"
     />
   </template>
 </tmpage-stub>

--- a/test/unit/specs/store/distribution.spec.js
+++ b/test/unit/specs/store/distribution.spec.js
@@ -160,14 +160,14 @@ describe(`Module: Fee Distribution`, () => {
       })
     })
 
-    describe(`withdrawAllRewards`, () => {
+    describe(`withdrawRewards`, () => {
       it(`should simulate a withdrawal transaction`, async () => {
         const { actions } = module
         const self = {
           rootState,
           dispatch: jest.fn(() => 123123)
         }
-        const res = await actions.simulateWithdrawAllRewards(self)
+        const res = await actions.simulateWithdralRewards(self)
 
         expect(self.dispatch).toHaveBeenCalledWith(`simulateTx`, {
           type: `MsgWithdrawDelegationReward`,
@@ -214,7 +214,7 @@ describe(`Module: Fee Distribution`, () => {
       })
 
       it(`success withdrawal`, async () => {
-        await actions.withdrawAllRewards(
+        await actions.withdrawRewards(
           {
             rootState,
             dispatch,

--- a/test/unit/specs/store/distribution.spec.js
+++ b/test/unit/specs/store/distribution.spec.js
@@ -24,6 +24,27 @@ describe(`Module: Fee Distribution`, () => {
     photino: 15
   }
 
+  const validatorRewards = {
+    address1: {
+      uatom: 100
+    },
+    address2: {
+      uatom: 10
+    },
+    address3: {
+      uatom: 70
+    },
+    address4: {
+      uatom: 2
+    },
+    address5: {
+      uatom: 3
+    },
+    address6: {
+      uatom: 99
+    }
+  }
+
   beforeEach(() => {
     module = distributionModule({ node })
     state = module.state
@@ -158,56 +179,16 @@ describe(`Module: Fee Distribution`, () => {
         expect(res).toBe(123123)
       })
 
-      it(`success withdrawal`, async () => {
-        await actions.withdrawAllRewards(
-          {
-            rootState,
-            dispatch,
-            getters: {
-              committedDelegations: {
-                coolval1: {}
-              }
-            }
-          },
-          {
-            gas: 456,
-            gasPrice: 123,
-            password: ``,
-            submitType: `ledger`
-          }
-        )
-        expect(dispatch).toHaveBeenCalledWith(`sendTx`, {
-          type: `MsgWithdrawDelegationReward`,
-          txArguments: {
-            toAddress: `cosmos1address`,
-            validatorAddresses: [`coolval1`]
-          },
-          password: ``,
-          submitType: `ledger`,
-          gas: "456",
-          gas_prices: [{ amount: "123000000", denom: undefined }]
-        })
-        expect(dispatch).toHaveBeenCalledWith(`getTotalRewards`)
-      })
-
       it(`success withdrawal one address`, async () => {
         await actions.withdrawAllRewards(
           {
             rootState,
             dispatch,
             getters: {
-              committedDelegations: {
-                address1: 100,
-                address2: 1,
-                address3: 5,
-                address4: 3,
-                address5: 0,
-                address6: 99,
-                address7: 9,
-                address8: 96,
-                address9: 98,
-                address10: 97
-              }
+              distribution: {
+                rewards: validatorRewards
+              },
+              bondDenom: "uatom"
             }
           },
           {
@@ -232,24 +213,16 @@ describe(`Module: Fee Distribution`, () => {
         expect(dispatch).toHaveBeenCalledWith(`getTotalRewards`)
       })
 
-      it(`success withdrawal top 5`, async () => {
+      it(`success withdrawal`, async () => {
         await actions.withdrawAllRewards(
           {
             rootState,
             dispatch,
             getters: {
-              committedDelegations: {
-                address1: 100,
-                address2: 1,
-                address3: 5,
-                address4: 3,
-                address5: 0,
-                address6: 99,
-                address7: 9,
-                address8: 96,
-                address9: 98,
-                address10: 97
-              }
+              distribution: {
+                rewards: validatorRewards
+              },
+              bondDenom: "uatom"
             }
           },
           {
@@ -266,9 +239,9 @@ describe(`Module: Fee Distribution`, () => {
             validatorAddresses: [
               `address1`,
               `address6`,
-              `address9`,
-              `address10`,
-              `address8`
+              `address3`,
+              `address2`,
+              `address5`
             ]
           },
           password: ``,

--- a/test/unit/specs/store/distribution.spec.js
+++ b/test/unit/specs/store/distribution.spec.js
@@ -172,45 +172,10 @@ describe(`Module: Fee Distribution`, () => {
         expect(self.dispatch).toHaveBeenCalledWith(`simulateTx`, {
           type: `MsgWithdrawDelegationReward`,
           txArguments: {
-            toAddress: `cosmos1address`,
-            validatorAddresses: []
+            toAddress: `cosmos1address`
           }
         })
         expect(res).toBe(123123)
-      })
-
-      it(`success withdrawal one address`, async () => {
-        await actions.withdrawAllRewards(
-          {
-            rootState,
-            dispatch,
-            getters: {
-              distribution: {
-                rewards: validatorRewards
-              },
-              bondDenom: "uatom"
-            }
-          },
-          {
-            gas: 456,
-            gasPrice: 123,
-            password: ``,
-            submitType: `ledger`,
-            validatorAddress: `address4`
-          }
-        )
-        expect(dispatch).toHaveBeenCalledWith(`sendTx`, {
-          type: `MsgWithdrawDelegationReward`,
-          txArguments: {
-            toAddress: `cosmos1address`,
-            validatorAddresses: [`address4`]
-          },
-          password: ``,
-          submitType: `ledger`,
-          gas: "456",
-          gas_prices: [{ amount: "123000000", denom: undefined }]
-        })
-        expect(dispatch).toHaveBeenCalledWith(`getTotalRewards`)
       })
 
       it(`success withdrawal`, async () => {

--- a/test/unit/specs/utils/utils.spec.js
+++ b/test/unit/specs/utils/utils.spec.js
@@ -1,8 +1,4 @@
-import {
-  roundObjectPercentages,
-  getTopDelegations,
-  getTop5Delegations
-} from "utils"
+import { roundObjectPercentages } from "utils"
 
 const tally = {
   yes: 13.626332,
@@ -40,58 +36,5 @@ describe(`roundObjectPercentages`, () => {
 
   it(`should sum again to 100`, () => {
     expect(sumOfValues(roundObjectPercentages(tally3))).toBe(100)
-  })
-})
-
-describe(`getTopRewards`, () => {
-  let list
-
-  beforeEach(() => {
-    list = {
-      address1: 100,
-      address2: 1,
-      address3: 5,
-      address4: 3,
-      address5: 0,
-      address6: 99,
-      address7: 9,
-      address8: 96,
-      address9: 98,
-      address10: 97
-    }
-  })
-
-  it(`should return top 5 rewards`, () => {
-    const result = getTop5Delegations(list)
-    const expected = {
-      address1: 100,
-      // address2: 1,
-      // address3: 5,
-      // address4: 3,
-      // address5: 0,
-      address6: 99,
-      // address7: 9,
-      address8: 96,
-      address9: 98,
-      address10: 97
-    }
-    expect(result).toEqual(expected)
-  })
-
-  it(`should return top 9 rewards`, () => {
-    const result = getTopDelegations(9, list)
-    const expected = {
-      address1: 100,
-      address2: 1,
-      address3: 5,
-      address4: 3,
-      // address5: 0,
-      address6: 99,
-      address7: 9,
-      address8: 96,
-      address9: 98,
-      address10: 97
-    }
-    expect(result).toEqual(expected)
   })
 })


### PR DESCRIPTION
Fix: Withdraw from the top 5 rewards

It was withdrawing from the top 5 delegations incorrectly.

Also removed old code related to withdrawing from single validators.

<!-- Briefly describe what you're adding or fixing with this PR -->

Thank you! 🚀

---

For contributor:

- [ ] Added changes entries. Run `yarn changelog` for a guided process.
- [ ] Reviewed `Files changed` in the github PR explorer
- [ ] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI