### PR TITLE
fix 2918 serve fonts directly

### DIFF
--- a/changes/ana_2918-serve-fonts-directly-buttons
+++ b/changes/ana_2918-serve-fonts-directly-buttons
@@ -1,0 +1,1 @@
+[Code Improvements] [###2918](https://github.com/cosmos/lunie/issues/##2918) material design icons are now served directly @Bitcoinera

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "lodash.orderby": "^4.6.0",
     "lodash.trim": "^4.5.1",
     "lodash.uniqby": "^4.7.0",
+    "material-design-icons": "3.0.1",
     "moment": "^2.24.0",
     "no-scroll": "^2.1.1",
     "register-service-worker": "^1.6.2",

--- a/public/index.html
+++ b/public/index.html
@@ -24,7 +24,6 @@
   <meta name="msapplication-TileImage" content="/ms-icon-144x144.png">
   <meta name="theme-color" content="#ffffff">
   <meta name="Description" content="Lunie is the staking and governance platform for proof-of-stake blockchains.">
-  <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
   <title>Lunie</title>
 </head>
 

--- a/src/main.js
+++ b/src/main.js
@@ -15,6 +15,7 @@ import { Plugins } from "@capacitor/core"
 import config from "src/../config"
 import * as Sentry from "@sentry/browser"
 import * as Integrations from "@sentry/integrations"
+import '../node_modules/material-design-icons/iconfont/material-icons.css';
 
 if (config.sentryDSN) {
   Sentry.init({

--- a/src/main.js
+++ b/src/main.js
@@ -15,7 +15,7 @@ import { Plugins } from "@capacitor/core"
 import config from "src/../config"
 import * as Sentry from "@sentry/browser"
 import * as Integrations from "@sentry/integrations"
-import '../node_modules/material-design-icons/iconfont/material-icons.css';
+import "material-design-icons/iconfont/material-icons.css"
 
 if (config.sentryDSN) {
   Sentry.init({

--- a/yarn.lock
+++ b/yarn.lock
@@ -7726,6 +7726,11 @@ markdown-table@^1.1.0:
   resolved "https://registry.yarnpkg.com/markdown-table/-/markdown-table-1.1.3.tgz#9fcb69bcfdb8717bfd0398c6ec2d93036ef8de60"
   integrity sha512-1RUZVgQlpJSPWYbFSpmudq5nHY1doEIv89gBtF0s4gW1GF2XorxcA/70M5vq7rLv0a6mhOUccRsqkwhwLCIQ2Q==
 
+material-design-icons@3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/material-design-icons/-/material-design-icons-3.0.1.tgz#9a71c48747218ebca51e51a66da682038cdcb7bf"
+  integrity sha1-mnHEh0chjrylHlGmbaaCA4zct78=
+
 mathml-tag-names@^2.0.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/mathml-tag-names/-/mathml-tag-names-2.1.1.tgz#6dff66c99d55ecf739ca53c492e626f1d12a33cc"


### PR DESCRIPTION
Closes #2918 

**Description:**

I added the material-design-icons package as described in the official developers' documentation and deleted the former link to the google apis in the index.html.

Thank you! 🚀

---

For contributor:

- [x] Added changes entries. Run `yarn changelog` for a guided process.
- [x] Reviewed `Files changed` in the github PR explorer
- [ ] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI
