### PR TITLE
Add provided STARGATE and RPC url's to connect-src list

### DIFF
--- a/changes/develop
+++ b/changes/develop
@@ -1,0 +1,1 @@
+[Changed] [#2839](https://github.com/cosmos/lunie/pull/2839) Add provided RPC and STARGATE URL's to Content-Security-Policy connect-src list @asoltys

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -222,7 +222,11 @@ if (process.env.NODE_ENV === `production`) {
           `wss://rpc.cosmos.network:26657`,
           // testnet
           `https://sntajlxzsg.execute-api.eu-central-1.amazonaws.com/`,
-          `wss://test.voyager.ninja:26657`
+          `wss://test.voyager.ninja:26657`,
+          ...[process.env.STARGATE].filter(x => x !== undefined),
+          ...[process.env.RPC]
+            .filter(x => x !== undefined)
+            .map(x => x.replace("https", "wss"))
         ],
         "frame-src": [`'self'`, `https://app.appzi.io/`],
         "img-src": [


### PR DESCRIPTION
When providing custom server URL's to the build:ui command via the STARGATE and RPC environment variables, let webpack also add them to the list of connect-src's in the Content-Secrity-Policy.

Replaces https:// with wss:// for the RPC url.