### PR TITLE
Mario/2671 show validator rank

### DIFF
--- a/changes/mario_2671-show-validator-rank
+++ b/changes/mario_2671-show-validator-rank
@@ -1,0 +1,1 @@
+[Added] [#2671](https://github.com/cosmos/lunie/issues/2671) Show validator rank number in Validator list @mariopino

--- a/src/components/staking/LiValidator.vue
+++ b/src/components/staking/LiValidator.vue
@@ -68,7 +68,7 @@ export default {
       required: true
     },
     index: {
-      type: Object,
+      type: Number,
       required: true
     },
     showOnMobile: {

--- a/src/components/staking/LiValidator.vue
+++ b/src/components/staking/LiValidator.vue
@@ -9,6 +9,7 @@
       })
     "
   >
+    <td>{{ index+1 }}</td>
     <td class="data-table__row__info">
       <Avatar
         v-if="!validator || !validator.avatarUrl"
@@ -63,6 +64,10 @@ export default {
   },
   props: {
     validator: {
+      type: Object,
+      required: true
+    },
+    index: {
       type: Object,
       required: true
     },

--- a/src/components/staking/PageValidator.vue
+++ b/src/components/staking/PageValidator.vue
@@ -15,7 +15,6 @@
           {{ status }}
         </span>
       </div>
-
       <tr class="li-validator">
         <td class="data-table__row__info">
           <Avatar

--- a/src/components/staking/PanelSort.vue
+++ b/src/components/staking/PanelSort.vue
@@ -1,6 +1,6 @@
 <template>
   <tr class="panel-sort-container">
-    <th width="20">#</th>
+    <th>#</th>
     <th
       v-for="property in properties"
       :key="property.value"

--- a/src/components/staking/PanelSort.vue
+++ b/src/components/staking/PanelSort.vue
@@ -1,5 +1,6 @@
 <template>
   <tr class="panel-sort-container">
+    <th width="20">#</th>
     <th
       v-for="property in properties"
       :key="property.value"

--- a/src/components/staking/TableValidators.vue
+++ b/src/components/staking/TableValidators.vue
@@ -10,8 +10,9 @@
       </thead>
       <tbody v-infinite-scroll="loadMore" infinite-scroll-distance="400">
         <LiValidator
-          v-for="validator in showingValidators"
+          v-for="(validator, index) in showingValidators"
           :key="validator.operator_address"
+          :index="index"
           :validator="validator"
           :show-on-mobile="showOnMobile"
         />

--- a/src/styles/table.css
+++ b/src/styles/table.css
@@ -15,6 +15,7 @@
 
 .data-table th:first-child {
   width: 10%;
+  color: var(--dim);
 }
 
 .data-table th:nth-child(2) {

--- a/src/styles/table.css
+++ b/src/styles/table.css
@@ -14,7 +14,11 @@
 }
 
 .data-table th:first-child {
-  width: 65%;
+  width: 10%;
+}
+
+.data-table th:nth-child(2) {
+  width: 55%;
 }
 
 .data-table th {

--- a/tests/unit/specs/components/staking/LiValidator.spec.js
+++ b/tests/unit/specs/components/staking/LiValidator.spec.js
@@ -41,6 +41,8 @@ describe(`LiValidator`, () => {
     expectedReturns: 0.13
   }
 
+  const index = 1;
+
   beforeEach(() => {
     $store = {
       state: {
@@ -56,6 +58,7 @@ describe(`LiValidator`, () => {
       localVue,
       propsData: {
         validator,
+        index,
         showOnMobile: "returns"
       },
       mocks: {

--- a/tests/unit/specs/components/staking/__snapshots__/LiValidator.spec.js.snap
+++ b/tests/unit/specs/components/staking/__snapshots__/LiValidator.spec.js.snap
@@ -5,6 +5,10 @@ exports[`LiValidator has the expected html structure 1`] = `
   class="li-validator"
   data-moniker="mr_mounty"
 >
+  <td>
+    2
+  </td>
+   
   <td
     class="data-table__row__info"
   >

--- a/tests/unit/specs/components/staking/__snapshots__/PanelSort.spec.js.snap
+++ b/tests/unit/specs/components/staking/__snapshots__/PanelSort.spec.js.snap
@@ -4,6 +4,10 @@ exports[`PanelSort has the expected html structure 1`] = `
 <tr
   class="panel-sort-container"
 >
+  <th>
+    #
+  </th>
+   
   <th
     class="panel-sort-table-header sort-by hide-xs"
   >

--- a/tests/unit/specs/components/staking/__snapshots__/TableValidators.spec.js.snap
+++ b/tests/unit/specs/components/staking/__snapshots__/TableValidators.spec.js.snap
@@ -17,22 +17,27 @@ exports[`TableValidators shows a validator table 1`] = `
       infinite-scroll-distance="400"
     >
       <livalidator-stub
+        index="0"
         showonmobile="returns"
         validator="[object Object]"
       />
       <livalidator-stub
+        index="1"
         showonmobile="returns"
         validator="[object Object]"
       />
       <livalidator-stub
+        index="2"
         showonmobile="returns"
         validator="[object Object]"
       />
       <livalidator-stub
+        index="3"
         showonmobile="returns"
         validator="[object Object]"
       />
       <livalidator-stub
+        index="4"
         showonmobile="returns"
         validator="[object Object]"
       />


### PR DESCRIPTION
Closes #2671 

**Description:**

Add a column on the left hand side of the validator table that include the row number. Works in portfolio tab too.

Thank you! 🚀

---

For contributor:

- [ ] Added changes entries. Run `yarn changelog` for a guided process.
- [ ] Reviewed `Files changed` in the github PR explorer
- [ ] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI
