### PR TITLE
Atharva/fixes #2966 `url for "activity" still points to "transactions"`

### DIFF
--- a/changes/route-change
+++ b/changes/route-change
@@ -1,0 +1,1 @@
+[Changed] [##2966](https://github.com/cosmos/lunie/issues/#2966) /transaction is changed to /activity @atharva3010

--- a/src/components/common/AppMenu.vue
+++ b/src/components/common/AppMenu.vue
@@ -57,7 +57,7 @@
 
       <router-link
         class="app-menu-item hide-xs"
-        to="/transactions"
+        to="/activity"
         exact="exact"
         title="Transactions"
         @click.native="close"

--- a/src/components/common/MobileMenu.vue
+++ b/src/components/common/MobileMenu.vue
@@ -25,7 +25,7 @@
     </router-link>
     <router-link
       class="mobile-menu-item"
-      to="/transactions"
+      to="/activity"
       exact="exact"
       title="Transactions"
     >

--- a/src/components/common/Page404.vue
+++ b/src/components/common/Page404.vue
@@ -18,7 +18,7 @@
           </router-link>
         </li>
         <li>
-          <router-link to="/transactions">
+          <router-link to="/activity">
             Transactions
           </router-link>
         </li>

--- a/src/routes.js
+++ b/src/routes.js
@@ -73,13 +73,18 @@ export default [
     }
   },
   {
-    path: `/transactions`,
-    name: `transactions`,
+    path: `/activity`,
+    name: `activity`,
     component: require(`./components/wallet/PageTransactions`).default,
     meta: {
       requiresAuth: true,
       feature: "Activity"
     }
+  },
+  {
+    path: `/transactions`,
+    name: `transactions`,
+    redirect: `/activity`
   },
   {
     path: `/networks`,

--- a/src/vuex/modules/connection.js
+++ b/src/vuex/modules/connection.js
@@ -4,7 +4,7 @@ import config from "src/../config"
 const NODE_HALTED_TIMEOUT = config.node_halted_timeout
 const MAX_CONNECTION_ATTEMPTS = 5
 
-export default function ({ node }) {
+export default function({ node }) {
   // get tendermint RPC client from basecoin client
 
   const state = {

--- a/src/vuex/modules/delegation.js
+++ b/src/vuex/modules/delegation.js
@@ -22,14 +22,14 @@ export default ({ node }) => {
     setUnbondingDelegations(state, unbondingDelegations) {
       state.unbondingDelegations = unbondingDelegations
         ? unbondingDelegations
-          // building a dict from the array and taking out the validators with no undelegations
-          .reduce(
-            (dict, { validator_address, entries }) => ({
-              ...dict,
-              [validator_address]: entries.length > 0 ? entries : undefined
-            }),
-            {}
-          )
+            // building a dict from the array and taking out the validators with no undelegations
+            .reduce(
+              (dict, { validator_address, entries }) => ({
+                ...dict,
+                [validator_address]: entries.length > 0 ? entries : undefined
+              }),
+              {}
+            )
         : {}
     }
   }

--- a/tests/unit/specs/components/common/TmSessionExplore.spec.js
+++ b/tests/unit/specs/components/common/TmSessionExplore.spec.js
@@ -107,5 +107,4 @@ describe(`TmSessionExplore`, () => {
       sessionType: `explore`
     })
   })
-
 })

--- a/tests/unit/specs/components/common/__snapshots__/Page404.spec.js.snap
+++ b/tests/unit/specs/components/common/__snapshots__/Page404.spec.js.snap
@@ -48,7 +48,7 @@ exports[`Page404 should show the 404 page 1`] = `
        
       <li>
         <router-link-stub
-          to="/transactions"
+          to="/activity"
         >
           
           Transactions

--- a/tests/unit/specs/components/network/PageBlock.spec.js
+++ b/tests/unit/specs/components/network/PageBlock.spec.js
@@ -3,7 +3,7 @@ import PageBlock from "network/PageBlock"
 import { bankTxs } from "../../store/json/txs"
 
 const localVue = createLocalVue()
-localVue.directive(`tooltip`, () => { })
+localVue.directive(`tooltip`, () => {})
 
 describe(`PageBlock`, () => {
   let wrapper

--- a/tests/unit/specs/store/wallet.spec.js
+++ b/tests/unit/specs/store/wallet.spec.js
@@ -246,7 +246,7 @@ describe(`Module: Wallet`, () => {
 
     it(`should catch errors from subscriptions`, async () => {
       jest.useFakeTimers()
-      jest.spyOn(console, "error").mockImplementation(() => { })
+      jest.spyOn(console, "error").mockImplementation(() => {})
 
       const node = {
         tendermint: {


### PR DESCRIPTION
Closes #2966 

**Description:**

<!-- Briefly describe what you're adding or fixing with this PR -->
- redirects `/transactions` to `/activity`  
- added default route / URL for Activity to be `/activity`

Thank you! 🚀

---

For contributor:

- [x] Added changes entries. Run `yarn changelog` for a guided process.
- [ ] Reviewed `Files changed` in the github PR explorer
- [ ] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI
