### PR TITLE
Mario/2963 increase circleci timeout

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,7 +76,7 @@ jobs:
           command: |
             yarn run test:unit --coverage --maxWorkers=2
             bash <(curl -s https://codecov.io/bash)
-          no_output_timeout: 120
+          no_output_timeout: 180
 
   security:
     executor: web

--- a/changes/mario_2963-increase-circleci-timeout
+++ b/changes/mario_2963-increase-circleci-timeout
@@ -1,0 +1,1 @@
+[Fixed] [#2963](https://github.com/cosmos/lunie/issues/2963) Increase circleci testUnit test timeout from 120 to 180 seconds @mariopino


### PR DESCRIPTION
Closes #2963

**Description:**

ci/circleci testUnit test execution returns a timeout that causes test to fail despite all the individual tests run ok.

Current test timeout is 120 and test execution in the last PR takes 137 seconds so let't increase the testUnit timeout to 180 seconds.

Thank you! 🚀

---

For contributor:

- [ ] Added changes entries. Run `yarn changelog` for a guided process.
- [ ] Reviewed `Files changed` in the github PR explorer
- [ ] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI
