### PR TITLE
Ana/3133 loader on networks page missing

### DIFF
--- a/changes/ana_3133-loader-networks-page-missing
+++ b/changes/ana_3133-loader-networks-page-missing
@@ -1,0 +1,1 @@
+[Changed] [#3133](https://github.com/cosmos/lunie/issues/3133) Now the networks page also has a loader @Bitcoinera

--- a/src/components/network/PageNetworks.vue
+++ b/src/components/network/PageNetworks.vue
@@ -1,6 +1,7 @@
 <template>
   <TmPage data-title="Network" class="page" hide-header>
-    <template>
+    <TmDataLoading v-if="$apollo.loading" />
+    <template v-else-if="!$apollo.loading">
       <h3>Main Networks</h3>
       <NetworkList :networks="mainNetworks" />
       <h3>Test Networks</h3>
@@ -12,13 +13,15 @@
 <script>
 import { Networks, NetworksResult } from "src/gql"
 import NetworkList from "./NetworkList"
+import TmDataLoading from "common/TmDataLoading"
 
 import TmPage from "common/TmPage"
 export default {
   name: `page-network`,
   components: {
     TmPage,
-    NetworkList
+    NetworkList,
+    TmDataLoading
   },
   data: () => ({
     networks: []

--- a/tests/unit/specs/components/network/PageNetworks.spec.js
+++ b/tests/unit/specs/components/network/PageNetworks.spec.js
@@ -23,6 +23,15 @@ describe(`PageNetworks`, () => {
     }
   ]
 
+  const $apollo = {
+    queries: {
+      parameters: {
+        loading: false,
+        error: undefined
+      }
+    }
+  }
+
   beforeEach(() => {
     wrapper = shallowMount(PageNetworks, {
       localVue,
@@ -40,7 +49,8 @@ describe(`PageNetworks`, () => {
         },
         $router: {
           push: jest.fn()
-        }
+        },
+        $apollo
       },
       stubs: [`router-link`]
     })


### PR DESCRIPTION
Closes #3133

**Description:**

<!-- Briefly describe what you're adding or fixing with this PR -->
I added the simple loader (`TmDataLoading.vue`) to the Networks page

Thank you! 🚀

---

For contributor:

- [x] Added changes entries. Run `yarn changelog` for a guided process.
- [x] Reviewed `Files changed` in the github PR explorer
- [ ] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI
