### PR TITLE
Fabo/fixed bad validator image size

### DIFF
--- a/changes/fabo_fix-valdiator-img-firefox
+++ b/changes/fabo_fix-valdiator-img-firefox
@@ -1,0 +1,1 @@
+[Fixed] [#2910](https://github.com/cosmos/lunie/pull/2910) Fixed bad validator image sizing @faboweb

--- a/src/components/staking/LiValidator.vue
+++ b/src/components/staking/LiValidator.vue
@@ -149,7 +149,7 @@ export default {
 .li-validator-image {
   border-radius: 0.25rem;
   height: 2.5rem;
-  min-width: 2.5rem;
+  width: 2.5rem;
   border: 1px solid var(--bc-dim);
 }
 </style>


### PR DESCRIPTION
Before
![image](https://user-images.githubusercontent.com/5869273/63723316-698af300-c855-11e9-9cf0-005da852f92f.png)

After
![image](https://user-images.githubusercontent.com/5869273/63723332-7576b500-c855-11e9-950f-644b4f0f7487.png)

**Description:**

<!-- Briefly describe what you're adding or fixing with this PR -->

Thank you! 🚀

---

For contributor:

- [ ] Added changes entries. Run `yarn changelog` for a guided process.
- [ ] Reviewed `Files changed` in the github PR explorer
- [ ] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI
