### PR TITLE
Mario/2858 add warning field backend

### DIFF
--- a/changes/mario_2858-add-warning-field-backend
+++ b/changes/mario_2858-add-warning-field-backend
@@ -1,0 +1,1 @@
+[Added] [#2858](https://github.com/cosmos/lunie/issues/2858) Add warning field to backend @mariopino

--- a/src/components/common/MaintenanceBar.vue
+++ b/src/components/common/MaintenanceBar.vue
@@ -63,16 +63,6 @@ export default {
   color: var(--bright);
 }
 
- /* don't change - should be consistent across themes */
-  --input-bg: transparent;
-  --success: hsl(120, 58%, 50%);
-  --success-bc: hsl(120, 58%, 41%);
-  --warning: hsl(35, 100%, 50%);
-  --warning-bc: hsl(35, 75%, 38%);
-  --danger: hsl(0, 100%, 55%);
-  --danger-bc: hsl(0, 100%, 41%);
-  --tendermint: #5ead37;
-
 .maintenance-bar.success {
   background-color: var(--success);
 }

--- a/src/components/common/MaintenanceBar.vue
+++ b/src/components/common/MaintenanceBar.vue
@@ -1,6 +1,6 @@
 <template>
   <div v-if="maintenance.length > 0">
-    <div v-for="message in maintenance">
+    <div v-for="message in maintenance" v-bind:key="message">
       <div v-if="message.show" class="maintenance-bar" v-bind:class="message.type">
         <i></i>
         <p>
@@ -21,7 +21,7 @@ export default {
   data: () => ({
     maintenance: []
   }),
-  methods: { 
+  methods: {
     close(message) {
       message.show = false
     }
@@ -37,7 +37,7 @@ export default {
           }
         }
       `,
-      update: result => result.maintenance,
+      update: result => result.maintenance
     }
   }
 }

--- a/src/components/common/MaintenanceBar.vue
+++ b/src/components/common/MaintenanceBar.vue
@@ -25,7 +25,7 @@
 
 <script>
 import { mapState } from "vuex"
-import { Maintenance, MaintenanceResult } from "src/gql"
+import gql from "graphql-tag"
 export default {
   name: `maintenance-bar`,
   data: () => ({
@@ -41,9 +41,24 @@ export default {
     }
   },
   apollo: {
+    // They key is the name of the data property
+    // on the component that you intend to populate.
     maintenance: {
-      query: Maintenance,
-      update: MaintenanceResult
+      // Yes, this looks confusing.
+      // It's just normal GraphQL.
+      query: gql`
+        query Maintenance {
+          maintenance {
+            message
+            type
+          }
+        }
+      `,
+
+      // Apollo maps results to the name of the query, for caching.
+      // So to update the right property on the componet, you need to
+      // select the property of the result with the name of the query.
+      update: result => result.maintenance,
     }
   }
 }

--- a/src/components/common/MaintenanceBar.vue
+++ b/src/components/common/MaintenanceBar.vue
@@ -11,10 +11,10 @@
         <i class="material-icons" @click="close">close</i>
       </a>
     </div>
-    <div v-if="maintenance.length > 0" class="maintenance-bar" v-bind:class="maintenance.type">
+    <div v-if="maintenance.length > 0" class="maintenance-bar" v-bind:class="maintenance[0].type">
       <i></i>
       <p>
-        {{ maintenance.message }}
+        {{ maintenance[0].message }}
       </p>
       <a class="close">
         <i class="material-icons" @click="close">close</i>

--- a/src/components/common/MaintenanceBar.vue
+++ b/src/components/common/MaintenanceBar.vue
@@ -1,6 +1,6 @@
 <template>
   <div v-if="maintenance.length > 0">
-    <div v-for="message in maintenance" v-bind:key="message">
+    <div v-for="message in maintenance">
       <div v-if="message.show" class="maintenance-bar" v-bind:class="message.type">
         <i></i>
         <p>

--- a/src/components/common/MaintenanceBar.vue
+++ b/src/components/common/MaintenanceBar.vue
@@ -108,6 +108,14 @@ export default {
     bottom: 72px;
   }
 
+  .message-4 {
+    bottom: 108px;
+  }
+
+  .message-5 {
+    bottom: 144px;
+  }
+
   .hide-on-mobile {
     display: none;
   }

--- a/src/components/common/MaintenanceBar.vue
+++ b/src/components/common/MaintenanceBar.vue
@@ -25,7 +25,7 @@
 
 <script>
 import { mapState } from "vuex"
-import { Maintenance } from "src/gql"
+import { Maintenance, MaintenanceResult } from "src/gql"
 export default {
   name: `maintenance-bar`,
   data: () => ({

--- a/src/components/common/MaintenanceBar.vue
+++ b/src/components/common/MaintenanceBar.vue
@@ -29,7 +29,8 @@ import { Maintenance } from "src/gql"
 export default {
   name: `maintenance-bar`,
   data: () => ({
-    show: true
+    show: true,
+    maintenance: []
   }),
   computed: {
     ...mapState([`session`])

--- a/src/components/common/MaintenanceBar.vue
+++ b/src/components/common/MaintenanceBar.vue
@@ -11,15 +11,6 @@
         <i class="material-icons" @click="close">close</i>
       </a>
     </div>
-    <div v-if="maintenance" class="maintenance-bar">
-      <i></i>
-      <p>
-       {{ maintenance.message }}
-      </p>
-      <a class="close">
-        <i class="material-icons" @click="close">close</i>
-      </a>
-    </div>
   </div>
 </template>
 
@@ -44,10 +35,10 @@ export default {
     maintenance: {
       query: Maintenance,
       variables() {
-        console.log(`message: ${this.message} type: ${this.type}`);
+        console.log(`message: ${this.maintenance[0].message} type: ${this.maintenance[0].type}`);
         return {
-          message: this.message,
-          type: this.type,
+          message: this.maintenance[0].message,
+          type: this.maintenance[0].type,
         }
       },
       update: MaintenanceResult

--- a/src/components/common/MaintenanceBar.vue
+++ b/src/components/common/MaintenanceBar.vue
@@ -15,7 +15,6 @@
 </template>
 
 <script>
-import { mapState } from "vuex"
 import gql from "graphql-tag"
 export default {
   name: `maintenance-bar`,

--- a/src/components/common/MaintenanceBar.vue
+++ b/src/components/common/MaintenanceBar.vue
@@ -1,7 +1,7 @@
 <template>
   <div v-if="maintenance.length > 0">
     <div v-for="(message, index) in maintenance">
-      <div v-if="message.show" class="maintenance-bar" v-bind:class="`${message.type} message-${index}`">
+      <div v-if="message.show" class="maintenance-bar" v-bind:class="`${message.type} message-${index+1}`">
         <i></i>
         <p>
           {{ message.message }}

--- a/src/components/common/MaintenanceBar.vue
+++ b/src/components/common/MaintenanceBar.vue
@@ -11,7 +11,7 @@
         <i class="material-icons" @click="close">close</i>
       </a>
     </div>
-    <div v-if="maintenance.length > 0" class="maintenance-bar" v-bind:class="maintenance[0].type">
+    <div v-if="maintenance.length > 0 && show" class="maintenance-bar" v-bind:class="maintenance[0].type">
       <i></i>
       <p>
         {{ maintenance[0].message }}

--- a/src/components/common/MaintenanceBar.vue
+++ b/src/components/common/MaintenanceBar.vue
@@ -11,10 +11,10 @@
         <i class="material-icons" @click="close">close</i>
       </a>
     </div>
-    <div v-if="maintenance.length > 0" class="maintenance-bar">
+    <div v-if="maintenance.length > 0" class="maintenance-bar" v-bind:class="maintenance.type">
       <i></i>
       <p>
-        Maintenance text
+        {{ maintenance.message }}
       </p>
       <a class="close">
         <i class="material-icons" @click="close">close</i>
@@ -41,11 +41,7 @@ export default {
     }
   },
   apollo: {
-    // They key is the name of the data property
-    // on the component that you intend to populate.
     maintenance: {
-      // Yes, this looks confusing.
-      // It's just normal GraphQL.
       query: gql`
         query Maintenance {
           maintenance {
@@ -54,10 +50,6 @@ export default {
           }
         }
       `,
-
-      // Apollo maps results to the name of the query, for caching.
-      // So to update the right property on the componet, you need to
-      // select the property of the result with the name of the query.
       update: result => result.maintenance,
     }
   }

--- a/src/components/common/MaintenanceBar.vue
+++ b/src/components/common/MaintenanceBar.vue
@@ -1,19 +1,31 @@
 <template>
-  <div v-if="session.maintenanceBar && show" class="maintenance-bar">
-    <i></i>
-    <p>
-      We've identified problems with our servers that are causing issues for
-      some of our users. We apologize for the disruption and are working on a
-      fix.
-    </p>
-    <a class="close">
-      <i class="material-icons" @click="close">close</i>
-    </a>
+  <div>
+    <div v-if="session.maintenanceBar && show" class="maintenance-bar">
+      <i></i>
+      <p>
+        We've identified problems with our servers that are causing issues for
+        some of our users. We apologize for the disruption and are working on a
+        fix.
+      </p>
+      <a class="close">
+        <i class="material-icons" @click="close">close</i>
+      </a>
+    </div>
+    <div v-if="maintenance" class="maintenance-bar">
+      <i></i>
+      <p>
+       {{ maintenance.message }}
+      </p>
+      <a class="close">
+        <i class="material-icons" @click="close">close</i>
+      </a>
+    </div>
   </div>
 </template>
 
 <script>
 import { mapState } from "vuex"
+import { Maintenance } from "src/gql"
 export default {
   name: `maintenance-bar`,
   data: () => ({
@@ -25,6 +37,18 @@ export default {
   methods: {
     close() {
       this.show = false
+    }
+  },
+  apollo: {
+    maintenance: {
+      query: Maintenance,
+      variables() {
+        console.log(`message: ${this.message} type: ${this.type}`);
+        return {
+          message: this.message,
+          type: this.type,
+        }
+      }
     }
   }
 }

--- a/src/components/common/MaintenanceBar.vue
+++ b/src/components/common/MaintenanceBar.vue
@@ -35,11 +35,11 @@ export default {
     maintenance: {
       query: Maintenance,
       variables() {
-        console.log(`message: ${this.maintenance[0].message} type: ${this.maintenance[0].type}`);
-        return {
-          message: this.maintenance[0].message,
-          type: this.maintenance[0].type,
-        }
+        console.log(maintenance);
+        // return {
+        //   message: this.maintenance[0].message,
+        //   type: this.maintenance[0].type,
+        // }
       },
       update: MaintenanceResult
     }

--- a/src/components/common/MaintenanceBar.vue
+++ b/src/components/common/MaintenanceBar.vue
@@ -1,24 +1,15 @@
 <template>
-  <div>
-    <div v-if="session.maintenanceBar && show" class="maintenance-bar">
-      <i></i>
-      <p>
-        We've identified problems with our servers that are causing issues for
-        some of our users. We apologize for the disruption and are working on a
-        fix.
-      </p>
-      <a class="close">
-        <i class="material-icons" @click="close">close</i>
-      </a>
-    </div>
-    <div v-if="maintenance.length > 0 && show" class="maintenance-bar" v-bind:class="maintenance[0].type">
-      <i></i>
-      <p>
-        {{ maintenance[0].message }}
-      </p>
-      <a class="close">
-        <i class="material-icons" @click="close">close</i>
-      </a>
+  <div v-if="maintenance.length > 0">
+    <div v-for="message in maintenance">
+      <div v-if="show" class="maintenance-bar" v-bind:class="message.type">
+        <i></i>
+        <p>
+          {{ message.message }}
+        </p>
+        <a class="close">
+          <i class="material-icons" @click="close">close</i>
+        </a>
+      </div>
     </div>
   </div>
 </template>
@@ -75,16 +66,26 @@ export default {
   color: var(--bright);
 }
 
-.maintenance-bar.ok {
-  background-color: #61b360;
+ /* don't change - should be consistent across themes */
+  --input-bg: transparent;
+  --success: hsl(120, 58%, 50%);
+  --success-bc: hsl(120, 58%, 41%);
+  --warning: hsl(35, 100%, 50%);
+  --warning-bc: hsl(35, 75%, 38%);
+  --danger: hsl(0, 100%, 55%);
+  --danger-bc: hsl(0, 100%, 41%);
+  --tendermint: #5ead37;
+
+.maintenance-bar.success {
+  background-color: var(--success);
 }
 
 .maintenance-bar.warning {
-  background-color: #b3b060;
+  background-color: var(--warning);
 }
 
 .maintenance-bar.danger {
-  background-color: #ca3e4b;
+  background-color: var(--danger);
 }
 
 .maintenance-bar .link {

--- a/src/components/common/MaintenanceBar.vue
+++ b/src/components/common/MaintenanceBar.vue
@@ -37,6 +37,7 @@ export default {
           }
         }
       `,
+      /* istanbul ignore next */
       update: result => result.maintenance
     }
   }

--- a/src/components/common/MaintenanceBar.vue
+++ b/src/components/common/MaintenanceBar.vue
@@ -34,6 +34,7 @@ export default {
           maintenance {
             message
             type
+            show
           }
         }
       `,

--- a/src/components/common/MaintenanceBar.vue
+++ b/src/components/common/MaintenanceBar.vue
@@ -1,7 +1,7 @@
 <template>
   <div v-if="maintenance.length > 0">
-    <div v-for="message in maintenance">
-      <div v-if="message.show" class="maintenance-bar" v-bind:class="message.type">
+    <div v-for="(message, index) in maintenance">
+      <div v-if="message.show" class="maintenance-bar" v-bind:class="`${message.type} message-${index}`">
         <i></i>
         <p>
           {{ message.message }}
@@ -100,11 +100,11 @@ export default {
     justify-content: space-around;
   }
 
-  div > div.maintenance-bar:nth-child(2) {
+  .message-2 {
     bottom: 36px;
   }
 
-  div > div.maintenance-bar:nth-child(3) {
+  .message-3 {
     bottom: 72px;
   }
 

--- a/src/components/common/MaintenanceBar.vue
+++ b/src/components/common/MaintenanceBar.vue
@@ -21,7 +21,7 @@ export default {
   name: `maintenance-bar`,
   data: () => ({
     show: true,
-    maintenance: []
+    maintenance
   }),
   computed: {
     ...mapState([`session`])
@@ -35,7 +35,7 @@ export default {
     maintenance: {
       query: Maintenance,
       variables() {
-        console.log(maintenance);
+        console.log(this.maintenance);
         // return {
         //   message: this.maintenance[0].message,
         //   type: this.maintenance[0].type,

--- a/src/components/common/MaintenanceBar.vue
+++ b/src/components/common/MaintenanceBar.vue
@@ -30,7 +30,7 @@ export default {
     close() {
       this.show = false
     }
-  },
+  }, 
   apollo: {
     maintenance: {
       query: Maintenance,

--- a/src/components/common/MaintenanceBar.vue
+++ b/src/components/common/MaintenanceBar.vue
@@ -100,11 +100,11 @@ export default {
     justify-content: space-around;
   }
 
-  .maintenance-bar:nth-child(2) {
+  div > div.maintenance-bar:nth-child(2) {
     bottom: 36px;
   }
 
-  .maintenance-bar:nth-child(3) {
+  div > div.maintenance-bar:nth-child(3) {
     bottom: 72px;
   }
 

--- a/src/components/common/MaintenanceBar.vue
+++ b/src/components/common/MaintenanceBar.vue
@@ -7,7 +7,7 @@
           {{ message.message }}
         </p>
         <a class="close">
-          <i class="material-icons" @click="close(message)">close</i>
+          <i class="material-icons close-icon" @click="close(message)">close</i>
         </a>
       </div>
     </div>
@@ -86,6 +86,10 @@ export default {
   color: var(--bright);
 }
 
+.close-icon {
+  line-height: 18px;
+}
+
 @media (max-width: 1024px) {
   .maintenance-bar {
     position: fixed;
@@ -94,6 +98,14 @@ export default {
     z-index: 99;
     padding: 0.5rem;
     justify-content: space-around;
+  }
+
+  .maintenance-bar:nth-child(2) {
+    bottom: 36px;
+  }
+
+  .maintenance-bar:nth-child(3) {
+    bottom: 72px;
   }
 
   .hide-on-mobile {

--- a/src/components/common/MaintenanceBar.vue
+++ b/src/components/common/MaintenanceBar.vue
@@ -49,7 +49,8 @@ export default {
           message: this.message,
           type: this.type,
         }
-      }
+      },
+      update: MaintenanceResult
     }
   }
 }

--- a/src/components/common/MaintenanceBar.vue
+++ b/src/components/common/MaintenanceBar.vue
@@ -1,13 +1,13 @@
 <template>
   <div v-if="maintenance.length > 0">
     <div v-for="message in maintenance">
-      <div v-if="show" class="maintenance-bar" v-bind:class="message.type">
+      <div v-if="message.show" class="maintenance-bar" v-bind:class="message.type">
         <i></i>
         <p>
           {{ message.message }}
         </p>
         <a class="close">
-          <i class="material-icons" @click="close">close</i>
+          <i class="material-icons" @click="close(message)">close</i>
         </a>
       </div>
     </div>
@@ -20,15 +20,11 @@ import gql from "graphql-tag"
 export default {
   name: `maintenance-bar`,
   data: () => ({
-    show: true,
     maintenance: []
   }),
-  computed: {
-    ...mapState([`session`])
-  },
-  methods: {
-    close() {
-      this.show = false
+  methods: { 
+    close(message) {
+      message.show = false
     }
   },
   apollo: {

--- a/src/components/common/MaintenanceBar.vue
+++ b/src/components/common/MaintenanceBar.vue
@@ -75,6 +75,18 @@ export default {
   color: var(--bright);
 }
 
+.maintenance-bar.ok {
+  background-color: #61b360;
+}
+
+.maintenance-bar.warning {
+  background-color: #b3b060;
+}
+
+.maintenance-bar.danger {
+  background-color: #ca3e4b;
+}
+
 .maintenance-bar .link {
   text-decoration: underline;
   color: var(--bright);

--- a/src/components/common/MaintenanceBar.vue
+++ b/src/components/common/MaintenanceBar.vue
@@ -1,6 +1,6 @@
 <template>
   <div v-if="maintenance.length > 0">
-    <div v-for="(message, index) in maintenance">
+    <div v-for="(message, index) in maintenance" :key="index">
       <div v-if="message.show" class="maintenance-bar" v-bind:class="`${message.type} message-${index+1}`">
         <i></i>
         <p>

--- a/src/components/common/MaintenanceBar.vue
+++ b/src/components/common/MaintenanceBar.vue
@@ -11,6 +11,15 @@
         <i class="material-icons" @click="close">close</i>
       </a>
     </div>
+    <div v-if="maintenance.length > 0" class="maintenance-bar">
+      <i></i>
+      <p>
+        Maintenance text
+      </p>
+      <a class="close">
+        <i class="material-icons" @click="close">close</i>
+      </a>
+    </div>
   </div>
 </template>
 
@@ -21,7 +30,7 @@ export default {
   name: `maintenance-bar`,
   data: () => ({
     show: true,
-    maintenance
+    maintenance: []
   }),
   computed: {
     ...mapState([`session`])
@@ -30,17 +39,10 @@ export default {
     close() {
       this.show = false
     }
-  }, 
+  },
   apollo: {
     maintenance: {
       query: Maintenance,
-      variables() {
-        console.log(this.maintenance);
-        // return {
-        //   message: this.maintenance[0].message,
-        //   type: this.maintenance[0].type,
-        // }
-      },
       update: MaintenanceResult
     }
   }

--- a/src/gql/index.js
+++ b/src/gql/index.js
@@ -94,4 +94,4 @@ query Maintenance {
 export const AllValidatorsResult = data => data.allValidators
 export const ValidatorResult = data => data.allValidators[0]
 export const NetworkCapabilityResult = data => data.networks.length === 1
-export const MaintenanceResult = data => data.maintenance
+export const MaintenanceResult = data => data.maintenance[0]

--- a/src/gql/index.js
+++ b/src/gql/index.js
@@ -80,18 +80,6 @@ query Networks {
 }
 `
 
-// Maintenance
-export const Maintenance = gql`
-query Maintenance {
-  maintenance {
-    message
-    type
-  }
-}
-`
-
-
 export const AllValidatorsResult = data => data.allValidators
 export const ValidatorResult = data => data.allValidators[0]
 export const NetworkCapabilityResult = data => data.networks.length === 1
-export const MaintenanceResult = data => data.maintenance[0]

--- a/src/gql/index.js
+++ b/src/gql/index.js
@@ -80,6 +80,16 @@ query Networks {
 }
 `
 
+// Maintenance
+export const Maintenance = gql`
+  query Maintenance {
+    maintenance {
+      message
+      type
+    }
+  }
+`
+
 export const AllValidatorsResult = data => data.allValidators
 export const ValidatorResult = data => data.allValidators[0]
 export const NetworkCapabilityResult = data => data.networks.length === 1

--- a/src/gql/index.js
+++ b/src/gql/index.js
@@ -82,13 +82,14 @@ query Networks {
 
 // Maintenance
 export const Maintenance = gql`
-  query Maintenance {
-    maintenance {
-      message
-      type
-    }
+query Maintenance {
+  maintenance {
+    message
+    type
   }
+}
 `
+
 
 export const AllValidatorsResult = data => data.allValidators
 export const ValidatorResult = data => data.allValidators[0]

--- a/src/gql/index.js
+++ b/src/gql/index.js
@@ -93,3 +93,4 @@ export const Maintenance = gql`
 export const AllValidatorsResult = data => data.allValidators
 export const ValidatorResult = data => data.allValidators[0]
 export const NetworkCapabilityResult = data => data.networks.length === 1
+export const MaintenanceResult = data => data.maintenance

--- a/src/vuex/modules/session.js
+++ b/src/vuex/modules/session.js
@@ -26,7 +26,6 @@ export default () => {
     cookiesAccepted: undefined,
     stateLoaded: false, // shows if the persisted state is already loaded. used to prevent overwriting the persisted state before it is loaded
     error: null,
-    maintenanceBar: false,
     modals: {
       error: { active: false },
       help: { active: false }

--- a/tests/unit/specs/components/common/MaintenanceBar.spec.js
+++ b/tests/unit/specs/components/common/MaintenanceBar.spec.js
@@ -1,0 +1,70 @@
+import { shallowMount } from "@vue/test-utils"
+import MaintenanceBar from "common/MaintenanceBar"
+
+describe(`MaintenanceBar`, () => {
+  let wrapper
+  beforeEach(async () => {
+    wrapper = shallowMount(MaintenanceBar)
+  })
+
+  it(`has the expected html structure`, () => {
+    expect(wrapper.element).toMatchSnapshot()
+  })
+
+  it(`show success message`, () => {
+    wrapper.setData({
+      maintenance: [
+        {
+          message: 'success test message',
+          type: 'success',
+          show: true
+        }        
+      ],
+    });
+    expect(wrapper.find(".maintenance-bar.success p").text())
+      .toBe("success test message");
+  })
+
+  it(`show warning message`, () => {
+    wrapper.setData({
+      maintenance: [
+        {
+          message: 'warning test message',
+          type: 'warning',
+          show: true
+        }        
+      ],
+    });
+    expect(wrapper.find(".maintenance-bar.warning p").text())
+      .toBe("warning test message");
+  })
+
+  it(`show danger message`, () => {
+    wrapper.setData({
+      maintenance: [
+        {
+          message: 'danger test message',
+          type: 'danger',
+          show: true
+        }        
+      ],
+    });
+    expect(wrapper.find(".maintenance-bar.danger p").text())
+      .toBe("danger test message");
+  })
+
+  it(`close message button works`, () => {
+    wrapper.setData({
+      maintenance: [
+        {
+          message: 'success test message',
+          type: 'success',
+          show: true
+        }        
+      ],
+    });
+    wrapper.vm.maintenance[0].show = false
+    expect(wrapper.find(".maintenance-bar.success p").exists())
+      .toBe(false)
+  })
+})

--- a/tests/unit/specs/components/common/MaintenanceBar.spec.js
+++ b/tests/unit/specs/components/common/MaintenanceBar.spec.js
@@ -63,7 +63,7 @@ describe(`MaintenanceBar`, () => {
         }        
       ],
     });
-    wrapper.vm.maintenance[0].show = false
+    wrapper.vm.close(wrapper.vm.maintenance[0])
     expect(wrapper.find(".maintenance-bar.success p").exists())
       .toBe(false)
   })

--- a/tests/unit/specs/components/common/__snapshots__/MaintenanceBar.spec.js.snap
+++ b/tests/unit/specs/components/common/__snapshots__/MaintenanceBar.spec.js.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`MaintenanceBar has the expected html structure 1`] = `<!---->`;


### PR DESCRIPTION
Closes #2858

**Description:**

When a row is found in maintenance table the message is displayed to the user.

Maintenance table in Hasura backend have two columns: message and type. 

Type can be ok, warning, danger or empty (default) and changes the maintenance bar background color accordingly to each type.

Thank you! 🚀

---

For contributor:

- [ ] Added changes entries. Run `yarn changelog` for a guided process.
- [ ] Reviewed `Files changed` in the github PR explorer
- [ ] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI
