### PR TITLE
colw/Reduce lag when switching staking tabs.

### DIFF
--- a/changes/colw_staking-perf
+++ b/changes/colw_staking-perf
@@ -1,0 +1,1 @@
+[Changed] [#2870](https://github.com/cosmos/lunie/pull/2870) Keep staking tabs in memory even when switching between them @colw

--- a/src/components/staking/PageStaking.vue
+++ b/src/components/staking/PageStaking.vue
@@ -1,6 +1,8 @@
 <template>
   <TmPage :tabs="tabs" class="staking" data-title="Staking">
-    <router-view />
+    <keep-alive>
+      <router-view />
+    </keep-alive>
   </TmPage>
 </template>
 

--- a/tests/unit/specs/components/staking/__snapshots__/PageStaking.spec.js.snap
+++ b/tests/unit/specs/components/staking/__snapshots__/PageStaking.spec.js.snap
@@ -8,6 +8,8 @@ exports[`PageStaking has the expected html structure 1`] = `
   tabs="[object Object],[object Object],[object Object]"
   title=""
 >
-  <router-view-stub />
+  <keep-alive-stub>
+    <router-view-stub />
+  </keep-alive-stub>
 </tmpage-stub>
 `;


### PR DESCRIPTION
**Description:**

Keep validator list in memory.

This wraps the router-view with the `<keep-alive>` component which keeps dynamic components in memory when switched out.

Thank you! 🚀

---

For contributor:

- [ ] Added changes entries. Run `yarn changelog` for a guided process.
- [ ] Reviewed `Files changed` in the github PR explorer
- [ ] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI
