### PR TITLE
colw/clean-action-modal

### DIFF
--- a/changes/colw_clean-action-modal
+++ b/changes/colw_clean-action-modal
@@ -1,0 +1,1 @@
+[Code Improvements] [#2745](https://github.com/cosmos/lunie/pull/2745) Clean action modal template syntax @colw

--- a/src/ActionModal/components/ActionModal.vue
+++ b/src/ActionModal/components/ActionModal.vue
@@ -253,8 +253,6 @@ export default {
       `connected`,
       `session`,
       `bondDenom`,
-      `wallet`,
-      `ledger`,
       `liquidAtoms`,
       `modalContext`
     ]),

--- a/src/ActionModal/components/ActionModal.vue
+++ b/src/ActionModal/components/ActionModal.vue
@@ -12,7 +12,7 @@
         <span class="action-modal-title">
           {{ requiresSignIn ? `Sign in required` : title }}
         </span>
-        <Steps :steps="['Details', 'Fees', 'Sign']" :active="step" />
+        <Steps :steps="['Details', 'Fees', 'Sign']" :active-step="step" />
       </div>
       <div v-if="requiresSignIn" class="action-modal-form">
         <p>You need to sign in to submit a transaction.</p>

--- a/src/ActionModal/components/DelegationModal.vue
+++ b/src/ActionModal/components/DelegationModal.vue
@@ -35,7 +35,7 @@
       field-id="amount"
       field-label="Amount"
     >
-      <span class="input-suffix">{{ num.viewDenom(denom) }}</span>
+      <span class="input-suffix">{{ denom | viewDenom }}</span>
       <TmField
         id="amount"
         v-model="amount"
@@ -45,16 +45,16 @@
       <span v-if="!isRedelegation()" class="form-message">
         Available to Delegate:
         {{ getFromBalance() }}
-        {{ num.viewDenom(denom) }}s
+        {{ denom | viewDenom }}s
       </span>
       <span v-else-if="isRedelegation()" class="form-message">
         Available to Redelegate:
         {{ getFromBalance() }}
-        {{ num.viewDenom(denom) }}s
+        {{ denom | viewDenom }}s
       </span>
       <TmFormMsg
         v-if="balance === 0"
-        :msg="`doesn't have any ${num.viewDenom(denom)}s`"
+        :msg="`doesn't have any ${viewDenom(denom)}s`"
         name="Wallet"
         type="custom"
       />
@@ -82,7 +82,7 @@
 <script>
 import { mapGetters } from "vuex"
 import { between, decimal } from "vuelidate/lib/validators"
-import num, { uatoms, atoms, SMALLEST } from "src/scripts/num.js"
+import { uatoms, atoms, viewDenom, SMALLEST } from "src/scripts/num.js"
 import TmField from "src/components/common/TmField"
 import TmFormGroup from "src/components/common/TmFormGroup"
 import TmFormMsg from "src/components/common/TmFormMsg"
@@ -96,6 +96,9 @@ export default {
     TmFormGroup,
     TmFormMsg,
     ActionModal
+  },
+  filters: {
+    viewDenom
   },
   props: {
     fromOptions: {
@@ -117,11 +120,10 @@ export default {
   },
   data: () => ({
     amount: null,
-    selectedIndex: 0,
-    num
+    selectedIndex: 0
   }),
   computed: {
-    ...mapGetters([`delegates`, `session`, `bondDenom`, `modalContext`]),
+    ...mapGetters([`session`, `modalContext`]),
     balance() {
       if (!this.session.signedIn) return 0
 
@@ -157,14 +159,12 @@ export default {
       if (this.from === this.modalContext.userAddress) {
         return {
           title: `Successful delegation!`,
-          body: `You have successfully delegated your ${num.viewDenom(
-            this.denom
-          )}s`
+          body: `You have successfully delegated your ${viewDenom(this.denom)}s`
         }
       } else {
         return {
           title: `Successful redelegation!`,
-          body: `You have successfully redelegated your ${num.viewDenom(
+          body: `You have successfully redelegated your ${viewDenom(
             this.denom
           )}s`
         }
@@ -172,6 +172,7 @@ export default {
     }
   },
   methods: {
+    viewDenom,
     open() {
       this.$refs.actionModal.open()
     },

--- a/src/ActionModal/components/ModalDeposit.vue
+++ b/src/ActionModal/components/ModalDeposit.vue
@@ -17,11 +17,11 @@
       field-id="amount"
       field-label="Amount"
     >
-      <span class="input-suffix">{{ num.viewDenom(denom) }}</span>
+      <span class="input-suffix">{{ denom | viewDenom }}</span>
       <TmField id="amount" v-model="amount" type="number" />
       <TmFormMsg
         v-if="balance === 0"
-        :msg="`doesn't have any ${num.viewDenom(denom)}s`"
+        :msg="`doesn't have any ${viewDenom(denom)}s`"
         name="Wallet"
         type="custom"
       />
@@ -48,7 +48,7 @@
 
 <script>
 import { mapGetters } from "vuex"
-import num, { uatoms, atoms, SMALLEST } from "src/scripts/num.js"
+import { uatoms, atoms, viewDenom, SMALLEST } from "src/scripts/num.js"
 import { between, decimal } from "vuelidate/lib/validators"
 import TmField from "src/components/common/TmField"
 import TmFormGroup from "src/components/common/TmFormGroup"
@@ -63,6 +63,9 @@ export default {
     TmField,
     TmFormGroup,
     TmFormMsg
+  },
+  filters: {
+    viewDenom
   },
   props: {
     proposalId: {
@@ -79,11 +82,10 @@ export default {
     }
   },
   data: () => ({
-    num,
     amount: 0
   }),
   computed: {
-    ...mapGetters([`wallet`, `bondDenom`]),
+    ...mapGetters([`wallet`]),
     balance() {
       const denom = this.wallet.balances.find(b => b.denom === this.denom)
       return (denom && denom.amount) || 0
@@ -103,7 +105,7 @@ export default {
     notifyMessage() {
       return {
         title: `Successful deposit!`,
-        body: `You have successfully deposited your ${num.viewDenom(
+        body: `You have successfully deposited your ${viewDenom(
           this.denom
         )}s on proposal #${this.proposalId}`
       }
@@ -119,6 +121,7 @@ export default {
     }
   },
   methods: {
+    viewDenom,
     open() {
       this.$refs.actionModal.open()
     },

--- a/src/ActionModal/components/ModalPropose.vue
+++ b/src/ActionModal/components/ModalPropose.vue
@@ -66,7 +66,7 @@
       field-id="amount"
       field-label="Deposit"
     >
-      <span class="input-suffix">{{ num.viewDenom(denom) }}</span>
+      <span class="input-suffix">{{ denom | viewDenom }}</span>
       <TmField
         id="amount"
         v-model="amount"
@@ -75,7 +75,7 @@
       />
       <TmFormMsg
         v-if="balance === 0"
-        :msg="`doesn't have any ${num.viewDenom(denom)}s`"
+        :msg="`doesn't have any ${viewDenom(denom)}s`"
         name="Wallet"
         type="custom"
       />
@@ -109,7 +109,7 @@ import {
   between,
   decimal
 } from "vuelidate/lib/validators"
-import num, { uatoms, atoms, SMALLEST } from "src/scripts/num.js"
+import { uatoms, atoms, viewDenom, SMALLEST } from "src/scripts/num.js"
 import isEmpty from "lodash.isempty"
 import trim from "lodash.trim"
 import TmField from "src/components/common/TmField"
@@ -132,6 +132,9 @@ export default {
     TmFormGroup,
     TmFormMsg
   },
+  filters: {
+    viewDenom
+  },
   props: {
     denom: {
       type: String,
@@ -144,11 +147,10 @@ export default {
     title: ``,
     description: ``,
     type: `Text`,
-    amount: 0,
-    num
+    amount: 0
   }),
   computed: {
-    ...mapGetters([`wallet`, `bondDenom`]),
+    ...mapGetters([`wallet`]),
     balance() {
       // TODO: refactor to get the selected coin when multicoin deposit is enabled
       if (!this.wallet.loading && !!this.wallet.balances.length) {
@@ -205,6 +207,7 @@ export default {
     }
   },
   methods: {
+    viewDenom,
     open() {
       this.$refs.actionModal.open()
     },

--- a/src/ActionModal/components/SendModal.vue
+++ b/src/ActionModal/components/SendModal.vue
@@ -18,7 +18,7 @@
     >
       <TmField
         id="send-denomination"
-        :value="num.viewDenom($v.denom.$model)"
+        :value="viewDenom($v.denom.$model)"
         type="text"
         readonly
       />
@@ -68,7 +68,7 @@
       />
       <TmFormMsg
         v-if="balance === 0"
-        :msg="`doesn't have any ${num.viewDenom(denom)}s`"
+        :msg="`doesn't have any ${viewDenom(denom)}s`"
         name="Wallet"
         type="custom"
       />
@@ -126,7 +126,7 @@
 <script>
 import b32 from "scripts/b32"
 import { required, between, decimal, maxLength } from "vuelidate/lib/validators"
-import num, { uatoms, atoms, SMALLEST } from "src/scripts/num.js"
+import { uatoms, atoms, viewDenom, SMALLEST } from "src/scripts/num.js"
 import { mapGetters } from "vuex"
 import TmFormGroup from "src/components/common/TmFormGroup"
 import TmField from "src/components/common/TmField"
@@ -148,13 +148,12 @@ export default {
     address: ``,
     amount: null,
     denom: ``,
-    num,
     memo: "(Sent via Lunie)",
     max_memo_characters: 256,
     editMemo: false
   }),
   computed: {
-    ...mapGetters([`wallet`, `session`]),
+    ...mapGetters([`wallet`]),
     balance() {
       const denom = this.wallet.balances.find(b => b.denom === this.denom)
       return (denom && denom.amount) || 0
@@ -175,9 +174,9 @@ export default {
     notifyMessage() {
       return {
         title: `Successful Send`,
-        body: `Successfully sent ${+this.amount} ${num.viewDenom(
-          this.denom
-        )}s to ${this.address}`
+        body: `Successfully sent ${+this.amount} ${viewDenom(this.denom)}s to ${
+          this.address
+        }`
       }
     }
   },
@@ -187,6 +186,7 @@ export default {
     }
   },
   methods: {
+    viewDenom,
     open(denom) {
       this.denom = denom
       this.$refs.actionModal.open()

--- a/src/ActionModal/components/Steps.vue
+++ b/src/ActionModal/components/Steps.vue
@@ -4,7 +4,7 @@
       v-for="(step, i) in steps"
       :key="step"
       :title="step"
-      :active="step.toLocaleLowerCase() === active.toLocaleLowerCase()"
+      :active="step.toLocaleLowerCase() === activeStep.toLocaleLowerCase()"
       :number="i + 1"
       :include-line="i < steps.length - 1"
     />
@@ -23,8 +23,7 @@ export default {
       type: Array,
       required: true
     },
-    // active step name
-    active: {
+    activeStep: {
       type: String,
       required: true
     }

--- a/src/ActionModal/components/TableInvoice.vue
+++ b/src/ActionModal/components/TableInvoice.vue
@@ -3,32 +3,32 @@
     <ul class="table-invoice">
       <li v-if="subTotal > 0">
         <span>Subtotal</span>
-        <span>
-          {{ num.fullDecimals(subTotal) }} {{ num.viewDenom(bondDenom) }}
-        </span>
+        <span> {{ subTotal | fullDecimals }} {{ bondDenom | viewDenom }} </span>
       </li>
       <li>
         <span>Network Fee</span>
         <span>
-          {{ num.fullDecimals(estimatedFee) }}
-          {{ num.viewDenom(bondDenom) }}
+          {{ estimatedFee | fullDecimals }}
+          {{ bondDenom | viewDenom }}
         </span>
       </li>
       <li class="total-row">
         <span>Total</span>
-        <span>
-          {{ num.fullDecimals(total) }} {{ num.viewDenom(bondDenom) }}
-        </span>
+        <span> {{ total | fullDecimals }} {{ bondDenom | viewDenom }} </span>
       </li>
     </ul>
   </div>
 </template>
 <script>
-import num from "../../scripts/num.js"
+import { fullDecimals, viewDenom } from "../../scripts/num.js"
 import { mapGetters } from "vuex"
 
 export default {
   name: `table-invoice`,
+  filters: {
+    fullDecimals,
+    viewDenom
+  },
   props: {
     amount: {
       type: Number,
@@ -44,7 +44,6 @@ export default {
     }
   },
   data: () => ({
-    num,
     info: `Estimated network fees based on simulation.`
   }),
   computed: {

--- a/test/unit/specs/components/ActionModal/components/StepComponent.spec.js
+++ b/test/unit/specs/components/ActionModal/components/StepComponent.spec.js
@@ -5,7 +5,7 @@ describe(`Steps`, () => {
   let wrapper
   beforeEach(async () => {
     wrapper = mount(Steps, {
-      propsData: { steps: ["first", "second"], active: "first" }
+      propsData: { steps: ["first", "second"], activeStep: "first" }
     })
   })
 
@@ -17,7 +17,7 @@ describe(`Steps`, () => {
     expect(
       wrapper.find(".stepItem:first-child .circle--default").classes()
     ).toContain("active")
-    wrapper.setProps({ active: "second" })
+    wrapper.setProps({ activeStep: "second" })
     expect(
       wrapper.find(".stepItem:nth-child(2) .circle--default").classes()
     ).toContain("active")

--- a/test/unit/specs/components/ActionModal/components/__snapshots__/ActionModal.spec.js.snap
+++ b/test/unit/specs/components/ActionModal/components/__snapshots__/ActionModal.spec.js.snap
@@ -29,7 +29,7 @@ exports[`ActionModal should show the action modal when user has logged in with l
     </span>
      
     <steps-stub
-      active="details"
+      activestep="details"
       steps="Details,Fees,Sign"
     />
   </div>
@@ -86,7 +86,7 @@ exports[`ActionModal should show the action modal when user has logged in with l
     </span>
      
     <steps-stub
-      active="fees"
+      activestep="fees"
       steps="Details,Fees,Sign"
     />
   </div>
@@ -153,7 +153,7 @@ exports[`ActionModal should show the action modal when user has logged in with l
     </span>
      
     <steps-stub
-      active="sign"
+      activestep="sign"
       steps="Details,Fees,Sign"
     />
   </div>
@@ -224,7 +224,7 @@ exports[`ActionModal should show the action modal when user has logged in with l
     </span>
      
     <steps-stub
-      active="details"
+      activestep="details"
       steps="Details,Fees,Sign"
     />
   </div>
@@ -281,7 +281,7 @@ exports[`ActionModal should show the action modal when user has logged in with l
     </span>
      
     <steps-stub
-      active="fees"
+      activestep="fees"
       steps="Details,Fees,Sign"
     />
   </div>
@@ -348,7 +348,7 @@ exports[`ActionModal should show the action modal when user has logged in with l
     </span>
      
     <steps-stub
-      active="sign"
+      activestep="sign"
       steps="Details,Fees,Sign"
     />
   </div>
@@ -422,7 +422,7 @@ exports[`ActionModal should show the action modal when user hasn't logged in 1`]
     </span>
      
     <steps-stub
-      active="details"
+      activestep="details"
       steps="Details,Fees,Sign"
     />
   </div>

--- a/test/unit/specs/components/ActionModal/components/__snapshots__/TableInvoice.spec.js.snap
+++ b/test/unit/specs/components/ActionModal/components/__snapshots__/TableInvoice.spec.js.snap
@@ -11,9 +11,7 @@ exports[`TableInvoice should show the transaction invoice summary 1`] = `
       </span>
        
       <span>
-        
-        1.000000 STAKE
-      
+         1.000000 STAKE 
       </span>
     </li>
      
@@ -38,9 +36,7 @@ exports[`TableInvoice should show the transaction invoice summary 1`] = `
       </span>
        
       <span>
-        
-        1.030864 STAKE
-      
+         1.030864 STAKE 
       </span>
     </li>
   </ul>


### PR DESCRIPTION
**Description:**

Minor changes to clean up the vue templates

- Remove default import from num.js
- Remove method binding from data object
- Assign template filters in filter property
- Assign template methods in methods property
- Change step variable name for clarity
- Remove unused getters

Thank you! 🚀

---

For contributor:

- [ ] Added changes entries. Run `yarn changelog` for a guided process.
- [ ] Reviewed `Files changed` in the github PR explorer
- [ ] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI