### PR TITLE
colw/Include option to set Graphql endpoint in URL

### DIFF
--- a/changes/colw_url-param-graphql-endpoint
+++ b/changes/colw_url-param-graphql-endpoint
@@ -1,0 +1,1 @@
+[Added] [#2896](https://github.com/cosmos/lunie/pull/2896) Allow user to set graphql endpoint as a URL parametera @colw

--- a/src/gql/apollo.js
+++ b/src/gql/apollo.js
@@ -3,15 +3,17 @@ import ApolloClient from "apollo-boost"
 import { InMemoryCache } from "apollo-cache-inmemory"
 import VueApollo from "vue-apollo"
 
-const apolloClient = new ApolloClient({
-  uri: process.env.VUE_APP_GRAPHQL_URL
-})
-
 Vue.use(VueApollo)
 
-const apolloProvider = new VueApollo({
-  defaultClient: apolloClient,
-  cache: new InMemoryCache()
-})
+const createApolloClient = urlParams => {
+  return new ApolloClient({
+    uri: urlParams.graphql || process.env.VUE_APP_GRAPHQL_URL
+  })
+}
 
-export default apolloProvider
+export const createApolloProvider = urlParams => {
+  return new VueApollo({
+    defaultClient: createApolloClient(urlParams),
+    cache: new InMemoryCache()
+  })
+}

--- a/src/main.js
+++ b/src/main.js
@@ -6,7 +6,7 @@ import Vuelidate from "vuelidate"
 import InfiniteScroll from "vue-infinite-scroll"
 import VueClipboard from "vue-clipboard2"
 import { focusElement, focusParentLast } from "src/directives"
-import apolloProvider from "src/gql/apollo.js"
+import { createApolloProvider } from "src/gql/apollo.js"
 import App from "./App.vue"
 import init from "./initializeApp"
 import { getURLParams } from "scripts/url"
@@ -24,6 +24,7 @@ Vue.directive(`focus`, focusElement)
 Vue.directive(`focus-last`, focusParentLast)
 
 const urlParams = getURLParams(window)
+const apolloProvider = createApolloProvider(urlParams)
 const { store, router } = init(urlParams)
 
 new Vue({

--- a/src/scripts/url.js
+++ b/src/scripts/url.js
@@ -2,7 +2,9 @@ export function getURLParams(window, env = process.env.NODE_ENV) {
   const queries = window.location.search.slice(1).split(`&`)
   const parameters = queries.reduce((config, current) => {
     const [name, value] = current.split(`=`)
-    if ([`stargate`, `rpc`, `experimental`, `insecure`].includes(name)) {
+    if (
+      [`stargate`, `rpc`, `experimental`, `insecure`, `graphql`].includes(name)
+    ) {
       return {
         ...config,
         [name]: value


### PR DESCRIPTION
**Description:**

Allows a user to set the graphql endpoint

Usage:

```
https://www.lunie.io/?graphql=https://backend.lunie.io/v1/graphql
```

Thank you! 🚀

---

For contributor:

- [ ] Added changes entries. Run `yarn changelog` for a guided process.
- [ ] Reviewed `Files changed` in the github PR explorer
- [ ] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI
