### PR TITLE
Mario/2302 show tombstone validator

### DIFF
--- a/changes/mario_2302-show-tombstone-validator
+++ b/changes/mario_2302-show-tombstone-validator
@@ -1,0 +1,1 @@
+[Changed] [#2302](https://github.com/cosmos/lunie/issues/2302) Show INACTIVE status if validator is either jailed or tombstoned @mariopino

--- a/src/components/staking/LiValidator.vue
+++ b/src/components/staking/LiValidator.vue
@@ -10,7 +10,7 @@
     "
   >
     <td>{{ index + 1 }}</td>
-    <td>
+    <td class="hide-xs">
       <div class="status-container">
         <span :class="status | toLower" class="validator-status">
           {{ status }}

--- a/src/components/staking/LiValidator.vue
+++ b/src/components/staking/LiValidator.vue
@@ -15,12 +15,6 @@
         <span :class="status | toLower" class="validator-status">
           {{ status }}
         </span>
-        <span v-if="jailed" class="jailed">
-          Temporally banned from the network
-        </span>
-        <span v-if="tombstoned" class="tombstoned">
-          Banned from the network
-        </span>
       </div>
     </td>
     <td class="data-table__row__info">
@@ -73,7 +67,8 @@ export default {
   filters: {
     atoms,
     shortDecimals,
-    percent
+    percent,
+    toLower: text => text.toLowerCase()
   },
   props: {
     validator: {

--- a/src/components/staking/LiValidator.vue
+++ b/src/components/staking/LiValidator.vue
@@ -10,6 +10,7 @@
     "
   >
     <td>{{ index + 1 }}</td>
+    <td>Status: {{ validator.status }} Jailed: {{ validator.jailed }}</td>
     <td class="data-table__row__info">
       <Avatar
         v-if="!validator || !validator.avatarUrl"

--- a/src/components/staking/LiValidator.vue
+++ b/src/components/staking/LiValidator.vue
@@ -10,7 +10,19 @@
     "
   >
     <td>{{ index + 1 }}</td>
-    <td>Status: {{ validator.status }} Jailed: {{ validator.jailed }}</td>
+    <td>
+      <div class="status-container">
+        <span :class="status | toLower" class="validator-status">
+          {{ status }}
+        </span>
+        <span v-if="jailed" class="jailed">
+          Temporally banned from the network
+        </span>
+        <span v-if="tombstoned" class="tombstoned">
+          Banned from the network
+        </span>
+      </div>
+    </td>
     <td class="data-table__row__info">
       <Avatar
         v-if="!validator || !validator.avatarUrl"

--- a/src/components/staking/LiValidator.vue
+++ b/src/components/staking/LiValidator.vue
@@ -15,7 +15,7 @@
         <span
           :class="status | toLower"
           class="validator-status"
-          :title="status_datailed"
+          :title="status_detailed"
         >
           {{ status }}
         </span>
@@ -99,7 +99,7 @@ export default {
         return `Inactive`
       return `Active`
     },
-    status_datailed() {
+    status_detailed() {
       if (this.validator.jailed) return `Temporally banned from the network`
       if (this.validator.tombstoned) return `Banned from the network`
       if (this.validator.status === 0) return `Banned from the network`

--- a/src/components/staking/LiValidator.vue
+++ b/src/components/staking/LiValidator.vue
@@ -90,6 +90,17 @@ export default {
       default: () => "returns"
     }
   },
+  computed: {
+    status() {
+      if (
+        this.validator.jailed ||
+        this.validator.tombstoned ||
+        this.validator.status === 0
+      )
+        return `Inactive`
+      return `Active`
+    }
+  },
   methods: {
     percent
   }

--- a/src/components/staking/LiValidator.vue
+++ b/src/components/staking/LiValidator.vue
@@ -12,7 +12,11 @@
     <td>{{ index + 1 }}</td>
     <td class="hide-xs">
       <div class="status-container">
-        <span :class="status | toLower" class="validator-status">
+        <span
+          :class="status | toLower"
+          class="validator-status"
+          :title="status_datailed"
+        >
           {{ status }}
         </span>
       </div>
@@ -94,6 +98,12 @@ export default {
       )
         return `Inactive`
       return `Active`
+    },
+    status_datailed() {
+      if (this.validator.jailed) return `Temporally banned from the network`
+      if (this.validator.tombstoned) return `Banned from the network`
+      if (this.validator.status === 0) return `Banned from the network`
+      return false
     }
   },
   methods: {

--- a/src/components/staking/LiValidator.vue
+++ b/src/components/staking/LiValidator.vue
@@ -156,4 +156,23 @@ export default {
   width: 2.5rem;
   border: 1px solid var(--bc-dim);
 }
+
+.validator-status {
+  text-transform: uppercase;
+  font-size: 10px;
+  font-weight: 600;
+  border: 2px solid;
+  padding: 2px 4px;
+  border-radius: 0.25rem;
+}
+
+.validator-status.inactive {
+  color: var(--warning);
+  border-color: var(--warning);
+}
+
+.validator-status.active {
+  color: var(--success);
+  border-color: var(--success);
+}
 </style>

--- a/src/components/staking/PageValidator.vue
+++ b/src/components/staking/PageValidator.vue
@@ -14,8 +14,8 @@
         <span :class="status | toLower" class="validator-status">
           {{ status }} 
         </span>
-        <span v-if="jailed">Jailed</span>
-        <span v-if="tombstoned">Tombstoned</span>
+        <span v-if="jailed" class="jailed">Temporally banned from the network</span>
+        <span v-if="tombstoned" class="tombstoned">Banned from the network</span>
       </div>
       <tr class="li-validator">
         <td class="data-table__row__info">
@@ -269,8 +269,12 @@ export default {
       )
     },
     status() {
-      if (this.validator.jailed) return `Jailed`
-      else if (this.validator.status === 0) return `Inactive`
+      if (
+        this.validator.jailed ||
+        this.validator.tombstoned ||
+        this.validator.status === 0
+      )
+        return `Inactive`
       return `Active`
     },
     website() {
@@ -477,11 +481,6 @@ span {
   border-radius: 0.25rem;
 }
 
-.validator-status.jailed {
-  color: var(--danger);
-  border-color: var(--danger);
-}
-
 .validator-status.inactive {
   color: var(--warning);
   border-color: var(--warning);
@@ -490,6 +489,14 @@ span {
 .validator-status.active {
   color: var(--success);
   border-color: var(--success);
+}
+
+.tombstoned,
+.jailed {
+  display: block;
+  margin-top: 0.4rem;
+  color: #e07b7b;
+  font-size: 0.8rem;
 }
 </style>
 <style>

--- a/src/components/staking/PageValidator.vue
+++ b/src/components/staking/PageValidator.vue
@@ -12,7 +12,7 @@
     <template v-if="validator.operator_address" slot="managed-body">
       <div class="status-container">
         <span :class="status | toLower" class="validator-status">
-          {{ status }}
+          {{ status }} {{ status_detailed }}
         </span>
         <span v-if="status_detailed !== false" class="validator-status-detailed">
           {{ status_detailed }}

--- a/src/components/staking/PageValidator.vue
+++ b/src/components/staking/PageValidator.vue
@@ -12,7 +12,7 @@
     <template v-if="validator.operator_address" slot="managed-body">
       <div class="status-container">
         <span :class="status | toLower" class="validator-status">
-          {{ status }}
+          {{ status }} Jailed: {{ jailed }} Tombstoned: {{ tombstoned }}
         </span>
       </div>
       <tr class="li-validator">

--- a/src/components/staking/PageValidator.vue
+++ b/src/components/staking/PageValidator.vue
@@ -14,11 +14,8 @@
         <span :class="status | toLower" class="validator-status">
           {{ status }}
         </span>
-        <span v-if="jailed" class="jailed">
-          Temporally banned from the network
-        </span>
-        <span v-if="tombstoned" class="tombstoned">
-          Banned from the network
+        <span v-if="status_detailed" class="validator-status-detailed">
+          {{ status_detailed }}
         </span>
       </div>
       <tr class="li-validator">
@@ -281,6 +278,12 @@ export default {
         return `Inactive`
       return `Active`
     },
+    status_datailed() {
+      if (this.validator.jailed) return `Temporally banned from the network`
+      if (this.validator.tombstoned) return `Banned from the network`
+      if (this.validator.status === 0) return `Banned from the network`
+      return false
+    },
     website() {
       let url = this.validator.website
 
@@ -495,8 +498,7 @@ span {
   border-color: var(--success);
 }
 
-.tombstoned,
-.jailed {
+.validator-status-detailed {
   display: block;
   margin-top: 0.4rem;
   color: #e07b7b;

--- a/src/components/staking/PageValidator.vue
+++ b/src/components/staking/PageValidator.vue
@@ -14,7 +14,7 @@
         <span :class="status | toLower" class="validator-status">
           {{ status }}
         </span>
-        <span v-if="status_detailed" class="validator-status-detailed">
+        <span v-if="status_detailed !== false" class="validator-status-detailed">
           {{ status_detailed }}
         </span>
       </div>

--- a/src/components/staking/PageValidator.vue
+++ b/src/components/staking/PageValidator.vue
@@ -12,8 +12,10 @@
     <template v-if="validator.operator_address" slot="managed-body">
       <div class="status-container">
         <span :class="status | toLower" class="validator-status">
-          {{ status }} Jailed: {{ jailed }} Tombstoned: {{ tombstoned }}
+          {{ status }} 
         </span>
+        <span v-if="jailed">Jailed</span>
+        <span v-if="tombstoned">Tombstoned</span>
       </div>
       <tr class="li-validator">
         <td class="data-table__row__info">

--- a/src/components/staking/PageValidator.vue
+++ b/src/components/staking/PageValidator.vue
@@ -12,9 +12,9 @@
     <template v-if="validator.operator_address" slot="managed-body">
       <div class="status-container">
         <span :class="status | toLower" class="validator-status">
-          {{ status }} {{ status_detailed }}
+          {{ status }}
         </span>
-        <span v-if="status_detailed !== false" class="validator-status-detailed">
+        <span v-if="status_detailed" class="validator-status-detailed">
           {{ status_detailed }}
         </span>
       </div>
@@ -278,7 +278,7 @@ export default {
         return `Inactive`
       return `Active`
     },
-    status_datailed() {
+    status_detailed() {
       if (this.validator.jailed) return `Temporally banned from the network`
       if (this.validator.tombstoned) return `Banned from the network`
       if (this.validator.status === 0) return `Banned from the network`

--- a/src/components/staking/PageValidator.vue
+++ b/src/components/staking/PageValidator.vue
@@ -12,10 +12,14 @@
     <template v-if="validator.operator_address" slot="managed-body">
       <div class="status-container">
         <span :class="status | toLower" class="validator-status">
-          {{ status }} 
+          {{ status }}
         </span>
-        <span v-if="jailed" class="jailed">Temporally banned from the network</span>
-        <span v-if="tombstoned" class="tombstoned">Banned from the network</span>
+        <span v-if="jailed" class="jailed">
+          Temporally banned from the network
+        </span>
+        <span v-if="tombstoned" class="tombstoned">
+          Banned from the network
+        </span>
       </div>
       <tr class="li-validator">
         <td class="data-table__row__info">

--- a/src/components/staking/PageValidator.vue
+++ b/src/components/staking/PageValidator.vue
@@ -501,7 +501,7 @@ span {
 .validator-status-detailed {
   display: block;
   margin-top: 0.4rem;
-  color: #e07b7b;
+  color: var(--warning);
   font-size: 0.8rem;
 }
 </style>

--- a/src/components/staking/PanelSort.vue
+++ b/src/components/staking/PanelSort.vue
@@ -1,6 +1,7 @@
 <template>
   <tr class="panel-sort-container">
     <th>#</th>
+    <th>Status</th>
     <th
       v-for="property in properties"
       :key="property.value"

--- a/src/components/staking/PanelSort.vue
+++ b/src/components/staking/PanelSort.vue
@@ -1,7 +1,7 @@
 <template>
   <tr class="panel-sort-container">
     <th>#</th>
-    <th>Status</th>
+    <th class="hide-xs">Status</th>
     <th
       v-for="property in properties"
       :key="property.value"

--- a/src/gql/index.js
+++ b/src/gql/index.js
@@ -16,6 +16,7 @@ const ValidatorFragment = `
     id
     identity
     jailed
+    tombstoned
     keybaseId
     lastUpdated
     max_change_rate

--- a/src/styles/table.css
+++ b/src/styles/table.css
@@ -16,11 +16,13 @@
 .data-table th:first-child {
   width: 10%;
   color: var(--dim);
+  font-size: var(--sm)
 }
 
 .data-table th:nth-child(2) {
   width: 10%;
   color: var(--dim);
+  font-size: var(--sm)
 }
 
 .data-table th:nth-child(3) {

--- a/src/styles/table.css
+++ b/src/styles/table.css
@@ -14,19 +14,19 @@
 }
 
 .data-table th:first-child {
-  width: 10%;
+  width: 5%;
   color: var(--dim);
   font-size: var(--sm)
 }
 
 .data-table th:nth-child(2) {
-  width: 10%;
+  width: 5%;
   color: var(--dim);
   font-size: var(--sm)
 }
 
 .data-table th:nth-child(3) {
-  width: 45%;
+  width: 55%;
 }
 
 .data-table th {

--- a/src/styles/table.css
+++ b/src/styles/table.css
@@ -20,13 +20,13 @@
 }
 
 .data-table th:nth-child(2) {
-  width: 5%;
+  width: 10%;
   color: var(--dim);
   font-size: var(--sm)
 }
 
 .data-table th:nth-child(3) {
-  width: 55%;
+  width: 50%;
 }
 
 .data-table th {

--- a/src/styles/table.css
+++ b/src/styles/table.css
@@ -20,6 +20,7 @@
 
 .data-table th:nth-child(2) {
   width: 10%;
+  color: var(--dim);
 }
 
 .data-table th:nth-child(3) {

--- a/src/styles/table.css
+++ b/src/styles/table.css
@@ -19,7 +19,11 @@
 }
 
 .data-table th:nth-child(2) {
-  width: 55%;
+  width: 10%;
+}
+
+.data-table th:nth-child(3) {
+  width: 45%;
 }
 
 .data-table th {

--- a/tests/unit/specs/components/staking/PageValidator.spec.js
+++ b/tests/unit/specs/components/staking/PageValidator.spec.js
@@ -157,7 +157,7 @@ describe(`PageValidator`, () => {
       expect(wrapper.vm.status).toBe(`Active`)
 
       wrapper.setData({ validator: validators[3] })
-      expect(wrapper.vm.status).toBe(`Jailed`)
+      expect(wrapper.vm.status).toBe(`Inactive`)
       // Is not a validator
       wrapper.setData({ validator: validators[4] })
       expect(wrapper.vm.status).toBe(`Inactive`)

--- a/tests/unit/specs/components/staking/PanelSort.spec.js
+++ b/tests/unit/specs/components/staking/PanelSort.spec.js
@@ -92,7 +92,7 @@ describe(`PanelSort`, () => {
       wrapper.setProps({ showOnMobile: "amount" })
       const numHidden = wrapper.findAll("th").filter(w => w.classes("hide-xs"))
         .length
-      expect(numHidden).toBe(1)
+      expect(numHidden).toBe(2)
     })
   })
 })

--- a/tests/unit/specs/components/staking/__snapshots__/LiValidator.spec.js.snap
+++ b/tests/unit/specs/components/staking/__snapshots__/LiValidator.spec.js.snap
@@ -10,6 +10,22 @@ exports[`LiValidator has the expected html structure 1`] = `
   </td>
    
   <td
+    class="hide-xs"
+  >
+    <div
+      class="status-container"
+    >
+      <span
+        class="validator-status active"
+      >
+        
+        Active
+      
+      </span>
+    </div>
+  </td>
+   
+  <td
     class="data-table__row__info"
   >
     <img

--- a/tests/unit/specs/components/staking/__snapshots__/PageValidator.spec.js.snap
+++ b/tests/unit/specs/components/staking/__snapshots__/PageValidator.spec.js.snap
@@ -21,6 +21,8 @@ exports[`PageValidator shows a validator profile information errors signing info
         Active
       
       </span>
+       
+      <!---->
     </div>
      
     <tr
@@ -269,6 +271,8 @@ exports[`PageValidator shows a validator profile information if user has signed 
         Active
       
       </span>
+       
+      <!---->
     </div>
      
     <tr
@@ -517,6 +521,8 @@ exports[`PageValidator shows a validator profile information if user hasn't sign
         Active
       
       </span>
+       
+      <!---->
     </div>
      
     <tr
@@ -767,6 +773,8 @@ exports[`PageValidator shows a validator profile information shows empty website
         Active
       
       </span>
+       
+      <!---->
     </div>
      
     <tr
@@ -1015,6 +1023,8 @@ exports[`PageValidator shows a validator profile information shows http website 
         Active
       
       </span>
+       
+      <!---->
     </div>
      
     <tr

--- a/tests/unit/specs/components/staking/__snapshots__/PanelSort.spec.js.snap
+++ b/tests/unit/specs/components/staking/__snapshots__/PanelSort.spec.js.snap
@@ -9,6 +9,12 @@ exports[`PanelSort has the expected html structure 1`] = `
   </th>
    
   <th
+    class="hide-xs"
+  >
+    Status
+  </th>
+   
+  <th
     class="panel-sort-table-header sort-by hide-xs"
   >
     <a


### PR DESCRIPTION
Closes #2302

**Description:**

Show INACTIVE status if validator status is either jailed or tombstoned. Show `detailed_status` as a subtitle in validator page.

Now both `status` and  `detailed_status`  are computed fields, when merge  https://github.com/luniehq/lunie-backend/pull/16, we'll simply use `status` and `detailed_status` directly as provided by the backend.


Thank you! 🚀

---

For contributor:

- [ ] Added changes entries. Run `yarn changelog` for a guided process.
- [ ] Reviewed `Files changed` in the github PR explorer
- [ ] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI
