### PR TITLE
Fix link to security page

### DIFF
--- a/src/components/common/PageAbout.vue
+++ b/src/components/common/PageAbout.vue
@@ -52,7 +52,7 @@
       </p>
       <p>
         To learn more about our security policies on Lunie.io, please visit our
-        <router-link to="careers">security page</router-link>.
+        <router-link to="security">security page</router-link>.
       </p>
     </div>
 


### PR DESCRIPTION
**Description:**

The link to the Security page currently points to Careers. This fixes that.

--

For contributor:

- [x] Added changes entries. Run `yarn changelog` for a guided process.
- [x] Reviewed `Files changed` in the github PR explorer

For reviewer:

- [ ] Manually tested the changes on the UI
