### PR TITLE
Mario/Improve send confirmation screen

### DIFF
--- a/changes/mario_2938-address-send-confirmation
+++ b/changes/mario_2938-address-send-confirmation
@@ -1,0 +1,1 @@
+[Fixed] [#2938](https://github.com/cosmos/lunie/issues/2938) Prevent destination address to expand over its container on Send confirmation screen.  @mariopino

--- a/src/ActionModal/components/ActionModal.vue
+++ b/src/ActionModal/components/ActionModal.vue
@@ -805,7 +805,7 @@ export default {
   opacity: 0;
 }
 
-.success-step .tm-data-msg {
+#send-modal .tm-data-msg {
   margin: 2rem 0 2rem 0;
 }
 

--- a/src/ActionModal/components/ActionModal.vue
+++ b/src/ActionModal/components/ActionModal.vue
@@ -44,7 +44,7 @@
         <FeatureNotAvailable :feature="title" />
       </template>
       <template v-else>
-        <p v-if="session.windowsDevice" class="form-message notice">
+        <p v-if="session.windowsDevice && step !== successStep" class="form-message notice">
           {{ session.windowsWarning }}
         </p>
         <div v-if="requiresSignIn" class="action-modal-form">

--- a/src/ActionModal/components/ActionModal.vue
+++ b/src/ActionModal/components/ActionModal.vue
@@ -193,7 +193,7 @@
             </div>
             <div slot="subtitle">
               The transaction
-              <!--with the hash {{ txHash }}-->
+              <!-- with the hash {{ txHash }} -->
               was successfully signed and sent the network. Waiting for it to be
               confirmed.
             </div>

--- a/src/ActionModal/components/ActionModal.vue
+++ b/src/ActionModal/components/ActionModal.vue
@@ -209,7 +209,7 @@
               <br />
               <br />Block
               <router-link :to="`/blocks/${includedHeight}`"
-                >#{{ prettyBlockHeight }}</router-link
+                >#{{ prettyIncludedHeight }}</router-link
               >
             </div>
           </TmDataMsg>
@@ -453,7 +453,7 @@ export default {
           this.modalContext.isExtensionAccount)
       )
     },
-    prettyBlockHeight() {
+    prettyIncludedHeight() {
       return prettyInt(this.includedHeight)
   },
   watch: {

--- a/src/ActionModal/components/ActionModal.vue
+++ b/src/ActionModal/components/ActionModal.vue
@@ -455,6 +455,7 @@ export default {
     },
     prettyIncludedHeight() {
       return prettyInt(this.includedHeight)
+    }
   },
   watch: {
     // if there is only one sign method, preselect it

--- a/src/ActionModal/components/ActionModal.vue
+++ b/src/ActionModal/components/ActionModal.vue
@@ -44,7 +44,10 @@
         <FeatureNotAvailable :feature="title" />
       </template>
       <template v-else>
-        <p v-if="session.windowsDevice && step !== successStep" class="form-message notice">
+        <p
+          v-if="session.windowsDevice && step !== successStep"
+          class="form-message notice"
+        >
           {{ session.windowsWarning }}
         </p>
         <div v-if="requiresSignIn" class="action-modal-form">
@@ -837,7 +840,4 @@ export default {
     top: 0;
   }
 }
-
-
-
 </style>

--- a/src/ActionModal/components/ActionModal.vue
+++ b/src/ActionModal/components/ActionModal.vue
@@ -809,6 +809,15 @@ export default {
   margin: 2rem 0 2rem 0;
 }
 
+@media screen and (max-width: 576px) {
+  #send-modal {
+    text-align: center;
+  }
+  .tm-data-msg__icon {
+    margin-right: 0;
+  }
+}
+
 @media screen and (max-width: 767px) {
   .tm-form-group__field {
     width: 100%;
@@ -825,4 +834,7 @@ export default {
     top: 0;
   }
 }
+
+
+
 </style>

--- a/src/ActionModal/components/ActionModal.vue
+++ b/src/ActionModal/components/ActionModal.vue
@@ -209,8 +209,8 @@
               <br />
               <br />Block
               <router-link :to="`/blocks/${includedHeight}`"
-                >#{{ includedHeight }}</router-link
-              >.
+                >#{{ prettyBlockHeight }}</router-link
+              >
             </div>
           </TmDataMsg>
         </div>
@@ -284,7 +284,7 @@ import TmDataMsg from "common/TmDataMsg"
 import TableInvoice from "./TableInvoice"
 import Steps from "./Steps"
 import { mapState, mapGetters } from "vuex"
-import { atoms, viewDenom } from "src/scripts/num"
+import { atoms, viewDenom, prettyInt } from "src/scripts/num"
 import { between, requiredIf } from "vuelidate/lib/validators"
 import { track } from "scripts/google-analytics"
 import { NetworkCapability, NetworkCapabilityResult } from "src/gql"
@@ -452,7 +452,9 @@ export default {
         (this.selectedSignMethod === "extension" &&
           this.modalContext.isExtensionAccount)
       )
-    }
+    },
+    prettyBlockHeight() {
+      return prettyInt(this.includedHeight)
   },
   watch: {
     // if there is only one sign method, preselect it

--- a/src/ActionModal/components/ActionModal.vue
+++ b/src/ActionModal/components/ActionModal.vue
@@ -805,6 +805,10 @@ export default {
   opacity: 0;
 }
 
+.success-step .tm-data-msg {
+  margin: 2rem 0 2rem 0;
+}
+
 @media screen and (max-width: 767px) {
   .tm-form-group__field {
     width: 100%;

--- a/src/ActionModal/components/SendModal.vue
+++ b/src/ActionModal/components/SendModal.vue
@@ -272,5 +272,4 @@ export default {
 #edit-memo-btn {
   margin-top: 2.4rem;
 }
-
 </style>

--- a/src/components/common/Bar.vue
+++ b/src/components/common/Bar.vue
@@ -20,7 +20,7 @@ export default {
     },
     show: Boolean
   },
-  data: function () {
+  data: function() {
     return {
       showMessage: this.show
     }

--- a/src/components/common/MaintenanceBar.vue
+++ b/src/components/common/MaintenanceBar.vue
@@ -1,7 +1,9 @@
 <template>
   <div>
     <div v-for="message in maintenance" :key="message.id">
-      <Bar :bar-type="message.type" :show="message.show">{{ message.message }}</Bar>
+      <Bar :bar-type="message.type" :show="message.show">{{
+        message.message
+      }}</Bar>
     </div>
   </div>
 </template>

--- a/src/components/common/TmDataMsg.vue
+++ b/src/components/common/TmDataMsg.vue
@@ -78,6 +78,7 @@ export default {
 .tm-data-msg__subtitle {
   color: var(--txt);
   font-size: 1rem;
+  word-break: break-word;
 }
 
 @media screen and (max-width: 767px) {

--- a/tests/unit/specs/components/ActionModal/components/DelegationModal.spec.js
+++ b/tests/unit/specs/components/ActionModal/components/DelegationModal.spec.js
@@ -25,7 +25,7 @@ describe(`DelegationModal`, () => {
   const state = {
     session: {
       signedIn: true,
-      address: `cosmosvaladdr15ky9du8a2wlstz6fpx3p4mqpjyrm5ctqzh8yqw`,
+      address: `cosmosvaladdr15ky9du8a2wlstz6fpx3p4mqpjyrm5ctqzh8yqw`
     }
   }
 

--- a/tests/unit/specs/components/ActionModal/components/__snapshots__/ActionModal.spec.js.snap
+++ b/tests/unit/specs/components/ActionModal/components/__snapshots__/ActionModal.spec.js.snap
@@ -247,10 +247,8 @@ exports[`ActionModal should show the action modal on success 1`] = `
         <router-link-stub
           to="/blocks/undefined"
         >
-          #
+          #0
         </router-link-stub>
-        .
-          
       </div>
     </tmdatamsg-stub>
   </div>


### PR DESCRIPTION
Closes #2938

**Description:**

Prevent destination address to expand over its container on Send confirmation screen. We simply add `word-break: break-word;` to `.tm-data-msg__subtitle` class.

![image](https://user-images.githubusercontent.com/9256178/65867067-16d1b900-e376-11e9-8225-15bc4af3128b.png)


Thank you! 🚀

---

For contributor:

- [ ] Added changes entries. Run `yarn changelog` for a guided process.
- [ ] Reviewed `Files changed` in the github PR explorer
- [ ] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI
