### PR TITLE
Fabo/handle errors from extension

### DIFF
--- a/changes/fabo_propper-handling-of-extension-errors
+++ b/changes/fabo_propper-handling-of-extension-errors
@@ -1,0 +1,1 @@
+[Fixed] [#2835](https://github.com/cosmos/lunie/pull/2835) Errors from extension were not handled in async requests @faboweb

--- a/src/scripts/extension-utils.js
+++ b/src/scripts/extension-utils.js
@@ -58,6 +58,9 @@ function waitForResponse(type) {
       if (message.type === type) {
         resolve(message.payload)
       }
+
+      // cleanup
+      window.removeEventListener("message", handler)
     })
     window.addEventListener("message", handler)
   })
@@ -65,12 +68,15 @@ function waitForResponse(type) {
 
 const sendAsyncMessageToContentScript = async payload => {
   // I think we can deal with async console errors problems by returning true
-  sendMessageToContentScript(payload, false)
+  sendMessageToContentScript(payload, true)
 
   // await async response
   const response = await waitForResponse(`${payload.type}_RESPONSE`)
   if (response.rejected) {
     throw new Error("User rejected action in extension.")
+  }
+  if (response.error) {
+    throw new Error(response.error)
   }
   return response
 }

--- a/test/unit/specs/scripts/extension-utils.spec.js
+++ b/test/unit/specs/scripts/extension-utils.spec.js
@@ -138,7 +138,7 @@ describe(`Extension Utils`, () => {
                 },
                 type: "LUNIE_SIGN_REQUEST"
               },
-              skipResponse: false,
+              skipResponse: true,
               type: "FROM_LUNIE_IO"
             },
             "*"
@@ -164,6 +164,24 @@ describe(`Extension Utils`, () => {
         expect(signWithExtension("abc")).rejects.toThrow(
           "User rejected action in extension."
         )
+      })
+
+      it("should react to errors in extension", () => {
+        global.addEventListener.mockImplementationOnce((type, callback) => {
+          callback({
+            source: global,
+            data: {
+              message: {
+                payload: {
+                  error: "Expected"
+                },
+                type: "LUNIE_SIGN_REQUEST_RESPONSE"
+              },
+              type: "FROM_LUNIE_EXTENSION"
+            }
+          })
+        })
+        expect(signWithExtension("abc")).rejects.toThrow("Expected")
       })
 
       it("should react to signature approval", async () => {


### PR DESCRIPTION
Handles an error (wallet not found) and potential future errors

Closes https://github.com/luniehq/lunie-browser-extension/issues/47