### PR TITLE
add ?ref=lunie to outgoing links

### DIFF
--- a/changes/ana_3182-add-ref=lunie-to-outgoing-links
+++ b/changes/ana_3182-add-ref=lunie-to-outgoing-links
@@ -1,0 +1,1 @@
+[Code Improvements] [#3182](https://github.com/cosmos/lunie/issues/3182) I added "?ref=lunie" at the end of the outgoing links @Bitcoinera

--- a/src/ActionModal/components/ActionModal.vue
+++ b/src/ActionModal/components/ActionModal.vue
@@ -159,7 +159,7 @@
             <div v-if="!extension.enabled">
               Please install the Lunie Browser Extension from the
               <a
-                href="https://chrome.google.com/webstore/category/extensions"
+                href="https://chrome.google.com/webstore/category/extensions?ref=lunie"
                 target="_blank"
                 rel="noopener norefferer"
                 >Chrome Web Store</a

--- a/src/components/common/PageAbout.vue
+++ b/src/components/common/PageAbout.vue
@@ -53,7 +53,7 @@
         To send transactions with Lunie, you'll have to sign them with your
         Ledger Nano. If you don't have a Ledger Nano, you can
         <a
-          href="https://shop.ledger.com/?r=3dd204ef7508?ref=lunie"
+          href="https://shop.ledger.com/?r=3dd204ef7508&ref=lunie"
           target="_blank"
           rel="noopener norefferer"
           >buy one here</a

--- a/src/components/common/PageAbout.vue
+++ b/src/components/common/PageAbout.vue
@@ -53,7 +53,7 @@
         To send transactions with Lunie, you'll have to sign them with your
         Ledger Nano. If you don't have a Ledger Nano, you can
         <a
-          href="https://shop.ledger.com/?r=3dd204ef7508"
+          href="https://shop.ledger.com/?r=3dd204ef7508?ref=lunie"
           target="_blank"
           rel="noopener norefferer"
           >buy one here</a

--- a/src/components/common/PageCareers.vue
+++ b/src/components/common/PageCareers.vue
@@ -26,7 +26,7 @@
       <ul class="jobs-list">
         <li>
           <a
-            href="https://angel.co/lunie/jobs/553123-senior-software-engineer-api-engineering-blockchain-systems"
+            href="https://angel.co/lunie/jobs/553123-senior-software-engineer-api-engineering-blockchain-systems?ref=lunie"
             class="job-title"
             target="_blank"
             rel="nofollow noreferrer noopener"
@@ -36,7 +36,7 @@
         </li>
         <li>
           <a
-            href="https://angel.co/lunie/jobs/553137-senior-software-engineer-javascript-frontend"
+            href="https://angel.co/lunie/jobs/553137-senior-software-engineer-javascript-frontend?ref=lunie"
             class="job-title"
             target="_blank"
             rel="nofollow noreferrer noopener"
@@ -46,7 +46,7 @@
         </li>
         <li>
           <a
-            href="https://angel.co/lunie/jobs/553139-senior-designer-product-marketing"
+            href="https://angel.co/lunie/jobs/553139-senior-designer-product-marketing?ref=lunie"
             class="job-title"
             target="_blank"
             rel="nofollow noreferrer noopener"

--- a/src/components/staking/PageValidator.vue
+++ b/src/components/staking/PageValidator.vue
@@ -68,7 +68,7 @@
           <span v-if="validator.website !== ``">
             <a
               id="validator-website"
-              :href="validator.website"
+              :href="validator.website + `?ref=lunie`"
               target="_blank"
               rel="nofollow noreferrer noopener"
               >{{ validator.website }}</a


### PR DESCRIPTION
Closes #3182

**Description:**
I just added the string "?ref=lunie" at the end of all the outgoing links of Lunie (going elsewhere than our own sites)
Somehow it doesn't seem to work much with `angel.co`. There the ending just disappears from the link. And also wondered if it made sense to add it in the links directing to the Lunie browser extension. But there it would also disappear.
 
<!-- Briefly describe what you're adding or fixing with this PR -->

Thank you! 🚀

---

For contributor:

- [x] Added changes entries. Run `yarn changelog` for a guided process.
- [x] Reviewed `Files changed` in the github PR explorer
- [ ] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI
