### PR TITLE
colw/fix-get-rewards-on-load

### DIFF
--- a/changes/colw_fix-get-rewards-on-load
+++ b/changes/colw_fix-get-rewards-on-load
@@ -1,0 +1,1 @@
+[Fixed] [#2771](https://github.com/cosmos/lunie/pull/2771) Delegates were not loaded before attempting to calculate rewards @colw

--- a/src/vuex/modules/delegates.js
+++ b/src/vuex/modules/delegates.js
@@ -112,6 +112,7 @@ export default ({ node }) => {
         commit(`setDelegates`, validators)
         commit(`setDelegateLoading`, false)
         dispatch(`updateSigningInfo`, validators)
+        dispatch(`getRewardsFromMyValidators`)
 
         return validators
       } catch (error) {

--- a/test/unit/specs/store/delegates.spec.js
+++ b/test/unit/specs/store/delegates.spec.js
@@ -123,7 +123,10 @@ describe(`Module: Delegates`, () => {
       dispatch,
       rootState: mockRootState
     })
-    expect(dispatch.mock.calls).toEqual([[`updateSigningInfo`, candidates]])
+    expect(dispatch.mock.calls).toEqual([
+      [`updateSigningInfo`, candidates],
+      [`getRewardsFromMyValidators`]
+    ])
   })
 
   it(`fetches the signing information from all delegates`, async () => {


### PR DESCRIPTION
Closes #ISSUE

**Description:**

Delegates were not loaded before attempting to calculate rewards

Thank you! 🚀

---

For contributor:

- [ ] Added changes entries. Run `yarn changelog` for a guided process.
- [ ] Reviewed `Files changed` in the github PR explorer
- [ ] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI