### PR TITLE
Benji/ext 30 validators monikers fix

### DIFF
--- a/changes/Benji_Ext-30-Validators-Monikers-Fix
+++ b/changes/Benji_Ext-30-Validators-Monikers-Fix
@@ -1,0 +1,1 @@
+[Fixed] [#Ext:30](https://github.com/cosmos/lunie/issues/Ext:30) Passes delegates to chrome extension components so that SessionApprove can access the Moniker.  @thebkr7

--- a/src/ActionModal/components/ActionModal.vue
+++ b/src/ActionModal/components/ActionModal.vue
@@ -457,7 +457,7 @@ export default {
       }
 
       try {
-        await this.actionManager.send(memo, feeProperties)
+        await this.actionManager.send(memo, feeProperties, this.transactionData.valdiators)        
         this.trackEvent(
           `event`,
           `successful-submit`,

--- a/src/ActionModal/components/ActionModal.vue
+++ b/src/ActionModal/components/ActionModal.vue
@@ -457,7 +457,11 @@ export default {
       }
 
       try {
-        await this.actionManager.send(memo, feeProperties, this.transactionData.valdiators)        
+        await this.actionManager.send(
+          memo,
+          feeProperties,
+          this.transactionData.valdiators
+        )
         this.trackEvent(
           `event`,
           `successful-submit`,

--- a/src/ActionModal/components/ActionModal.vue
+++ b/src/ActionModal/components/ActionModal.vue
@@ -460,7 +460,7 @@ export default {
         await this.actionManager.send(
           memo,
           feeProperties,
-          this.transactionData.valdiators
+          this.transactionData.validators
         )
         this.trackEvent(
           `event`,

--- a/src/ActionModal/components/DelegationModal.vue
+++ b/src/ActionModal/components/DelegationModal.vue
@@ -124,7 +124,8 @@ export default {
     amount: null,
     selectedIndex: 0
   }),
-  computed: {...mapGetters([`session`, `modalContext`, `delegates`]),
+  computed: {
+    ...mapGetters([`session`, `modalContext`, `delegates`]),
     balance() {
       if (!this.session.signedIn) return 0
 

--- a/src/ActionModal/components/DelegationModal.vue
+++ b/src/ActionModal/components/DelegationModal.vue
@@ -124,8 +124,7 @@ export default {
     amount: null,
     selectedIndex: 0
   }),
-  computed: {
-    ...mapGetters([`session`, `modalContext`]),
+  computed: {...mapGetters([`session`, `modalContext`, `delegates`]),
     balance() {
       if (!this.session.signedIn) return 0
 
@@ -142,7 +141,8 @@ export default {
           type: transaction.DELEGATE,
           validator_address: this.validator.operator_address,
           amount: uatoms(this.amount),
-          denom: this.denom
+          denom: this.denom,
+          valdiators: this.delegates.delegates
         }
       } else {
         const validatorSrc = this.modalContext.delegates.find(
@@ -153,7 +153,8 @@ export default {
           validator_src_address: validatorSrc.operator_address,
           validator_dst_address: this.validator.operator_address,
           amount: uatoms(this.amount),
-          denom: this.denom
+          denom: this.denom,
+          valdiators: this.delegates.delegates
         }
       }
     },

--- a/src/ActionModal/components/DelegationModal.vue
+++ b/src/ActionModal/components/DelegationModal.vue
@@ -143,7 +143,7 @@ export default {
           validator_address: this.validator.operator_address,
           amount: uatoms(this.amount),
           denom: this.denom,
-          valdiators: this.delegates.delegates
+          validators: this.delegates.delegates
         }
       } else {
         const validatorSrc = this.modalContext.delegates.find(
@@ -155,7 +155,7 @@ export default {
           validator_dst_address: this.validator.operator_address,
           amount: uatoms(this.amount),
           denom: this.denom,
-          valdiators: this.delegates.delegates
+          validators: this.delegates.delegates
         }
       }
     },

--- a/src/ActionModal/components/UndelegationModal.vue
+++ b/src/ActionModal/components/UndelegationModal.vue
@@ -115,13 +115,14 @@ export default {
     num
   }),
   computed: {
-    ...mapGetters([`liquidAtoms`]),
+    ...mapGetters([`liquidAtoms`, `delegates`]),
     transactionData() {
       return {
         type: transaction.UNDELEGATE,
         validator_address: this.validator.operator_address,
         amount: uatoms(this.amount),
-        denom: this.denom
+        denom: this.denom,
+        valdiators: this.delegates.delegates
       }
     },
     notifyMessage() {

--- a/src/ActionModal/components/UndelegationModal.vue
+++ b/src/ActionModal/components/UndelegationModal.vue
@@ -122,7 +122,7 @@ export default {
         validator_address: this.validator.operator_address,
         amount: uatoms(this.amount),
         denom: this.denom,
-        valdiators: this.delegates.delegates
+        validators: this.delegates.delegates
       }
     },
     notifyMessage() {

--- a/src/ActionModal/utils/ActionManager.js
+++ b/src/ActionModal/utils/ActionManager.js
@@ -67,13 +67,14 @@ export default class ActionManager {
     return gasEstimate
   }
 
-  async send(memo, txMetaData) {
+  async send(memo, txMetaData, delegates) {
     this.readyCheck()
 
     const { gasEstimate, gasPrice, submitType, password } = txMetaData
     const signer = getSigner(config, submitType, {
       address: this.context.userAddress,
-      password
+      password,
+      delegates: delegates
     })
 
     if (this.messageType === transaction.WITHDRAW) {

--- a/src/ActionModal/utils/signer.js
+++ b/src/ActionModal/utils/signer.js
@@ -2,7 +2,11 @@ import Ledger from "@lunie/cosmos-ledger"
 import { signWithPrivateKey, getStoredWallet } from "@lunie/cosmos-keys"
 import { sign } from "src/scripts/extension-utils"
 
-export function getSigner(config, submitType = "", { address, password, delegates }) {
+export function getSigner(
+  config,
+  submitType = "",
+  { address, password, delegates }
+) {
   if (submitType === `local`) {
     const wallet = getStoredWallet(address, password)
     return signMessage => {

--- a/src/ActionModal/utils/signer.js
+++ b/src/ActionModal/utils/signer.js
@@ -2,7 +2,7 @@ import Ledger from "@lunie/cosmos-ledger"
 import { signWithPrivateKey, getStoredWallet } from "@lunie/cosmos-keys"
 import { sign } from "src/scripts/extension-utils"
 
-export function getSigner(config, submitType = "", { address, password }) {
+export function getSigner(config, submitType = "", { address, password, delegates }) {
   if (submitType === `local`) {
     const wallet = getStoredWallet(address, password)
     return signMessage => {
@@ -10,7 +10,7 @@ export function getSigner(config, submitType = "", { address, password }) {
         signMessage,
         Buffer.from(wallet.privateKey, "hex")
       )
-
+      
       return {
         signature,
         publicKey: Buffer.from(wallet.publicKey, "hex")
@@ -29,7 +29,7 @@ export function getSigner(config, submitType = "", { address, password }) {
     }
   } else if (submitType === `extension`) {
     return signMessage => {
-      return sign(signMessage, address)
+      return sign(signMessage, address, delegates)
     }
   }
 }

--- a/src/components/common/SessionApprove.vue
+++ b/src/components/common/SessionApprove.vue
@@ -115,7 +115,7 @@ export default {
     senderAddress() {
       return this.signRequest ? this.signRequest.senderAddress : null
     },
-    deligates() {
+    delegates() {
       return this.tx ? this.tx.tx.value.delegates : null
     }
   },

--- a/src/components/common/SessionApprove.vue
+++ b/src/components/common/SessionApprove.vue
@@ -7,7 +7,7 @@
     <TmFormGroup field-id="to" field-label="Your address">
       <LiAnyTransaction
         v-if="tx"
-        :validators="deligates"
+        :validators="delegates"
         :transaction="tx"
         :hide-meta-data="true"
         validators-url="/"

--- a/src/components/common/SessionApprove.vue
+++ b/src/components/common/SessionApprove.vue
@@ -75,7 +75,7 @@ import { required } from "vuelidate/lib/validators"
 // TODO move into own helper file
 // Parse into Lunie tx format from signMessage to display tx properly
 function parseTx(signMessage) {
-  const { msgs, fee, memo } = JSON.parse(signMessage)
+  const { msgs, fee, memo, delegates } = JSON.parse(signMessage)
 
   return {
     tx: {
@@ -83,7 +83,8 @@ function parseTx(signMessage) {
       value: {
         msg: msgs,
         fee,
-        memo
+        memo,
+        delegates
       }
     }
   }
@@ -101,7 +102,6 @@ export default {
     TmFormMsg
   },
   data: () => ({
-    deligates: [],
     password: null
   }),
   computed: {
@@ -114,6 +114,9 @@ export default {
     },
     senderAddress() {
       return this.signRequest ? this.signRequest.senderAddress : null
+    },
+    deligates() {
+      return this.tx ? this.tx.tx.value.delegates : null
     }
   },
   methods: {

--- a/src/scripts/extension-utils.js
+++ b/src/scripts/extension-utils.js
@@ -48,13 +48,14 @@ export const getWallets = () => {
   sendMessageToContentScript({ type: "GET_WALLETS" })
 }
 
-export const sign = (signMessage, senderAddress) => {
+export const sign = (signMessage, senderAddress, delegates) => {
   sendMessageToContentScript(
     {
       type: "LUNIE_SIGN_REQUEST",
       payload: {
         signMessage,
-        senderAddress
+        senderAddress,
+        delegates
       }
     },
     true


### PR DESCRIPTION
Closes #ISSUE

Passes delegates to chrome extension components so that SessionApprove can access the Moniker. There is a more efficient way of only passing the Moniker rather than passing all the delegates and filtering them in LiStakeTransaction but this would take reworking how that side of Lunie.io works.

Thank you! 🚀

---

For contributor:

- [x] Added changes entries. Run `yarn changelog` for a guided process.
- [x] Reviewed `Files changed` in the github PR explorer
- [ ] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI
