### PR TITLE
Mario/2821 account list in explore

### DIFF
--- a/changes/mario_2821-account-list-in-explore
+++ b/changes/mario_2821-account-list-in-explore
@@ -1,0 +1,1 @@
+[Added] [#2821](https://github.com/cosmos/lunie/issues/2821) Use account list in explore mode with previously used addresses @mariopino

--- a/src/components/common/TmSessionExplore.vue
+++ b/src/components/common/TmSessionExplore.vue
@@ -90,7 +90,6 @@ export default {
     ...mapState([`session`])
   },
   mounted() {
-    console.log(this.session)
     this.address = localStorage.getItem(`prevAddress`)
   },
   methods: {

--- a/src/components/common/TmSessionExplore.vue
+++ b/src/components/common/TmSessionExplore.vue
@@ -126,13 +126,11 @@ export default {
       if (addressType === "explore") return `language`
       if (addressType === "ledger") return `vpn_key`
       if (addressType === "extension") return `laptop`
-      return false
     },
     getAddressTypeDescription(addressType) {
       if (addressType === "explore") return `Explore Mode`
       if (addressType === "ledger") return `Ledger Nano S`
       if (addressType === "extension") return `Lunie Browser Extension`
-      return false
     },
     shortenAddress(address) {
       return `${address.substring(0, 12)}...${address.substring(address.length - 12)}`

--- a/src/components/common/TmSessionExplore.vue
+++ b/src/components/common/TmSessionExplore.vue
@@ -126,6 +126,15 @@ export default {
     },
     updateAddress(address) {
       this.address = address
+      this.$v.$touch()
+      if (this.$v.$error) return
+
+      this.$store.dispatch(`signIn`, {
+        sessionType: `explore`,
+        address: this.address
+      })
+      localStorage.setItem(`prevAddress`, this.address)
+      this.$router.push(`/`)
     }
   },
   validations() {

--- a/src/components/common/TmSessionExplore.vue
+++ b/src/components/common/TmSessionExplore.vue
@@ -20,7 +20,7 @@
             </div>
             <div class="tm-li-session-text">
               <div class="tm-li-session-title">
-                <span>{{ shortenAddress(account.address) }}</span>
+                <span>{{ account.address | formatBech32(false, 12) }}</span>
                 <p class="tm-li-session-subtitle">
                   {{ getAddressTypeDescription(account.type) }}
                 </p>
@@ -75,6 +75,8 @@ import TmFormStruct from "common/TmFormStruct"
 import TmField from "common/TmField"
 import TmFormMsg from "common/TmFormMsg"
 import bech32 from "bech32"
+import { formatBech32 } from "src/filters"
+
 export default {
   name: `session-explore`,
   components: {
@@ -84,6 +86,9 @@ export default {
     TmFormGroup,
     TmFormMsg,
     TmFormStruct
+  },
+  filters: {
+    formatBech32
   },
   data: () => ({
     address: ``,
@@ -131,9 +136,6 @@ export default {
       if (addressType === "explore") return `Explore Mode`
       if (addressType === "ledger") return `Ledger Nano S`
       if (addressType === "extension") return `Lunie Browser Extension`
-    },
-    shortenAddress(address) {
-      return `${address.substring(0, 12)}...${address.substring(address.length - 12)}`
     },
     exploreWith(address) {
       this.address = address

--- a/src/components/common/TmSessionExplore.vue
+++ b/src/components/common/TmSessionExplore.vue
@@ -180,6 +180,7 @@ export default {
   color: var(--bright);
   font-size: var(--h4);
   font-weight: 400;
+  margin-top: -0.4rem;
 }
 
 .tm-li-session-subtitle {
@@ -187,6 +188,7 @@ export default {
   width: 100%;
   font-size: var(--h6);
   font-weight: 400;
+  color: var(--dim);
 }
 
 .tm-li-session-text {

--- a/src/components/common/TmSessionExplore.vue
+++ b/src/components/common/TmSessionExplore.vue
@@ -14,14 +14,16 @@
         >
           <div class="tm-li-session">
             <div class="tm-li-session-icon">
-              <i class="material-icons circle">{{
-                getAddressIcon(account.type)
-              }}</i>
+              <i class="material-icons circle">
+                {{ getAddressIcon(account.type) }}
+              </i>
             </div>
             <div class="tm-li-session-text">
               <div class="tm-li-session-title">
                 <span>{{ shortenAddress(account.address) }}</span>
-                <p class="tm-li-session-subtitle">{{ getAddressTypeDescription(account.type)}}</p>
+                <p class="tm-li-session-subtitle">
+                  {{ getAddressTypeDescription(account.type) }}
+                </p>
               </div>
             </div>
             <div class="tm-li-session-icon">

--- a/src/components/common/TmSessionExplore.vue
+++ b/src/components/common/TmSessionExplore.vue
@@ -6,7 +6,12 @@
       </h2>
 
       <div v-if="session.addresses.length > 0" class="session-list">
-        <div v-for="account in session.addresses" v-bind:key="account.address" @click="updateAddress(account.address)">
+        <div
+          v-for="account in session.addresses"
+          v-bind:key="account.address"
+          v-bind:title="account.address"
+          @click="exploreWith(account.address)"
+        >
           <div class="tm-li-session">
             <div class="tm-li-session-icon">
               <i class="material-icons circle">{{
@@ -124,7 +129,7 @@ export default {
     shortenAddress(address) {
       return `${address.substring(0, 12)}...${address.substring(address.length - 12)}`
     },
-    updateAddress(address) {
+    exploreWith(address) {
       this.address = address
       this.onSubmit()
     }

--- a/src/components/common/TmSessionExplore.vue
+++ b/src/components/common/TmSessionExplore.vue
@@ -126,15 +126,7 @@ export default {
     },
     updateAddress(address) {
       this.address = address
-      this.$v.$touch()
-      if (this.$v.$error) return
-
-      this.$store.dispatch(`signIn`, {
-        sessionType: `explore`,
-        address: this.address
-      })
-      localStorage.setItem(`prevAddress`, this.address)
-      this.$router.push(`/`)
+      this.onSubmit()
     }
   },
   validations() {

--- a/src/components/common/TmSessionExplore.vue
+++ b/src/components/common/TmSessionExplore.vue
@@ -21,6 +21,7 @@
             <div class="tm-li-session-text">
               <div class="tm-li-session-title">
                 <span>{{ shortenAddress(account.address) }}</span>
+                <p class="tm-li-session-subtitle">{{ getAddressTypeDescription(account.type)}}</p>
               </div>
             </div>
             <div class="tm-li-session-icon">
@@ -125,6 +126,12 @@ export default {
       if (addressType === "extension") return `laptop`
       return false
     },
+    getAddressTypeDescription(addressType) {
+      if (addressType === "explore") return `Explore Mode`
+      if (addressType === "ledger") return `Ledger Nano S`
+      if (addressType === "extension") return `Lunie Browser Extension`
+      return false
+    },
     shortenAddress(address) {
       return `${address.substring(0, 12)}...${address.substring(address.length - 12)}`
     },
@@ -172,6 +179,13 @@ export default {
 .tm-li-session-title {
   color: var(--bright);
   font-size: var(--h4);
+  font-weight: 400;
+}
+
+.tm-li-session-subtitle {
+  display: block;
+  width: 100%;
+  font-size: var(--h6);
   font-weight: 400;
 }
 

--- a/src/initializeApp.js
+++ b/src/initializeApp.js
@@ -53,6 +53,7 @@ export default function init(urlParams, env = process.env) {
     // wait for connected as the check for session will sign in directly and query account data
     .then(() => {
       store.dispatch(`checkForPersistedSession`)
+      store.dispatch(`checkForPersistedAddresses`)
       store.dispatch("getDelegates")
       store.dispatch(`getPool`)
       store.dispatch(`getMintingParameters`)

--- a/src/vuex/modules/session.js
+++ b/src/vuex/modules/session.js
@@ -106,18 +106,9 @@ export default () => {
     async persistAddresses(store, { addresses }) {
       localStorage.setItem(`addresses`, JSON.stringify(addresses))
     },
-    async signIn(
-      { state, commit, dispatch },
-      { address, sessionType = `ledger` }
-    ) {
-      if (state.signedIn) {
-        await dispatch(`resetSessionData`)
-      }
 
-      commit(`setSignIn`, true)
-      commit(`setSessionType`, sessionType)
-      commit(`setUserAddress`, address)
-
+    async rememberAddress({ state, commit }, address, sessionType) {
+      console.log(`rememberAddress: ${address}`)
       // Check if signin address was previously used
       const sessionExist = state.addresses.find(
         usedAddress => address === usedAddress.address
@@ -130,7 +121,41 @@ export default () => {
           type: sessionType
         })
         commit(`setUserAddresses`, state.addresses)
+        console.log(`state.addresses: ${state.addresses}`)
       }
+    },
+
+
+    async signIn(
+      { state, commit, dispatch },
+      { address, sessionType = `ledger` }
+    ) {
+      if (state.signedIn) {
+        await dispatch(`resetSessionData`)
+      }
+
+      commit(`setSignIn`, true)
+      commit(`setSessionType`, sessionType)
+      commit(`setUserAddress`, address)
+
+      await dispatch(`rememberAddress`, {
+        address,
+        sessionType
+      })
+
+      /* // Check if signin address was previously used
+      const sessionExist = state.addresses.find(
+        usedAddress => address === usedAddress.address
+      )
+
+      // Add signin address to addresses array if was not used previously
+      if (!sessionExist) {
+        state.addresses.push({
+          address: address,
+          type: sessionType
+        })
+        commit(`setUserAddresses`, state.addresses)
+      } */
 
       await dispatch(`initializeWallet`, { address })
 

--- a/src/vuex/modules/session.js
+++ b/src/vuex/modules/session.js
@@ -145,6 +145,14 @@ export default () => {
       state.history = ["/"]
       commit(`setUserAddress`, null)
       //localStorage.removeItem(`session`)
+      // Clear session address and sessionType but keep addresses
+      let addresses = state.addresses
+      localStorage.setItem(
+        `session`,
+        JSON.stringify({
+          addresses
+        })
+      )
     },
     loadLocalPreferences({ state, dispatch }) {
       const localPreferences = localStorage.getItem(USER_PREFERENCES_KEY)

--- a/src/vuex/modules/session.js
+++ b/src/vuex/modules/session.js
@@ -118,9 +118,7 @@ export default () => {
       if (!sessionExist) {
         state.addresses.push(session)
         commit(`setUserAddresses`, state.addresses)
-        console.log(`Addresses: ${JSON.stringify(state.addresses)}`)
       }
-      //
 
       await dispatch(`initializeWallet`, { address })
       dispatch(`persistSession`, {

--- a/src/vuex/modules/session.js
+++ b/src/vuex/modules/session.js
@@ -106,26 +106,6 @@ export default () => {
     async persistAddresses(store, { addresses }) {
       localStorage.setItem(`addresses`, JSON.stringify(addresses))
     },
-
-
-    async rememberAddress({ state, commit }, address, sessionType) {
-      console.log(`rememberAddress: ${address}`)
-      // Check if signin address was previously used
-      const sessionExist = state.addresses.find(
-        usedAddress => address === usedAddress
-      )
-      // Add signin address to addresses array if was not used previously
-      if (!sessionExist) {
-        state.addresses.push({
-          address: address,
-          type: sessionType
-        })
-        commit(`setUserAddresses`, state.addresses)
-        console.log(`state.addresses: ${state.addresses}`)
-      }
-    },
-
-
     async signIn(
       { state, commit, dispatch },
       { address, sessionType = `ledger` }
@@ -138,10 +118,19 @@ export default () => {
       commit(`setSessionType`, sessionType)
       commit(`setUserAddress`, address)
 
-      dispatch(`rememberAddress`, {
-        address,
-        sessionType
-      })
+      // Check if signin address was previously used
+      const sessionExist = state.addresses.find(
+        usedAddress => address === usedAddress.address
+      )
+
+      // Add signin address to addresses array if was not used previously
+      if (!sessionExist) {
+        state.addresses.push({
+          address: address,
+          type: sessionType
+        })
+        commit(`setUserAddresses`, state.addresses)
+      }
 
       await dispatch(`initializeWallet`, { address })
 

--- a/src/vuex/modules/session.js
+++ b/src/vuex/modules/session.js
@@ -121,7 +121,7 @@ export default () => {
           type: sessionType
         })
         commit(`setUserAddresses`, state.addresses)
-        console.log(`state.addresses: ${state.addresses}`)
+        console.log(`state.addresses: ${JSON.stringify(state.addresses)}`)
       }
     },
 

--- a/src/vuex/modules/session.js
+++ b/src/vuex/modules/session.js
@@ -108,7 +108,7 @@ export default () => {
     },
 
     async rememberAddress({ state, commit }, address, sessionType) {
-      console.log(`rememberAddress: ${address}`)
+      console.log(`rememberAddress: ${JSON.stringify(address)}`)
       // Check if signin address was previously used
       const sessionExist = state.addresses.find(
         usedAddress => address === usedAddress.address

--- a/src/vuex/modules/session.js
+++ b/src/vuex/modules/session.js
@@ -107,16 +107,11 @@ export default () => {
       commit(`setUserAddress`, address)
 
       // Check if signin address was previously used
-      const sessionExist = state.addresses.reduce(function (usedAddress) {
+      const sessionExist = state.addresses.find(function (usedAddress) {
         return address === usedAddress;
       }, false);
 
-      /* let sessionExist = false;
-      for (let i = 0; i < state.addresses.length; i++) {
-        if (state.addresses[i].address === address) sessionExist = true
-      } */
-
-      // Add signin address to addresses array if not exist previously
+      // Add signin address to addresses array if was not used previously
       if (!sessionExist) {
         state.addresses.push({
           address: address,

--- a/src/vuex/modules/session.js
+++ b/src/vuex/modules/session.js
@@ -107,7 +107,7 @@ export default () => {
       localStorage.setItem(`addresses`, JSON.stringify(addresses))
     },
 
-    async rememberAddress({ state, commit }, address, sessionType) {
+    async rememberAddress({ state, commit }, { address, sessionType }) {
       console.log(`remember address: ${address} type: ${sessionType}`)
       // Check if signin address was previously used
       const sessionExist = state.addresses.find(

--- a/src/vuex/modules/session.js
+++ b/src/vuex/modules/session.js
@@ -58,7 +58,9 @@ export default () => {
       state.address = address
     },
     setUserAddresses(state, addresses) {
+      console.log(`Updaeting used addresses!`)
       state.addresses = addresses
+      console.log(`Updated: ${state.addresses}`)
     },
     setExperimentalMode(state) {
       state.experimentalMode = true

--- a/src/vuex/modules/session.js
+++ b/src/vuex/modules/session.js
@@ -113,7 +113,6 @@ export default () => {
 
       // Add signin address to addresses array if was not used previously
       if (!sessionExist) {
-        console.log(`Signin address ${address} was not used previously`)
         state.addresses.push({
           address: address,
           type: sessionType

--- a/src/vuex/modules/session.js
+++ b/src/vuex/modules/session.js
@@ -93,6 +93,7 @@ export default () => {
     },
     async checkForPersistedAddresses({ commit }) {
       const addresses = localStorage.getItem(`addresses`)
+      console.log(`Used addresses: ${addresses}`)
       if (addresses) {
         commit(`setUserAddresses`, JSON.parse(addresses))
       }

--- a/src/vuex/modules/session.js
+++ b/src/vuex/modules/session.js
@@ -116,14 +116,13 @@ export default () => {
       commit(`setUserAddress`, address)
 
       // Check if signin address was previously used
-      let addresses = state.addresses
-      const sessionExist = addresses.find(function(usedAddress) {
+      const sessionExist = state.addresses.find(function(usedAddress) {
         return address === usedAddress.address
       })
 
       // Add signin address to addresses array if was not used previously
       if (!sessionExist) {
-        addresses.push({
+        state.addresses.push({
           address: address,
           type: sessionType
         })
@@ -136,7 +135,7 @@ export default () => {
         address,
         sessionType
       })
-
+      let addresses = state.addresses
       dispatch(`persistAddresses`, {
         addresses
       })

--- a/src/vuex/modules/session.js
+++ b/src/vuex/modules/session.js
@@ -17,11 +17,11 @@ export default () => {
     experimentalMode: config.development, // development mode, can be set from browser
     insecureMode: false, // show the local signer
     signedIn: false,
-    sessionType: null, // local, ledger, extension
+    sessionType: null, // explore, ledger, extension
     pauseHistory: false,
     history: [],
     address: null, // Current address
-    addresses: [], // Array of used addresses. Must include account source (ledger, extension, typed in)
+    addresses: [], // Array of previously used addresses
     errorCollection: false,
     analyticsCollection: false,
     cookiesAccepted: undefined,

--- a/src/vuex/modules/session.js
+++ b/src/vuex/modules/session.js
@@ -109,10 +109,12 @@ export default () => {
 
     // Add signin address to addresses array if was not used previously
     async rememberAddress({ state, commit, dispatch }, address, sessionType) {
+      console.log(`rememberAddress!`)
       // Check if signin address was previously used
       const sessionExist = state.addresses.find(
         usedAddress => address === usedAddress.address
       )
+      console.log(`sessionExist: ${sessionExist}`)
       if (!sessionExist) {
         state.addresses.push({
           address: address,

--- a/src/vuex/modules/session.js
+++ b/src/vuex/modules/session.js
@@ -106,17 +106,22 @@ export default () => {
       commit(`setSessionType`, sessionType)
       commit(`setUserAddress`, address)
 
-      // Add sign in address to addresses array if not exist previously
-      let session = {
-        address: address,
-        type: sessionType
-      }
-      let sessionExist = false;
+      // Check if signin address was previously used
+      const sessionExist = state.addresses.reduce(function (usedAddress) {
+        return address === usedAddress;
+      }, false);
+
+      /* let sessionExist = false;
       for (let i = 0; i < state.addresses.length; i++) {
         if (state.addresses[i].address === address) sessionExist = true
-      }
+      } */
+
+      // Add signin address to addresses array if not exist previously
       if (!sessionExist) {
-        state.addresses.push(session)
+        state.addresses.push({
+          address: address,
+          type: sessionType
+        })
         commit(`setUserAddresses`, state.addresses)
       }
 

--- a/src/vuex/modules/session.js
+++ b/src/vuex/modules/session.js
@@ -144,7 +144,7 @@ export default () => {
     resetSessionData({ commit, state }) {
       state.history = ["/"]
       commit(`setUserAddress`, null)
-      localStorage.removeItem(`session`)
+      //localStorage.removeItem(`session`)
     },
     loadLocalPreferences({ state, dispatch }) {
       const localPreferences = localStorage.getItem(USER_PREFERENCES_KEY)

--- a/src/vuex/modules/session.js
+++ b/src/vuex/modules/session.js
@@ -109,10 +109,11 @@ export default () => {
       // Check if signin address was previously used
       const sessionExist = state.addresses.find(function (usedAddress) {
         return address === usedAddress;
-      }, false);
+      });
 
       // Add signin address to addresses array if was not used previously
       if (!sessionExist) {
+        console.log(`Signin address ${address} was not used previously`)
         state.addresses.push({
           address: address,
           type: sessionType

--- a/src/vuex/modules/session.js
+++ b/src/vuex/modules/session.js
@@ -109,6 +109,7 @@ export default () => {
 
 
     async rememberAddress({ state, commit }, address, sessionType) {
+      console.log(`rememberAddress: ${address}`)
       // Check if signin address was previously used
       const sessionExist = state.addresses.find(
         usedAddress => address === usedAddress.address
@@ -120,6 +121,7 @@ export default () => {
           type: sessionType
         })
         commit(`setUserAddresses`, state.addresses)
+        console.log(`state.addresses: ${state.addresses}`)
       }
     },
 

--- a/src/vuex/modules/session.js
+++ b/src/vuex/modules/session.js
@@ -88,8 +88,8 @@ export default () => {
       const session = localStorage.getItem(`session`)
       if (session) {
         const { address, sessionType, addresses } = JSON.parse(session)
-        await dispatch(`signIn`, { address, sessionType })
         commit(`setUserAddresses`, addresses)
+        await dispatch(`signIn`, { address, sessionType })
       }
     },
     async persistSession(store, { address, sessionType }) {

--- a/src/vuex/modules/session.js
+++ b/src/vuex/modules/session.js
@@ -17,7 +17,7 @@ export default () => {
     experimentalMode: config.development, // development mode, can be set from browser
     insecureMode: false, // show the local signer
     signedIn: false,
-    sessionType: null, // explore, ledger, extension
+    sessionType: null, // local, explore, ledger, extension
     pauseHistory: false,
     history: [],
     address: null, // Current address

--- a/src/vuex/modules/session.js
+++ b/src/vuex/modules/session.js
@@ -106,6 +106,24 @@ export default () => {
     async persistAddresses(store, { addresses }) {
       localStorage.setItem(`addresses`, JSON.stringify(addresses))
     },
+
+
+    async rememberAddress({ state, commit }, address, sessionType) {
+      // Check if signin address was previously used
+      const sessionExist = state.addresses.find(
+        usedAddress => address === usedAddress.address
+      )
+      // Add signin address to addresses array if was not used previously
+      if (!sessionExist) {
+        state.addresses.push({
+          address: address,
+          type: sessionType
+        })
+        commit(`setUserAddresses`, state.addresses)
+      }
+    },
+
+
     async signIn(
       { state, commit, dispatch },
       { address, sessionType = `ledger` }
@@ -118,23 +136,10 @@ export default () => {
       commit(`setSessionType`, sessionType)
       commit(`setUserAddress`, address)
 
-      // Check if signin address was previously used
-      /* const sessionExist = state.addresses.find(function(usedAddress) {
-        return address === usedAddress.address
-      }) */
-
-      const sessionExist = state.addresses.find(
-        usedAddress => address === usedAddress.address
-      )
-
-      // Add signin address to addresses array if was not used previously
-      if (!sessionExist) {
-        state.addresses.push({
-          address: address,
-          type: sessionType
-        })
-        commit(`setUserAddresses`, state.addresses)
-      }
+      dispatch(`rememberAddress`, {
+        addresses,
+        sessionType
+      })
 
       await dispatch(`initializeWallet`, { address })
 

--- a/src/vuex/modules/session.js
+++ b/src/vuex/modules/session.js
@@ -107,7 +107,7 @@ export default () => {
       localStorage.setItem(`addresses`, JSON.stringify(addresses))
     },
 
-    async rememberAddress({ state, commit }, address, sessionType) {
+    async rememberAddress({ state, commit }, address) {
       console.log(`rememberAddress: ${JSON.stringify(address)}`)
       // Check if signin address was previously used
       const sessionExist = state.addresses.find(
@@ -117,8 +117,8 @@ export default () => {
       // Add signin address to addresses array if was not used previously
       if (!sessionExist) {
         state.addresses.push({
-          address: address,
-          type: sessionType
+          address: address.address,
+          type: address.sessionType
         })
         commit(`setUserAddresses`, state.addresses)
         console.log(`state.addresses: ${JSON.stringify(state.addresses)}`)
@@ -139,8 +139,7 @@ export default () => {
       commit(`setUserAddress`, address)
 
       await dispatch(`rememberAddress`, {
-        address,
-        sessionType
+        address
       })
 
       /* // Check if signin address was previously used

--- a/src/vuex/modules/session.js
+++ b/src/vuex/modules/session.js
@@ -107,7 +107,7 @@ export default () => {
       localStorage.setItem(`addresses`, JSON.stringify(addresses))
     },
 
-    async rememberAddress({ state, commit }, address) {
+    async rememberAddress({ state, commit }, address, sessionType) {
       console.log(`rememberAddress: ${JSON.stringify(address)}`)
       // Check if signin address was previously used
       const sessionExist = state.addresses.find(
@@ -117,8 +117,8 @@ export default () => {
       // Add signin address to addresses array if was not used previously
       if (!sessionExist) {
         state.addresses.push({
-          address: address.address,
-          type: address.sessionType
+          address: address,
+          type: sessionType
         })
         commit(`setUserAddresses`, state.addresses)
         console.log(`state.addresses: ${JSON.stringify(state.addresses)}`)
@@ -138,9 +138,7 @@ export default () => {
       commit(`setSessionType`, sessionType)
       commit(`setUserAddress`, address)
 
-      await dispatch(`rememberAddress`, {
-        address
-      })
+      await dispatch(`rememberAddress`, address, sessionType)
 
       /* // Check if signin address was previously used
       const sessionExist = state.addresses.find(

--- a/src/vuex/modules/session.js
+++ b/src/vuex/modules/session.js
@@ -146,13 +146,13 @@ export default () => {
       commit(`setUserAddress`, null)
       //localStorage.removeItem(`session`)
       // Clear session address and sessionType but keep addresses
-      let addresses = state.addresses
+      /* let addresses = state.addresses
       localStorage.setItem(
         `session`,
         JSON.stringify({
           addresses
         })
-      )
+      ) */
     },
     loadLocalPreferences({ state, dispatch }) {
       const localPreferences = localStorage.getItem(USER_PREFERENCES_KEY)

--- a/src/vuex/modules/session.js
+++ b/src/vuex/modules/session.js
@@ -95,7 +95,7 @@ export default () => {
       const addresses = localStorage.getItem(`addresses`)
       console.log(`Used addresses: ${addresses}`)
       if (addresses) {
-        commit(`setUserAddresses`, JSON.parse(addresses))
+        await commit(`setUserAddresses`, JSON.parse(addresses))
       }
     },
     async persistSession(store, { address, sessionType }) {

--- a/src/vuex/modules/session.js
+++ b/src/vuex/modules/session.js
@@ -138,7 +138,7 @@ export default () => {
       commit(`setSessionType`, sessionType)
       commit(`setUserAddress`, address)
 
-      await dispatch(`rememberAddress`, address, sessionType)
+      await dispatch(`rememberAddress`, { address, sessionType })
 
       /* // Check if signin address was previously used
       const sessionExist = state.addresses.find(

--- a/src/vuex/modules/session.js
+++ b/src/vuex/modules/session.js
@@ -84,15 +84,17 @@ export default () => {
   }
 
   const actions = {
-    async checkForPersistedSession({ dispatch }) {
+    async checkForPersistedSession({ dispatch, commit }) {
       const session = localStorage.getItem(`session`)
       if (session) {
-        const { address, sessionType } = JSON.parse(session)
+        const { address, sessionType, addresses } = JSON.parse(session)
         await dispatch(`signIn`, { address, sessionType })
+        commit(`setUserAddresses`, state.addresses)
       }
     },
     async persistSession(store, { address, sessionType }) {
-      localStorage.setItem(`session`, JSON.stringify({ address, sessionType }))
+      let addresses = store.addresses
+      localStorage.setItem(`session`, JSON.stringify({ address, sessionType, addresses }))
     },
     async signIn(
       { state, commit, dispatch },

--- a/src/vuex/modules/session.js
+++ b/src/vuex/modules/session.js
@@ -108,7 +108,7 @@ export default () => {
     },
 
     async rememberAddress({ state, commit }, address, sessionType) {
-      console.log(`rememberAddress: ${JSON.stringify(address)}`)
+      console.log(`remember address: ${address} type: ${sessionType}`)
       // Check if signin address was previously used
       const sessionExist = state.addresses.find(
         usedAddress => address === usedAddress.address

--- a/src/vuex/modules/session.js
+++ b/src/vuex/modules/session.js
@@ -108,9 +108,7 @@ export default () => {
 
       // Check if signin address was previously used
       const sessionExist = state.addresses.find(function (usedAddress) {
-        let ret = (address === usedAddress)
-        console.log(`address: ${address} - usedAddress: ${usedAddress} ret: ${JSON.stringify(ret)}`)
-        return address === usedAddress;
+        return address === usedAddress.address;
       });
 
       // Add signin address to addresses array if was not used previously

--- a/src/vuex/modules/session.js
+++ b/src/vuex/modules/session.js
@@ -111,7 +111,7 @@ export default () => {
       commit(`setUserAddress`, address)
 
       // Check if signin address was previously used
-      const sessionExist = state.addresses.find(function (usedAddress) {
+      const sessionExist = state.addresses.find(function(usedAddress) {
         return address === usedAddress.address
       })
 

--- a/src/vuex/modules/session.js
+++ b/src/vuex/modules/session.js
@@ -87,6 +87,7 @@ export default () => {
     async checkForPersistedSession({ dispatch, commit }) {
       const session = localStorage.getItem(`session`)
       if (session) {
+        console.log(`Local storage session: ${session}`);
         const { address, sessionType, addresses } = JSON.parse(session)
         commit(`setUserAddresses`, addresses)
         await dispatch(`signIn`, { address, sessionType })

--- a/src/vuex/modules/session.js
+++ b/src/vuex/modules/session.js
@@ -112,7 +112,7 @@ export default () => {
       console.log(`rememberAddress: ${address}`)
       // Check if signin address was previously used
       const sessionExist = state.addresses.find(
-        usedAddress => address === usedAddress.address
+        usedAddress => address === usedAddress
       )
       // Add signin address to addresses array if was not used previously
       if (!sessionExist) {

--- a/src/vuex/modules/session.js
+++ b/src/vuex/modules/session.js
@@ -92,9 +92,11 @@ export default () => {
         await dispatch(`signIn`, { address, sessionType })
       }
     },
-    async persistSession(store, { address, sessionType }) {
-      let addresses = store.addresses
-      localStorage.setItem(`session`, JSON.stringify({ address, sessionType, addresses }))
+    async persistSession(store, { address, sessionType, addresses }) {
+      localStorage.setItem(
+        `session`,
+        JSON.stringify({ address, sessionType, addresses })
+      )
     },
     async signIn(
       { state, commit, dispatch },
@@ -110,8 +112,8 @@ export default () => {
 
       // Check if signin address was previously used
       const sessionExist = state.addresses.find(function (usedAddress) {
-        return address === usedAddress.address;
-      });
+        return address === usedAddress.address
+      })
 
       // Add signin address to addresses array if was not used previously
       if (!sessionExist) {
@@ -123,9 +125,11 @@ export default () => {
       }
 
       await dispatch(`initializeWallet`, { address })
+      let addresses = state.addresses
       dispatch(`persistSession`, {
         address,
-        sessionType
+        sessionType,
+        addresses
       })
 
       state.externals.track(`event`, `session`, `sign-in`, sessionType)

--- a/src/vuex/modules/session.js
+++ b/src/vuex/modules/session.js
@@ -108,6 +108,8 @@ export default () => {
 
       // Check if signin address was previously used
       const sessionExist = state.addresses.find(function (usedAddress) {
+        let ret = (address === usedAddress)
+        console.log(`address: ${address} - usedAddress: ${usedAddress} ret: ${JSON.stringify(ret)}`)
         return address === usedAddress;
       });
 

--- a/src/vuex/modules/session.js
+++ b/src/vuex/modules/session.js
@@ -58,9 +58,9 @@ export default () => {
       state.address = address
     },
     setUserAddresses(state, addresses) {
-      console.log(`Updaeting used addresses!`)
+      console.log(`Updating used addresses!`)
       state.addresses = addresses
-      console.log(`Updated: ${state.addresses}`)
+      console.log(`Updated: ${JSON.stringify(state.addresses)}`)
     },
     setExperimentalMode(state) {
       state.experimentalMode = true

--- a/src/vuex/modules/session.js
+++ b/src/vuex/modules/session.js
@@ -104,7 +104,7 @@ export default () => {
       localStorage.setItem(`session`, JSON.stringify({ address, sessionType }))
     },
     async persistAddresses(store, { addresses }) {
-      localStorage.setItem(`addresses`, JSON.stringify({ addresses }))
+      localStorage.setItem(`addresses`, JSON.stringify(addresses))
     },
     async signIn(
       { state, commit, dispatch },

--- a/src/vuex/modules/session.js
+++ b/src/vuex/modules/session.js
@@ -58,9 +58,7 @@ export default () => {
       state.address = address
     },
     setUserAddresses(state, addresses) {
-      console.log(`Updating used addresses!`)
       state.addresses = addresses
-      console.log(`Updated: ${JSON.stringify(state.addresses)}`)
     },
     setExperimentalMode(state) {
       state.experimentalMode = true
@@ -95,7 +93,6 @@ export default () => {
     },
     async checkForPersistedAddresses({ commit }) {
       const addresses = localStorage.getItem(`addresses`)
-      console.log(`Used addresses: ${addresses}`)
       if (addresses) {
         await commit(`setUserAddresses`, JSON.parse(addresses))
       }
@@ -106,14 +103,11 @@ export default () => {
     async persistAddresses(store, { addresses }) {
       localStorage.setItem(`addresses`, JSON.stringify(addresses))
     },
-
     async rememberAddress({ state, commit }, { address, sessionType }) {
-      console.log(`remember address: ${address} type: ${sessionType}`)
       // Check if signin address was previously used
       const sessionExist = state.addresses.find(
         usedAddress => address === usedAddress.address
       )
-
       // Add signin address to addresses array if was not used previously
       if (!sessionExist) {
         state.addresses.push({
@@ -121,11 +115,8 @@ export default () => {
           type: sessionType
         })
         commit(`setUserAddresses`, state.addresses)
-        console.log(`state.addresses: ${JSON.stringify(state.addresses)}`)
       }
     },
-
-
     async signIn(
       { state, commit, dispatch },
       { address, sessionType = `ledger` }
@@ -139,20 +130,6 @@ export default () => {
       commit(`setUserAddress`, address)
 
       await dispatch(`rememberAddress`, { address, sessionType })
-
-      /* // Check if signin address was previously used
-      const sessionExist = state.addresses.find(
-        usedAddress => address === usedAddress.address
-      )
-
-      // Add signin address to addresses array if was not used previously
-      if (!sessionExist) {
-        state.addresses.push({
-          address: address,
-          type: sessionType
-        })
-        commit(`setUserAddresses`, state.addresses)
-      } */
 
       await dispatch(`initializeWallet`, { address })
 

--- a/src/vuex/modules/session.js
+++ b/src/vuex/modules/session.js
@@ -137,7 +137,7 @@ export default () => {
       commit(`setUserAddress`, address)
 
       dispatch(`rememberAddress`, {
-        addresses,
+        address,
         sessionType
       })
 

--- a/src/vuex/modules/session.js
+++ b/src/vuex/modules/session.js
@@ -89,7 +89,7 @@ export default () => {
       if (session) {
         const { address, sessionType, addresses } = JSON.parse(session)
         await dispatch(`signIn`, { address, sessionType })
-        commit(`setUserAddresses`, state.addresses)
+        commit(`setUserAddresses`, addresses)
       }
     },
     async persistSession(store, { address, sessionType }) {

--- a/src/vuex/modules/session.js
+++ b/src/vuex/modules/session.js
@@ -119,13 +119,13 @@ export default () => {
       commit(`setUserAddress`, address)
 
       // Check if signin address was previously used
-      const sessionExist = state.addresses.find(function(usedAddress) {
+      /* const sessionExist = state.addresses.find(function(usedAddress) {
         return address === usedAddress.address
-      })
+      }) */
 
-      /* const sessionExist = state.addresses.find(
+      const sessionExist = state.addresses.find(
         usedAddress => address === usedAddress.address
-      ) */
+      )
 
       // Add signin address to addresses array if was not used previously
       if (!sessionExist) {

--- a/src/vuex/modules/session.js
+++ b/src/vuex/modules/session.js
@@ -107,23 +107,20 @@ export default () => {
       localStorage.setItem(`addresses`, JSON.stringify(addresses))
     },
 
+    // Add signin address to addresses array if was not used previously
     async rememberAddress({ state, commit, dispatch }, address, sessionType) {
       // Check if signin address was previously used
       const sessionExist = state.addresses.find(
         usedAddress => address === usedAddress.address
       )
-      // Add signin address to addresses array if was not used previously
       if (!sessionExist) {
         state.addresses.push({
           address: address,
           type: sessionType
         })
         commit(`setUserAddresses`, state.addresses)
-        let addresses = state.addresses
-        dispatch(`persistAddresses`, {
-          addresses
-        })
       }
+      dispatch(`persistAddresses`, { addresses: state.addresses })
     },
 
     async signIn(

--- a/src/vuex/store.js
+++ b/src/vuex/store.js
@@ -103,7 +103,8 @@ function persistState(state) {
     votes: state.votes,
     governanceParameters: state.governanceParameters,
     session: {
-      address: state.session.address
+      address: state.session.address,
+      addresses: state.session.addresses
     }
   })
   // Store the state object as a JSON string

--- a/src/vuex/store.js
+++ b/src/vuex/store.js
@@ -103,8 +103,7 @@ function persistState(state) {
     votes: state.votes,
     governanceParameters: state.governanceParameters,
     session: {
-      address: state.session.address,
-      addresses: state.session.addresses
+      address: state.session.address
     }
   })
   // Store the state object as a JSON string

--- a/src/vuex/store.js
+++ b/src/vuex/store.js
@@ -81,7 +81,6 @@ export function storeUpdateHandler(mutation, state, pending) {
  * @param state
  */
 function persistState(state) {
-  //console.log(`Address: ${state.session.address}`)
   const cachedState = JSON.stringify({
     transactions: {
       wallet: state.transactions.wallet,

--- a/tests/unit/specs/components/common/TmSessionExplore.spec.js
+++ b/tests/unit/specs/components/common/TmSessionExplore.spec.js
@@ -12,8 +12,11 @@ describe(`TmSessionExplore`, () => {
     $store = {
       commit: jest.fn(),
       dispatch: jest.fn(() => true),
-      getters: {
-        connected: true
+      state: {
+        session: {
+          address: ``,
+          addresses: []
+        }
       }
     }
 

--- a/tests/unit/specs/components/common/TmSessionExplore.spec.js
+++ b/tests/unit/specs/components/common/TmSessionExplore.spec.js
@@ -15,7 +15,20 @@ describe(`TmSessionExplore`, () => {
       state: {
         session: {
           address: ``,
-          addresses: []
+          addresses: [
+            {
+              address: `cosmos1z8mzakma7vnaajysmtkwt4wgjqr2m84tzvyfkz`,
+              type: `explore`
+            },
+            {
+              address: `cosmos1unc788q8md2jymsns24eyhua58palg5kc7cstv`,
+              type: `ledger`
+            },
+            {
+              address: `cosmos1vxkye0mpdtjhzrc6va5lcnxnuaa7m64khj8klc`,
+              type: `extension`
+            }
+          ]
         }
       }
     }
@@ -80,5 +93,15 @@ describe(`TmSessionExplore`, () => {
     TmSessionExplore.mounted.call(self)
 
     expect(self.address).toBe(`cosmos1xxx`)
+  })
+
+  it(`should explore with a previously used address`, async () => {
+    console.log(wrapper.html())
+    let address = `cosmos1z8mzakma7vnaajysmtkwt4wgjqr2m84tzvyfkz`
+    await wrapper.vm.exploreWith(address)
+    expect($store.dispatch).toHaveBeenCalledWith(`signIn`, {
+      address: `cosmos1z8mzakma7vnaajysmtkwt4wgjqr2m84tzvyfkz`,
+      sessionType: `explore`
+    })
   })
 })

--- a/tests/unit/specs/components/common/TmSessionExplore.spec.js
+++ b/tests/unit/specs/components/common/TmSessionExplore.spec.js
@@ -96,7 +96,6 @@ describe(`TmSessionExplore`, () => {
   })
 
   it(`should explore with a previously used address`, async () => {
-    console.log(wrapper.html())
     let address = `cosmos1z8mzakma7vnaajysmtkwt4wgjqr2m84tzvyfkz`
     await wrapper.vm.exploreWith(address)
     expect($store.dispatch).toHaveBeenCalledWith(`signIn`, {
@@ -104,5 +103,5 @@ describe(`TmSessionExplore`, () => {
       sessionType: `explore`
     })
   })
-  
+
 })

--- a/tests/unit/specs/components/common/TmSessionExplore.spec.js
+++ b/tests/unit/specs/components/common/TmSessionExplore.spec.js
@@ -104,4 +104,5 @@ describe(`TmSessionExplore`, () => {
       sessionType: `explore`
     })
   })
+  
 })

--- a/tests/unit/specs/components/common/__snapshots__/TmSessionExplore.spec.js.snap
+++ b/tests/unit/specs/components/common/__snapshots__/TmSessionExplore.spec.js.snap
@@ -14,6 +14,8 @@ exports[`TmSessionExplore shows a form to sign in with an address 1`] = `
     
     </h2>
      
+    <!---->
+     
     <div
       class="session-main"
     >

--- a/tests/unit/specs/components/common/__snapshots__/TmSessionExplore.spec.js.snap
+++ b/tests/unit/specs/components/common/__snapshots__/TmSessionExplore.spec.js.snap
@@ -29,7 +29,9 @@ exports[`TmSessionExplore shows a form to sign in with an address 1`] = `
             <i
               class="material-icons circle"
             >
+              
               language
+            
             </i>
           </div>
            
@@ -42,6 +44,14 @@ exports[`TmSessionExplore shows a form to sign in with an address 1`] = `
               <span>
                 cosmos1z8mza...r2m84tzvyfkz
               </span>
+               
+              <p
+                class="tm-li-session-subtitle"
+              >
+                
+                Explore Mode
+              
+              </p>
             </div>
           </div>
            
@@ -68,7 +78,9 @@ exports[`TmSessionExplore shows a form to sign in with an address 1`] = `
             <i
               class="material-icons circle"
             >
+              
               vpn_key
+            
             </i>
           </div>
            
@@ -81,6 +93,14 @@ exports[`TmSessionExplore shows a form to sign in with an address 1`] = `
               <span>
                 cosmos1unc78...palg5kc7cstv
               </span>
+               
+              <p
+                class="tm-li-session-subtitle"
+              >
+                
+                Ledger Nano S
+              
+              </p>
             </div>
           </div>
            
@@ -107,7 +127,9 @@ exports[`TmSessionExplore shows a form to sign in with an address 1`] = `
             <i
               class="material-icons circle"
             >
+              
               laptop
+            
             </i>
           </div>
            
@@ -120,6 +142,14 @@ exports[`TmSessionExplore shows a form to sign in with an address 1`] = `
               <span>
                 cosmos1vxkye...a7m64khj8klc
               </span>
+               
+              <p
+                class="tm-li-session-subtitle"
+              >
+                
+                Lunie Browser Extension
+              
+              </p>
             </div>
           </div>
            

--- a/tests/unit/specs/components/common/__snapshots__/TmSessionExplore.spec.js.snap
+++ b/tests/unit/specs/components/common/__snapshots__/TmSessionExplore.spec.js.snap
@@ -14,7 +14,127 @@ exports[`TmSessionExplore shows a form to sign in with an address 1`] = `
     
     </h2>
      
-    <!---->
+    <div
+      class="session-list"
+    >
+      <div
+        title="cosmos1z8mzakma7vnaajysmtkwt4wgjqr2m84tzvyfkz"
+      >
+        <div
+          class="tm-li-session"
+        >
+          <div
+            class="tm-li-session-icon"
+          >
+            <i
+              class="material-icons circle"
+            >
+              language
+            </i>
+          </div>
+           
+          <div
+            class="tm-li-session-text"
+          >
+            <div
+              class="tm-li-session-title"
+            >
+              <span>
+                cosmos1z8mza...r2m84tzvyfkz
+              </span>
+            </div>
+          </div>
+           
+          <div
+            class="tm-li-session-icon"
+          >
+            <i
+              class="material-icons"
+            >
+              arrow_forward
+            </i>
+          </div>
+        </div>
+      </div>
+      <div
+        title="cosmos1unc788q8md2jymsns24eyhua58palg5kc7cstv"
+      >
+        <div
+          class="tm-li-session"
+        >
+          <div
+            class="tm-li-session-icon"
+          >
+            <i
+              class="material-icons circle"
+            >
+              vpn_key
+            </i>
+          </div>
+           
+          <div
+            class="tm-li-session-text"
+          >
+            <div
+              class="tm-li-session-title"
+            >
+              <span>
+                cosmos1unc78...palg5kc7cstv
+              </span>
+            </div>
+          </div>
+           
+          <div
+            class="tm-li-session-icon"
+          >
+            <i
+              class="material-icons"
+            >
+              arrow_forward
+            </i>
+          </div>
+        </div>
+      </div>
+      <div
+        title="cosmos1vxkye0mpdtjhzrc6va5lcnxnuaa7m64khj8klc"
+      >
+        <div
+          class="tm-li-session"
+        >
+          <div
+            class="tm-li-session-icon"
+          >
+            <i
+              class="material-icons circle"
+            >
+              laptop
+            </i>
+          </div>
+           
+          <div
+            class="tm-li-session-text"
+          >
+            <div
+              class="tm-li-session-title"
+            >
+              <span>
+                cosmos1vxkye...a7m64khj8klc
+              </span>
+            </div>
+          </div>
+           
+          <div
+            class="tm-li-session-icon"
+          >
+            <i
+              class="material-icons"
+            >
+              arrow_forward
+            </i>
+          </div>
+        </div>
+      </div>
+    </div>
      
     <div
       class="session-main"

--- a/tests/unit/specs/components/common/__snapshots__/TmSessionExplore.spec.js.snap
+++ b/tests/unit/specs/components/common/__snapshots__/TmSessionExplore.spec.js.snap
@@ -42,7 +42,7 @@ exports[`TmSessionExplore shows a form to sign in with an address 1`] = `
               class="tm-li-session-title"
             >
               <span>
-                cosmos1z8mza...r2m84tzvyfkz
+                cosmos…r2m84tzvyfkz
               </span>
                
               <p
@@ -91,7 +91,7 @@ exports[`TmSessionExplore shows a form to sign in with an address 1`] = `
               class="tm-li-session-title"
             >
               <span>
-                cosmos1unc78...palg5kc7cstv
+                cosmos…palg5kc7cstv
               </span>
                
               <p
@@ -140,7 +140,7 @@ exports[`TmSessionExplore shows a form to sign in with an address 1`] = `
               class="tm-li-session-title"
             >
               <span>
-                cosmos1vxkye...a7m64khj8klc
+                cosmos…a7m64khj8klc
               </span>
                
               <p

--- a/tests/unit/specs/store/session.spec.js
+++ b/tests/unit/specs/store/session.spec.js
@@ -190,7 +190,7 @@ describe(`Module: Session`, () => {
       expect(dispatch).toHaveBeenCalledWith(`resetSessionData`)
     })
 
-    it("should remember the address", async () => {
+    it("should dispatch required actions", async () => {
       const address = `cosmos1z8mzakma7vnaajysmtkwt4wgjqr2m84tzvyfkz`
       const commit = jest.fn()
       const dispatch = jest.fn()
@@ -213,6 +213,22 @@ describe(`Module: Session`, () => {
       expect(dispatch).toHaveBeenCalledWith(`initializeWallet`, {
         address: `cosmos1z8mzakma7vnaajysmtkwt4wgjqr2m84tzvyfkz`
       })
+    })
+
+    it("should remember the address", async () => {
+      const address = `cosmos1z8mzakma7vnaajysmtkwt4wgjqr2m84tzvyfkz`
+      const commit = jest.fn()
+      state.signedIn = true
+      await actions.rememberAddress(
+        { state, commit },
+        { sessionType: `explore`, address }
+      )
+      expect(commit).toHaveBeenCalledWith(`setUserAddresses`, [
+        {
+          type: `explore`,
+          address
+        }
+      ])
     })
   })
 

--- a/tests/unit/specs/store/session.spec.js
+++ b/tests/unit/specs/store/session.spec.js
@@ -456,4 +456,50 @@ describe(`Module: Session`, () => {
       expect(dispatch).not.toHaveBeenCalled()
     })
   })
+
+  it("should save used addresses in local storage", async () => {
+    state.addresses = [
+      {
+        address: `123`,
+        type: `explore`
+      }
+    ]
+    await actions.persistAddresses({}, { addresses: state.addresses })
+    expect(localStorage.getItem(`addresses`)).toEqual(
+      JSON.stringify([
+        {
+          address: `123`,
+          type: `explore`
+        }
+      ])
+    )
+  })
+
+  it(`should restore previously used addresses from local storage`, async () => {
+    const commit = jest.fn()
+    localStorage.setItem(
+      `addresses`,
+      JSON.stringify([
+        {
+          address: `xxx`,
+          type: `explore`
+        },
+        {
+          address: `yyy`,
+          type: `ledger`
+        }
+      ])
+    )
+    await actions.checkForPersistedAddresses({ commit })
+    expect(commit).toHaveBeenCalledWith(`setUserAddresses`, [
+      {
+        address: `xxx`,
+        type: `explore`
+      },
+      {
+        address: `yyy`,
+        type: `ledger`
+      }
+    ])
+  })
 })

--- a/tests/unit/specs/store/session.spec.js
+++ b/tests/unit/specs/store/session.spec.js
@@ -238,14 +238,24 @@ describe(`Module: Session`, () => {
       const address = `cosmos1z8mzakma7vnaajysmtkwt4wgjqr2m84tzvyfkz`
       const commit = jest.fn()
       state.signedIn = true
+      state.addresses = [
+        {
+          address: `123`,
+          type: `explore`
+        }
+      ]
       await actions.rememberAddress(
         { state, commit },
         { sessionType: `explore`, address }
       )
       expect(commit).toHaveBeenCalledWith(`setUserAddresses`, [
         {
-          type: `explore`,
-          address
+          address: `123`,
+          type: `explore`
+        },
+        {
+          address,
+          type: `explore`
         }
       ])
     })

--- a/tests/unit/specs/store/session.spec.js
+++ b/tests/unit/specs/store/session.spec.js
@@ -78,6 +78,15 @@ describe(`Module: Session`, () => {
       )
     })
 
+    it(`should add user address to previously used addresses array`, () => {
+      let address = {
+        address: `cosmos15ky9du8a2wlstz6fpx3p4mqpjyrm5ctpesxxn9`,
+        sessionType: `explore`
+      }
+      mutations.setUserAddresses(state, address)
+      expect(state.addresses).toEqual(address)
+    })
+
     it(`should activate experimental mode`, () => {
       mutations.setExperimentalMode(state)
       expect(state.experimentalMode).toBe(true)

--- a/tests/unit/specs/store/session.spec.js
+++ b/tests/unit/specs/store/session.spec.js
@@ -195,12 +195,31 @@ describe(`Module: Session`, () => {
       const commit = jest.fn()
       const dispatch = jest.fn()
       state.signedIn = true
+      state.addresses = [
+        {
+          address: `123`,
+          type: `explore`
+        },
+        {
+          address: `456`,
+          type: `ledger`
+        }
+      ]
       await actions.signIn(
         { state, commit, dispatch },
         { sessionType: `explore`, address }
       )
       expect(dispatch).toHaveBeenCalledWith(`persistAddresses`, {
-        addresses: []
+        addresses: [
+          {
+            address: `123`,
+            type: `explore`
+          },
+          {
+            address: `456`,
+            type: `ledger`
+          }
+        ]
       })
       expect(dispatch).toHaveBeenCalledWith(`persistSession`, {
         address: `cosmos1z8mzakma7vnaajysmtkwt4wgjqr2m84tzvyfkz`,
@@ -213,6 +232,22 @@ describe(`Module: Session`, () => {
       expect(dispatch).toHaveBeenCalledWith(`initializeWallet`, {
         address: `cosmos1z8mzakma7vnaajysmtkwt4wgjqr2m84tzvyfkz`
       })
+    })
+
+    it("should commit checkForPersistedAddresses when dispatch checkForPersistedAddresses ", async () => {
+      const address = `cosmos1z8mzakma7vnaajysmtkwt4wgjqr2m84tzvyfkz`
+      const commit = jest.fn()
+      state.signedIn = true
+      await actions.rememberAddress(
+        { state, commit },
+        { sessionType: `explore`, address }
+      )
+      expect(commit).toHaveBeenCalledWith(`setUserAddresses`, [
+        {
+          type: `explore`,
+          address
+        }
+      ])
     })
 
     it("should remember the address", async () => {

--- a/tests/unit/specs/store/session.spec.js
+++ b/tests/unit/specs/store/session.spec.js
@@ -187,7 +187,32 @@ describe(`Module: Session`, () => {
         { sessionType: `explore`, address }
       )
 
-      expect(dispatch).toHaveBeenCalledWith("resetSessionData")
+      expect(dispatch).toHaveBeenCalledWith(`resetSessionData`)
+    })
+
+    it("should remember the address", async () => {
+      const address = `cosmos1z8mzakma7vnaajysmtkwt4wgjqr2m84tzvyfkz`
+      const commit = jest.fn()
+      const dispatch = jest.fn()
+      state.signedIn = true
+      await actions.signIn(
+        { state, commit, dispatch },
+        { sessionType: `explore`, address }
+      )
+      expect(dispatch).toHaveBeenCalledWith(`persistAddresses`, {
+        addresses: []
+      })
+      expect(dispatch).toHaveBeenCalledWith(`persistSession`, {
+        address: `cosmos1z8mzakma7vnaajysmtkwt4wgjqr2m84tzvyfkz`,
+        sessionType: `explore`
+      })
+      expect(dispatch).toHaveBeenCalledWith(`rememberAddress`, {
+        address: `cosmos1z8mzakma7vnaajysmtkwt4wgjqr2m84tzvyfkz`,
+        sessionType: `explore`
+      })
+      expect(dispatch).toHaveBeenCalledWith(`initializeWallet`, {
+        address: `cosmos1z8mzakma7vnaajysmtkwt4wgjqr2m84tzvyfkz`
+      })
     })
   })
 


### PR DESCRIPTION
Closes #2821

**Description:**

Use account list in explore mode with previously used addresses. You can click on the address to explore with it,

![image](https://user-images.githubusercontent.com/9256178/66003218-c8bbd300-e4a5-11e9-8a8a-27c54608b2d9.png)



Thank you! 🚀

---

For contributor:

- [ ] Added changes entries. Run `yarn changelog` for a guided process.
- [ ] Reviewed `Files changed` in the github PR explorer
- [ ] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI
