### PR TITLE
Don't show apollo loading when searching

### DIFF
--- a/changes/mario_3131-loading-screen-in-search
+++ b/changes/mario_3131-loading-screen-in-search
@@ -1,0 +1,1 @@
+[Fixed] [#3131](https://github.com/cosmos/lunie/issues/3131) Don't show the loading screen when using search bar @mariopino

--- a/src/components/staking/PageValidators.vue
+++ b/src/components/staking/PageValidators.vue
@@ -32,7 +32,7 @@
       >
         No results for these search terms
       </div>
-      <TmDataLoading v-if="$apollo.loading" />
+      <TmDataLoading v-if="$apollo.loading && !searchTerm" />
     </template>
   </TmPage>
 </template>


### PR DESCRIPTION
Closes #3131 

**Description:**

Don't show the loading screen when using search bar.

Thank you! 🚀

---

For contributor:

- [ ] Added changes entries. Run `yarn changelog` for a guided process.
- [ ] Reviewed `Files changed` in the github PR explorer
- [ ] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI
