### PR TITLE
Fabo/fix page proposal

### DIFF
--- a/changes/fabo_fix-page-proposal
+++ b/changes/fabo_fix-page-proposal
@@ -1,0 +1,1 @@
+[Fixed] Hide balance header on page proposals @faboweb

--- a/src/components/governance/PageProposals.vue
+++ b/src/components/governance/PageProposals.vue
@@ -1,7 +1,5 @@
 <template>
-  <TmPage
-    data-title="Proposals"
-    :managed="false">
+  <TmPage data-title="Proposals" :managed="false" hide-header>
     <div class="button-container">
       <TmBtn
         id="propose-btn"
@@ -15,15 +13,15 @@
       :denom="parameters.depositDenom"
       @success="() => afterPropose()"
     />
-    <div v-if="!$apollo.loading && proposals.length === 0">     
+    <div v-if="!$apollo.loading && proposals.length === 0">
       <div>
         <TmDataMsg icon="gavel">
           <div slot="title">
             No Governance Proposals
           </div>
           <div slot="subtitle">
-            There are currently no governance proposals to display.
-            Click the 'Create Proposal' button to submit the first network proposal!
+            There are currently no governance proposals to display. Click the
+            'Create Proposal' button to submit the first network proposal!
           </div>
         </TmDataMsg>
       </div>

--- a/tests/unit/specs/components/governance/__snapshots__/PageProposals.spec.js.snap
+++ b/tests/unit/specs/components/governance/__snapshots__/PageProposals.spec.js.snap
@@ -3,6 +3,7 @@
 exports[`PageProposals shows a message if still loading 1`] = `
 <tmpage-stub
   data-title="Proposals"
+  hideheader="true"
   subtitle=""
   title=""
 >
@@ -33,8 +34,8 @@ exports[`PageProposals shows a message if still loading 1`] = `
          
         <div>
           
-          There are currently no governance proposals to display.
-          Click the 'Create Proposal' button to submit the first network proposal!
+          There are currently no governance proposals to display. Click the
+          'Create Proposal' button to submit the first network proposal!
         
         </div>
       </tmdatamsg-stub>
@@ -46,6 +47,7 @@ exports[`PageProposals shows a message if still loading 1`] = `
 exports[`PageProposals shows a message if there is nothing to display 1`] = `
 <tmpage-stub
   data-title="Proposals"
+  hideheader="true"
   subtitle=""
   title=""
 >
@@ -76,8 +78,8 @@ exports[`PageProposals shows a message if there is nothing to display 1`] = `
          
         <div>
           
-          There are currently no governance proposals to display.
-          Click the 'Create Proposal' button to submit the first network proposal!
+          There are currently no governance proposals to display. Click the
+          'Create Proposal' button to submit the first network proposal!
         
         </div>
       </tmdatamsg-stub>
@@ -89,6 +91,7 @@ exports[`PageProposals shows a message if there is nothing to display 1`] = `
 exports[`PageProposals shows a proposals table 1`] = `
 <tmpage-stub
   data-title="Proposals"
+  hideheader="true"
   subtitle=""
   title=""
 >


### PR DESCRIPTION
The balance header was showing. Now it isn't.
![image (1)](https://user-images.githubusercontent.com/5869273/69827060-1ccd0480-1216-11ea-9354-97856992d5eb.png)
