### PR TITLE
Fix validators are not being resolved to names in blocks page

### DIFF
--- a/changes/mario_3201-resolve-validator-names-blocks-page
+++ b/changes/mario_3201-resolve-validator-names-blocks-page
@@ -1,0 +1,1 @@
+[Fixed] [#3201](https://github.com/cosmos/lunie/issues/3201) Fix validators are not being resolved in blocks page @mariopino

--- a/src/components/network/PageBlock.vue
+++ b/src/components/network/PageBlock.vue
@@ -82,7 +82,7 @@ export default {
     validatorsAddressMap() {
       const names = {}
       this.validators.forEach(item => {
-        names[item.operator_address] = item
+        names[item.operatorAddress] = item
       })
       return names
     }
@@ -90,18 +90,8 @@ export default {
   apollo: {
     validators: {
       query: gql`
-        query validators(
-          $networkId: String!
-          $delegatorAddress: String
-          $all: Boolean
-          $query: String
-        ) {
-          validators(
-            networkId: $networkId
-            delegatorAddress: $delegatorAddress
-            all: $all
-            query: $query
-          ) {
+        query validators($networkId: String!) {
+          validators(networkId: $networkId) {
             name
             operatorAddress
           }


### PR DESCRIPTION
Closes #3201 

**Description:**

Fix typo in validatorsAddressMap() that was causing the problem and fix gql query errors by removing unused params that was causing errors in the frontend.

Thank you! 🚀

---

For contributor:

- [ ] Added changes entries. Run `yarn changelog` for a guided process.
- [ ] Reviewed `Files changed` in the github PR explorer
- [ ] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI
