### PR TITLE
Benji/2749 transaction screen validator address bug fix

### DIFF
--- a/changes/Benji_2749-Transaction-screen-validator-address-bug-fix
+++ b/changes/Benji_2749-Transaction-screen-validator-address-bug-fix
@@ -1,0 +1,1 @@
+[Changed] [#2749](https://github.com/cosmos/lunie/issues/2749) Updated how delegation transactions addresses appear in the Transactions screen. Shortened address to match @thebkr7

--- a/src/components/transactions/LiStakeTransaction.vue
+++ b/src/components/transactions/LiStakeTransaction.vue
@@ -177,7 +177,11 @@ export default {
       const validator = this.validators.find(
         c => c.operator_address === validatorAddr
       )
-      const shortenedAdd = validatorAddr.slice(0, 6) + '...' + validatorAddr.slice(-4)
+      let shortenedAdd = validatorAddr
+      if (validatorAddr) {
+        shortenedAdd =
+          validatorAddr.slice(0, 6) + "..." + validatorAddr.slice(-4)
+      }
       return validator ? validator.description.moniker : shortenedAdd
     }
   }

--- a/src/components/transactions/LiStakeTransaction.vue
+++ b/src/components/transactions/LiStakeTransaction.vue
@@ -177,7 +177,8 @@ export default {
       const validator = this.validators.find(
         c => c.operator_address === validatorAddr
       )
-      return validator ? validator.description.moniker : validatorAddr
+      const shortenedAdd = validatorAddr.slice(0, 6) + '...' + validatorAddr.slice(-4)
+      return validator ? validator.description.moniker : shortenedAdd
     }
   }
 }

--- a/src/components/transactions/LiStakeTransaction.vue
+++ b/src/components/transactions/LiStakeTransaction.vue
@@ -99,6 +99,7 @@
 <script>
 import LiTransaction from "./LiTransaction"
 import { atoms as toAtoms, viewDenom } from "../../scripts/num.js"
+import { formatBech32 } from "src/filters"
 import moment from "moment"
 
 /*
@@ -107,7 +108,9 @@ import moment from "moment"
 
 export default {
   name: `li-stake-transaction`,
-  components: { LiTransaction },
+  components: {
+    LiTransaction
+  },
   filters: {
     toAtoms,
     viewDenom
@@ -177,12 +180,8 @@ export default {
       const validator = this.validators.find(
         c => c.operator_address === validatorAddr
       )
-      let shortenedAdd = validatorAddr
-      if (validatorAddr) {
-        shortenedAdd =
-          validatorAddr.slice(0, 6) + "..." + validatorAddr.slice(-4)
-      }
-      return validator ? validator.description.moniker : shortenedAdd
+      let shortenedAddress = formatBech32(validatorAddr)
+      return validator ? validator.description.moniker : shortenedAddress
     }
   }
 }

--- a/test/unit/specs/components/transactions/__snapshots__/LiStakeTransaction.spec.js.snap
+++ b/test/unit/specs/components/transactions/__snapshots__/LiStakeTransaction.spec.js.snap
@@ -29,7 +29,7 @@ exports[`LiStakeTransaction create validator with fees 1`] = `
       to="/validator/cosmosvaloper1qecshyc40kshszkwrtscgmsdd8tz3n4hrj9yf2"
     >
       
-        cosmosvaloper1qecshyc40kshszkwrtscgmsdd8tz3n4hrj9yf2
+        cosmos...9yf2
       
     </router-link-stub>
   </div>
@@ -64,7 +64,7 @@ exports[`LiStakeTransaction create validator without fees 1`] = `
       to="/validator/cosmosvaloper1qecshyc40kshszkwrtscgmsdd8tz3n4hrj9yf2"
     >
       
-        cosmosvaloper1qecshyc40kshszkwrtscgmsdd8tz3n4hrj9yf2
+        cosmos...9yf2
       
     </router-link-stub>
   </div>
@@ -164,7 +164,7 @@ exports[`LiStakeTransaction edit validator with fees 1`] = `
       to="/validator/cosmosvaloper1qecshyc40kshszkwrtscgmsdd8tz3n4hrj9yf2"
     >
       
-        cosmosvaloper1qecshyc40kshszkwrtscgmsdd8tz3n4hrj9yf2
+        cosmos...9yf2
       
     </router-link-stub>
   </div>
@@ -192,7 +192,7 @@ exports[`LiStakeTransaction edit validator without fees 1`] = `
       to="/validator/cosmosvaloper1qecshyc40kshszkwrtscgmsdd8tz3n4hrj9yf2"
     >
       
-        cosmosvaloper1qecshyc40kshszkwrtscgmsdd8tz3n4hrj9yf2
+        cosmos...9yf2
       
     </router-link-stub>
   </div>
@@ -483,7 +483,7 @@ exports[`LiStakeTransaction unjail with fees 1`] = `
       to="/validator/cosmosvaloper1qecshyc40kshszkwrtscgmsdd8tz3n4hrj9yf2"
     >
       
-        cosmosvaloper1qecshyc40kshszkwrtscgmsdd8tz3n4hrj9yf2
+        cosmos...9yf2
       
     </router-link-stub>
   </div>
@@ -511,7 +511,7 @@ exports[`LiStakeTransaction unjail without fees 1`] = `
       to="/validator/cosmosvaloper1qecshyc40kshszkwrtscgmsdd8tz3n4hrj9yf2"
     >
       
-        cosmosvaloper1qecshyc40kshszkwrtscgmsdd8tz3n4hrj9yf2
+        cosmos...9yf2
       
     </router-link-stub>
   </div>

--- a/test/unit/specs/components/transactions/__snapshots__/LiStakeTransaction.spec.js.snap
+++ b/test/unit/specs/components/transactions/__snapshots__/LiStakeTransaction.spec.js.snap
@@ -29,7 +29,7 @@ exports[`LiStakeTransaction create validator with fees 1`] = `
       to="/validator/cosmosvaloper1qecshyc40kshszkwrtscgmsdd8tz3n4hrj9yf2"
     >
       
-        cosmos...9yf2
+        cosmosvaloper…9yf2
       
     </router-link-stub>
   </div>
@@ -64,7 +64,7 @@ exports[`LiStakeTransaction create validator without fees 1`] = `
       to="/validator/cosmosvaloper1qecshyc40kshszkwrtscgmsdd8tz3n4hrj9yf2"
     >
       
-        cosmos...9yf2
+        cosmosvaloper…9yf2
       
     </router-link-stub>
   </div>
@@ -164,7 +164,7 @@ exports[`LiStakeTransaction edit validator with fees 1`] = `
       to="/validator/cosmosvaloper1qecshyc40kshszkwrtscgmsdd8tz3n4hrj9yf2"
     >
       
-        cosmos...9yf2
+        cosmosvaloper…9yf2
       
     </router-link-stub>
   </div>
@@ -192,7 +192,7 @@ exports[`LiStakeTransaction edit validator without fees 1`] = `
       to="/validator/cosmosvaloper1qecshyc40kshszkwrtscgmsdd8tz3n4hrj9yf2"
     >
       
-        cosmos...9yf2
+        cosmosvaloper…9yf2
       
     </router-link-stub>
   </div>
@@ -483,7 +483,7 @@ exports[`LiStakeTransaction unjail with fees 1`] = `
       to="/validator/cosmosvaloper1qecshyc40kshszkwrtscgmsdd8tz3n4hrj9yf2"
     >
       
-        cosmos...9yf2
+        cosmosvaloper…9yf2
       
     </router-link-stub>
   </div>
@@ -511,7 +511,7 @@ exports[`LiStakeTransaction unjail without fees 1`] = `
       to="/validator/cosmosvaloper1qecshyc40kshszkwrtscgmsdd8tz3n4hrj9yf2"
     >
       
-        cosmos...9yf2
+        cosmosvaloper…9yf2
       
     </router-link-stub>
   </div>


### PR DESCRIPTION
Closes #2749

**Description:**

Adds abbreviated validator addresses in the transaction component. This will also reflect in the extension as the addresses would overflow the screen.

Thank you! 🚀

---

For contributor:

- [x] Added changes entries. Run `yarn changelog` for a guided process.
- [x] Reviewed `Files changed` in the github PR explorer
- [ ] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI
