### PR TITLE
Mario/1932 warn user delegate jailed

### DIFF
--- a/changes/mario_1932-warn-user-delegate-jailed
+++ b/changes/mario_1932-warn-user-delegate-jailed
@@ -1,0 +1,1 @@
+[Added] [#1932](https://github.com/cosmos/lunie/issues/1932) Warn if user is trying to delegate to a jailed/tombstone validator @mariopino

--- a/src/ActionModal/components/ActionModal.vue
+++ b/src/ActionModal/components/ActionModal.vue
@@ -759,7 +759,7 @@ export default {
 
 .action-modal-form .tm-form-group {
   display: block;
-  padding: 0.75rem 0;
+  padding: 1rem 0;
 }
 
 .action-modal-footer {

--- a/src/ActionModal/components/DelegationModal.vue
+++ b/src/ActionModal/components/DelegationModal.vue
@@ -14,8 +14,9 @@
     <TmFormGroup class="action-modal-form-group">
       <div class="form-message notice">
         <span v-if="getValidatorStatus() === 'Inactive'">
-          You are about to <span v-if="isRedelegation()">re</span>delegate to an <strong>inactive</strong> validator ({{ ValidatorStatusDetailed }})
+          You are about to <span v-if="isRedelegation()">re</span>delegate to an <strong>inactive</strong> validator ({{ getValidatorStatusDetailed }})
         </span>
+        <br />
         <span v-if="!isRedelegation()">
           It will take 21 days to unlock your tokens after a delegation and
           there is a risk that some tokens will be lost depending on the

--- a/src/ActionModal/components/DelegationModal.vue
+++ b/src/ActionModal/components/DelegationModal.vue
@@ -35,7 +35,7 @@
       />
       <TmFormMsg
         v-if="validatorStatus === 'Inactive' && isRedelegation()"
-        :msg="`You are about to delegate to an inactive validator (${validatorStatusDetailed})`"
+        :msg="`You are about to redelegate to an inactive validator (${validatorStatusDetailed})`"
         type="custom"
         class="tm-form-msg--desc"
       />

--- a/src/ActionModal/components/DelegationModal.vue
+++ b/src/ActionModal/components/DelegationModal.vue
@@ -15,6 +15,8 @@
       <div v-if="getValidatorStatus() === 'Inactive'" class="form-message notice">
         You are about to <span v-if="isRedelegation()">re</span>delegate to an <strong>inactive</strong> validator ({{ getValidatorStatusDetailed() }})
       </div>
+    </TmFormGroup>
+    <TmFormGroup class="action-modal-form-group">
       <div class="form-message notice">
         <span v-if="!isRedelegation()">
           It will take 21 days to unlock your tokens after a delegation and

--- a/src/ActionModal/components/DelegationModal.vue
+++ b/src/ActionModal/components/DelegationModal.vue
@@ -212,8 +212,8 @@ export default {
       }
     },
     ValidatorStatus() {
-      console.log()
-      if (this.validator)
+      console.log(this.validator)
+      if (
         this.validator.jailed ||
         this.validator.tombstoned ||
         this.validator.status === 0

--- a/src/ActionModal/components/DelegationModal.vue
+++ b/src/ActionModal/components/DelegationModal.vue
@@ -38,7 +38,7 @@
         :msg="`You are about to redelegate to an <strong>inactive</strong> validator (${getValidatorStatusDetailed()})`"
         type="custom"
         class="tm-form-msg--desc"
-      />      
+      />
     </TmFormGroup>
 
     <TmFormGroup

--- a/src/ActionModal/components/DelegationModal.vue
+++ b/src/ActionModal/components/DelegationModal.vue
@@ -29,13 +29,17 @@
       <TmField id="to" v-model="to" type="text" readonly />
       <TmFormMsg
         v-if="validatorStatus === 'Inactive' && !isRedelegation()"
-        :msg="`You are about to delegate to an inactive validator (${validatorStatusDetailed})`"
+        :msg="
+          `You are about to delegate to an inactive validator (${validatorStatusDetailed})`
+        "
         type="custom"
         class="tm-form-msg--desc"
       />
       <TmFormMsg
         v-if="validatorStatus === 'Inactive' && isRedelegation()"
-        :msg="`You are about to redelegate to an inactive validator (${validatorStatusDetailed})`"
+        :msg="
+          `You are about to redelegate to an inactive validator (${validatorStatusDetailed})`
+        "
         type="custom"
         class="tm-form-msg--desc"
       />

--- a/src/ActionModal/components/DelegationModal.vue
+++ b/src/ActionModal/components/DelegationModal.vue
@@ -12,11 +12,10 @@
     @close="clear"
   >
     <TmFormGroup class="action-modal-form-group">
+      <div v-if="getValidatorStatus() === 'Inactive'" class="form-message notice">
+        You are about to <span v-if="isRedelegation()">re</span>delegate to an <strong>inactive</strong> validator ({{ getValidatorStatusDetailed() }})
+      </div>
       <div class="form-message notice">
-        <span v-if="getValidatorStatus() === 'Inactive'">
-          You are about to <span v-if="isRedelegation()">re</span>delegate to an <strong>inactive</strong> validator ({{ getValidatorStatusDetailed() }})
-        </span>
-        <br />
         <span v-if="!isRedelegation()">
           It will take 21 days to unlock your tokens after a delegation and
           there is a risk that some tokens will be lost depending on the

--- a/src/ActionModal/components/DelegationModal.vue
+++ b/src/ActionModal/components/DelegationModal.vue
@@ -235,6 +235,7 @@ export default {
         this.selectedIndex = 1
       }
       this.$refs.actionModal.open()
+      console.log(this.validator)
     },
     validateForm() {
       this.$v.$touch()

--- a/src/ActionModal/components/DelegationModal.vue
+++ b/src/ActionModal/components/DelegationModal.vue
@@ -29,13 +29,13 @@
       <TmField id="to" v-model="to" type="text" readonly />
       <TmFormMsg
         v-if="getValidatorStatus() === 'Inactive' && !isRedelegation()"
-        :msg="`You are about to delegate to an <strong>inactive</strong> validator (${getValidatorStatusDetailed()})`"
+        :msg="`You are about to delegate to an inactive validator (${getValidatorStatusDetailed()})`"
         type="custom"
         class="tm-form-msg--desc"
       />
       <TmFormMsg
         v-if="getValidatorStatus() === 'Inactive' && isRedelegation()"
-        :msg="`You are about to redelegate to an <strong>inactive</strong> validator (${getValidatorStatusDetailed()})`"
+        :msg="`You are about to delegate to an inactive validator (${getValidatorStatusDetailed()})`"
         type="custom"
         class="tm-form-msg--desc"
       />

--- a/src/ActionModal/components/DelegationModal.vue
+++ b/src/ActionModal/components/DelegationModal.vue
@@ -13,7 +13,7 @@
   >
     <TmFormGroup class="action-modal-form-group">
       <div class="form-message notice">
-        <span v-if="getValidatorStatus() === `Inactive`">
+        <span v-if="getValidatorStatus() === 'Inactive'">
           You are about to <span v-if="isRedelegation()">re</span>delegate to an <strong>inactive</strong> validator ({{ ValidatorStatusDetailed }})
         </span>
         <span v-if="!isRedelegation()">

--- a/src/ActionModal/components/DelegationModal.vue
+++ b/src/ActionModal/components/DelegationModal.vue
@@ -212,7 +212,8 @@ export default {
       }
     },
     ValidatorStatus() {
-      if (
+      console.log()
+      if (this.validator)
         this.validator.jailed ||
         this.validator.tombstoned ||
         this.validator.status === 0

--- a/src/ActionModal/components/DelegationModal.vue
+++ b/src/ActionModal/components/DelegationModal.vue
@@ -28,14 +28,14 @@
     <TmFormGroup class="action-modal-form-group" field-id="to" field-label="To">
       <TmField id="to" v-model="to" type="text" readonly />
       <TmFormMsg
-        v-if="getValidatorStatus() === 'Inactive' && !isRedelegation()"
-        :msg="`You are about to delegate to an inactive validator (${getValidatorStatusDetailed()})`"
+        v-if="validatorStatus === 'Inactive' && !isRedelegation()"
+        :msg="`You are about to delegate to an inactive validator (${validatorStatusDetailed})`"
         type="custom"
         class="tm-form-msg--desc"
       />
       <TmFormMsg
-        v-if="getValidatorStatus() === 'Inactive' && isRedelegation()"
-        :msg="`You are about to delegate to an inactive validator (${getValidatorStatusDetailed()})`"
+        v-if="validatorStatus === 'Inactive' && isRedelegation()"
+        :msg="`You are about to delegate to an inactive validator (${validatorStatusDetailed})`"
         type="custom"
         class="tm-form-msg--desc"
       />
@@ -219,6 +219,23 @@ export default {
           )}s`
         }
       }
+    },
+    // Will be replaced by `status` field from backend
+    validatorStatus() {
+      if (
+        this.validator.jailed ||
+        this.validator.tombstoned ||
+        this.validator.status === 0
+      )
+        return `Inactive`
+      return `Active`
+    },
+    // Will be replaced by `status_detail` field from backend
+    validatorStatusDetailed() {
+      if (this.validator.jailed) return `temporally banned from the network`
+      if (this.validator.tombstoned) return `banned from the network`
+      if (this.validator.status === 0) return `banned from the network`
+      return false
     }
   },
   methods: {
@@ -228,7 +245,6 @@ export default {
         this.selectedIndex = 1
       }
       this.$refs.actionModal.open()
-      //console.log(this.validator)
     },
     validateForm() {
       this.$v.$touch()
@@ -255,26 +271,6 @@ export default {
     },
     getFromBalance() {
       return atoms(this.balance)
-    },
-    getValidatorStatus() {
-      //console.log(this.validator)
-      if (
-        this.validator.jailed ||
-        this.validator.tombstoned ||
-        this.validator.status === 0
-      ) {
-        console.log(`Inactive`)
-        return `Inactive`
-      } else {
-        console.log(`Active`)
-        return `Active`
-      }
-    },
-    getValidatorStatusDetailed() {
-      if (this.validator.jailed) return `Temporally banned from the network`
-      if (this.validator.tombstoned) return `Banned from the network`
-      if (this.validator.status === 0) return `Banned from the network`
-      return false
     }
   },
   validations() {

--- a/src/ActionModal/components/DelegationModal.vue
+++ b/src/ActionModal/components/DelegationModal.vue
@@ -13,7 +13,7 @@
   >
     <TmFormGroup class="action-modal-form-group">
       <div class="form-message notice">
-        <span v-if="validatorStatus === `Inactive`">
+        <span v-if="getValidatorStatus() === `Inactive`">
           You are about to <span v-if="isRedelegation()">re</span>delegate to an <strong>inactive</strong> validator ({{ ValidatorStatusDetailed }})
         </span>
         <span v-if="!isRedelegation()">
@@ -210,26 +210,6 @@ export default {
           )}s`
         }
       }
-    },
-    ValidatorStatus() {
-      //console.log(this.validator)
-      if (
-        this.validator.jailed ||
-        this.validator.tombstoned ||
-        this.validator.status === 0
-      ) {
-        console.log(`Inactive`)
-        return `Inactive`
-      } else {
-        console.log(`Active`)
-        return `Active`
-      }
-    },
-    ValidatorStatusDetailed() {
-      if (this.validator.jailed) return `Temporally banned from the network`
-      if (this.validator.tombstoned) return `Banned from the network`
-      if (this.validator.status === 0) return `Banned from the network`
-      return false
     }
   },
   methods: {
@@ -266,6 +246,26 @@ export default {
     },
     getFromBalance() {
       return atoms(this.balance)
+    },
+    getValidatorStatus() {
+      //console.log(this.validator)
+      if (
+        this.validator.jailed ||
+        this.validator.tombstoned ||
+        this.validator.status === 0
+      ) {
+        console.log(`Inactive`)
+        return `Inactive`
+      } else {
+        console.log(`Active`)
+        return `Active`
+      }
+    },
+    getValidatorStatusDetailed() {
+      if (this.validator.jailed) return `Temporally banned from the network`
+      if (this.validator.tombstoned) return `Banned from the network`
+      if (this.validator.status === 0) return `Banned from the network`
+      return false
     }
   },
   validations() {

--- a/src/ActionModal/components/DelegationModal.vue
+++ b/src/ActionModal/components/DelegationModal.vue
@@ -12,11 +12,6 @@
     @close="clear"
   >
     <TmFormGroup class="action-modal-form-group">
-      <div v-if="getValidatorStatus() === 'Inactive'" class="form-message notice">
-        You are about to <span v-if="isRedelegation()">re</span>delegate to an <strong>inactive</strong> validator ({{ getValidatorStatusDetailed() }})
-      </div>
-    </TmFormGroup>
-    <TmFormGroup class="action-modal-form-group">
       <div class="form-message notice">
         <span v-if="!isRedelegation()">
           It will take 21 days to unlock your tokens after a delegation and
@@ -32,6 +27,18 @@
     </TmFormGroup>
     <TmFormGroup class="action-modal-form-group" field-id="to" field-label="To">
       <TmField id="to" v-model="to" type="text" readonly />
+      <TmFormMsg
+        v-if="getValidatorStatus() === 'Inactive' && !isRedelegation()"
+        :msg="`You are about to delegate to an <strong>inactive</strong> validator (${getValidatorStatusDetailed()})`"
+        type="custom"
+        class="tm-form-msg--desc"
+      />
+      <TmFormMsg
+        v-if="getValidatorStatus() === 'Inactive' && isRedelegation()"
+        :msg="`You are about to redelegate to an <strong>inactive</strong> validator (${getValidatorStatusDetailed()})`"
+        type="custom"
+        class="tm-form-msg--desc"
+      />      
     </TmFormGroup>
 
     <TmFormGroup

--- a/src/ActionModal/components/DelegationModal.vue
+++ b/src/ActionModal/components/DelegationModal.vue
@@ -14,7 +14,7 @@
     <TmFormGroup class="action-modal-form-group">
       <div class="form-message notice">
         <span v-if="getValidatorStatus() === 'Inactive'">
-          You are about to <span v-if="isRedelegation()">re</span>delegate to an <strong>inactive</strong> validator ({{ getValidatorStatusDetailed }})
+          You are about to <span v-if="isRedelegation()">re</span>delegate to an <strong>inactive</strong> validator ({{ getValidatorStatusDetailed() }})
         </span>
         <br />
         <span v-if="!isRedelegation()">

--- a/src/ActionModal/components/DelegationModal.vue
+++ b/src/ActionModal/components/DelegationModal.vue
@@ -212,14 +212,18 @@ export default {
       }
     },
     ValidatorStatus() {
-      console.log(this.validator)
+      //console.log(this.validator)
       if (
         this.validator.jailed ||
         this.validator.tombstoned ||
         this.validator.status === 0
-      )
+      ) {
+        console.log(`Inactive`)
         return `Inactive`
-      return `Active`
+      } else {
+        console.log(`Active`)
+        return `Active`
+      }
     },
     ValidatorStatusDetailed() {
       if (this.validator.jailed) return `Temporally banned from the network`
@@ -235,7 +239,7 @@ export default {
         this.selectedIndex = 1
       }
       this.$refs.actionModal.open()
-      console.log(this.validator)
+      //console.log(this.validator)
     },
     validateForm() {
       this.$v.$touch()

--- a/src/ActionModal/components/DelegationModal.vue
+++ b/src/ActionModal/components/DelegationModal.vue
@@ -13,6 +13,9 @@
   >
     <TmFormGroup class="action-modal-form-group">
       <div class="form-message notice">
+        <span v-if="validatorStatus === `Inactive`">
+          You are about to <span v-if="isRedelegation()">re</span>delegate to an <strong>inactive</strong> validator ({{ ValidatorStatusDetailed }})
+        </span>
         <span v-if="!isRedelegation()">
           It will take 21 days to unlock your tokens after a delegation and
           there is a risk that some tokens will be lost depending on the
@@ -207,6 +210,21 @@ export default {
           )}s`
         }
       }
+    },
+    ValidatorStatus() {
+      if (
+        this.validator.jailed ||
+        this.validator.tombstoned ||
+        this.validator.status === 0
+      )
+        return `Inactive`
+      return `Active`
+    },
+    ValidatorStatusDetailed() {
+      if (this.validator.jailed) return `Temporally banned from the network`
+      if (this.validator.tombstoned) return `Banned from the network`
+      if (this.validator.status === 0) return `Banned from the network`
+      return false
     }
   },
   methods: {

--- a/tests/unit/specs/components/ActionModal/components/__snapshots__/DelegationModal.spec.js.snap
+++ b/tests/unit/specs/components/ActionModal/components/__snapshots__/DelegationModal.spec.js.snap
@@ -37,6 +37,10 @@ exports[`DelegationModal should display the delegation modal form 1`] = `
       type="text"
       value="cosmosvaladdr15ky9du8a2wlstz6fpx3p4mqpjyrm5ctplpn3au"
     />
+     
+    <!---->
+     
+    <!---->
   </tmformgroup-stub>
    
   <tmformgroup-stub


### PR DESCRIPTION
Closes #1932

**Description:**

Warn if user is trying to delegate to a jailed/tombstone validator.

Jailed:

![image](https://user-images.githubusercontent.com/9256178/65893514-5addb180-e3a8-11e9-97d2-b01d0d8c06c6.png)

Tombstoned:

![image](https://user-images.githubusercontent.com/9256178/65893614-82cd1500-e3a8-11e9-9702-ac9c9a9ed8f4.png)

Thank you! 🚀

---

For contributor:

- [ ] Added changes entries. Run `yarn changelog` for a guided process.
- [ ] Reviewed `Files changed` in the github PR explorer
- [ ] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI
