### PR TITLE
Benji/SessionAccounts add "Add Account" button

### DIFF
--- a/changes/Benji_SessionAccounts-add-AddAccount-Button
+++ b/changes/Benji_SessionAccounts-add-AddAccount-Button
@@ -1,0 +1,1 @@
+[Added] Adds a button to SessionAccounts to Add Account and includes a test @thebkr7

--- a/src/components/common/SessionAccounts.vue
+++ b/src/components/common/SessionAccounts.vue
@@ -18,20 +18,20 @@
         </div>
       </div>
     </div>
-    <!-- <div class="button-add-account">
-      <TmBtn value="Add Account" color="primary" />
-    </div> -->
+    <div class="button-add-account">
+      <TmBtn value="Add Account" color="primary" @click.native="addAccount" />
+    </div>
   </div>
 </template>
 
 <script>
-// import TmBtn from "common/TmBtn"
+import TmBtn from "common/TmBtn"
 import Bech32 from "common/Bech32"
 export default {
   name: `session-accounts`,
   components: {
-    Bech32
-    // TmBtn
+    Bech32,
+    TmBtn
   },
   computed: {
     accounts() {
@@ -40,6 +40,11 @@ export default {
         address,
         name
       }))
+    }
+  },
+  methods: {
+    addAccount() {
+      this.$router.push(`/welcome`)
     }
   }
 }

--- a/test/unit/specs/components/common/SessionAccounts.spec.js
+++ b/test/unit/specs/components/common/SessionAccounts.spec.js
@@ -35,4 +35,12 @@ describe(`SessionAccounts`, () => {
   it(`renders the correct account`, () => {
     expect(wrapper.html()).toContain("Benjis account")
   })
+
+  it(`opens session modal and closes itself`, () => {
+    const $store = { commit: jest.fn() }
+    const self = { $store, $router: { push: jest.fn() } }
+    SessionAccounts.methods.addAccount.call(self)
+    // expect(self.close).toHaveBeenCalled()
+    expect(self.$router.push).toHaveBeenCalledWith(`/welcome`)
+  })
 })

--- a/test/unit/specs/components/common/SessionAccounts.spec.js
+++ b/test/unit/specs/components/common/SessionAccounts.spec.js
@@ -36,7 +36,7 @@ describe(`SessionAccounts`, () => {
     expect(wrapper.html()).toContain("Benjis account")
   })
 
-  it(`opens session modal and closes itself`, () => {
+  it(`links to the welcome screen`, () => {
     const self = { $store, $router: { push: jest.fn() } }
     SessionAccounts.methods.addAccount.call(self)
     expect(self.$router.push).toHaveBeenCalledWith(`/welcome`)

--- a/test/unit/specs/components/common/SessionAccounts.spec.js
+++ b/test/unit/specs/components/common/SessionAccounts.spec.js
@@ -37,10 +37,8 @@ describe(`SessionAccounts`, () => {
   })
 
   it(`opens session modal and closes itself`, () => {
-    const $store = { commit: jest.fn() }
     const self = { $store, $router: { push: jest.fn() } }
     SessionAccounts.methods.addAccount.call(self)
-    // expect(self.close).toHaveBeenCalled()
     expect(self.$router.push).toHaveBeenCalledWith(`/welcome`)
   })
 })

--- a/test/unit/specs/components/common/__snapshots__/SessionAccounts.spec.js.snap
+++ b/test/unit/specs/components/common/__snapshots__/SessionAccounts.spec.js.snap
@@ -46,5 +46,14 @@ exports[`SessionAccounts has the expected html structure 1`] = `
       </div>
     </div>
   </div>
+   
+  <div
+    class="button-add-account"
+  >
+    <tmbtn-stub
+      color="primary"
+      value="Add Account"
+    />
+  </div>
 </div>
 `;


### PR DESCRIPTION
**Description:**

A simple change that adds the Add Account button to SessionAccounts for the chrome extension. When clicked it navigates the user to /welcome. Also includes an added test

![image](https://user-images.githubusercontent.com/11528441/60731317-4444cd00-9f15-11e9-9f9e-6c4177e316c7.png)

Thank you! 🚀

---

For contributor:

- [x] Added changes entries. Run `yarn changelog` for a guided process.
- [x] Reviewed `Files changed` in the github PR explorer
- [x] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI
