### PR TITLE
Ana/3199 mobile close button signin

### DIFF
--- a/changes/ana_3199-mobile-close-button-signin
+++ b/changes/ana_3199-mobile-close-button-signin
@@ -1,0 +1,1 @@
+[Added] [#3199](https://github.com/cosmos/lunie/issues/3199) Now there is a close button also for mobile screen during the sign in flow @Bitcoinera

--- a/src/components/common/SessionFrame.vue
+++ b/src/components/common/SessionFrame.vue
@@ -9,6 +9,9 @@
           <a v-if="!hideBack" @click="goBack">
             <i class="material-icons circle back">arrow_back</i>
           </a>
+          <a v-if="!desktop" class="close-signin" @click="goBack">
+            <i class="material-icons">close</i>
+          </a>
           <slot></slot>
         </div>
       </div>
@@ -36,9 +39,33 @@ export default {
       default: false
     }
   },
+  data: () => ({
+    desktop: false
+  }),
+  mounted() {
+    this.watchWindowSize()
+    window.onresize = this.watchWindowSize
+  },
+  updated() {
+    this.watchWindowSize()
+    window.onresize = this.watchWindowSize
+  },
   methods: {
     goBack() {
       this.$router.go(`-1`)
+    },
+    watchWindowSize() {
+      const w = Math.max(
+        document.documentElement.clientWidth,
+        window.innerWidth || 0
+      )
+
+      if (w >= 1024) {
+        this.desktop = true
+        return
+      } else {
+        this.desktop = false
+      }
     }
   }
 }

--- a/src/components/common/SessionFrame.vue
+++ b/src/components/common/SessionFrame.vue
@@ -9,18 +9,21 @@
           <a v-if="!hideBack" @click="goBack">
             <i class="material-icons circle back">arrow_back</i>
           </a>
-          <a v-if="!desktop" class="close-signin" @click="goBack">
-            <i class="material-icons">close</i>
-          </a>
           <slot></slot>
         </div>
       </div>
-      <TmBtn
-        class="session-close"
-        value="Back to Lunie"
-        color="secondary"
-        @click.native="$router.push(`/`)"
-      />
+      <div v-if="desktop" class="session-close">
+        <TmBtn
+          value="Back to Lunie"
+          color="secondary"
+          @click.native="$router.push(`/`)"
+        />
+      </div>
+      <div v-else class="session-close session-close-mobile">
+        <a @click="goBack">
+          <i class="material-icons">close</i>
+        </a>
+      </div>
     </div>
   </transition>
 </template>

--- a/src/components/common/SessionFrame.vue
+++ b/src/components/common/SessionFrame.vue
@@ -12,15 +12,13 @@
           <slot></slot>
         </div>
       </div>
-      <div v-if="desktop" class="session-close">
-        <TmBtn
+      <div class="session-close">
+        <TmBtn class="session-close-button"
           value="Back to Lunie"
           color="secondary"
           @click.native="$router.push(`/`)"
         />
-      </div>
-      <div v-else class="session-close user-box">
-        <a @click="goBack">
+        <a class="user-box" @click="goBack">
           <i class="material-icons">close</i>
         </a>
       </div>
@@ -42,33 +40,9 @@ export default {
       default: false
     }
   },
-  data: () => ({
-    desktop: false
-  }),
-  mounted() {
-    this.watchWindowSize()
-    window.onresize = this.watchWindowSize
-  },
-  updated() {
-    this.watchWindowSize()
-    window.onresize = this.watchWindowSize
-  },
   methods: {
     goBack() {
       this.$router.go(`-1`)
-    },
-    watchWindowSize() {
-      const w = Math.max(
-        document.documentElement.clientWidth,
-        window.innerWidth || 0
-      )
-
-      if (w >= 1024) {
-        this.desktop = true
-        return
-      } else {
-        this.desktop = false
-      }
     }
   }
 }

--- a/src/components/common/SessionFrame.vue
+++ b/src/components/common/SessionFrame.vue
@@ -13,7 +13,8 @@
         </div>
       </div>
       <div class="session-close">
-        <TmBtn class="session-close-button"
+        <TmBtn
+          class="session-close-button"
           value="Back to Lunie"
           color="secondary"
           @click.native="$router.push(`/`)"

--- a/src/components/common/SessionFrame.vue
+++ b/src/components/common/SessionFrame.vue
@@ -19,7 +19,7 @@
           @click.native="$router.push(`/`)"
         />
       </div>
-      <div v-else class="session-close session-close-mobile">
+      <div v-else class="session-close user-box">
         <a @click="goBack">
           <i class="material-icons">close</i>
         </a>

--- a/src/components/common/TmSessionWelcome.vue
+++ b/src/components/common/TmSessionWelcome.vue
@@ -8,6 +8,9 @@
           alt="a small spinning circle to display loading"
         />
       </router-link>
+      <router-link to="/" class="session-close-mobile user-box">
+        <i class="material-icons">close</i>
+      </router-link>
 
       <h2 class="session-title welcome">
         Welcome to Lunie

--- a/src/styles/session.css
+++ b/src/styles/session.css
@@ -93,10 +93,6 @@
   top: 1.25rem;
 }
 
-.session-close-mobile {
-  cursor: pointer;
-}
-
 .session-footer {
   display: flex;
   justify-content: flex-end;
@@ -136,6 +132,29 @@
 
 .accounts-header {
   padding: 0 1rem;
+}
+
+.user-box {
+  font-size: 12px;
+  margin: 1rem;
+  padding: 0.5rem 0.75rem;
+  border-radius: 0.25rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.user-box i {
+  display: flex;
+  align-items: center;
+  padding: 0.5rem;
+  border-radius: 50%;
+  background: var(--bc-dim);
+}
+
+.user-box i:hover {
+  background: var(--bc);
+  cursor: pointer;
 }
 
 .session .material-icons.circle.back {

--- a/src/styles/session.css
+++ b/src/styles/session.css
@@ -143,6 +143,11 @@
   font-size: var(--x);
 }
 
+.session .close-signin {
+  cursor: pointer;
+  float: right;
+}
+
 @media screen and (min-width: 667px) {
   .session {
     width: 100%;

--- a/src/styles/session.css
+++ b/src/styles/session.css
@@ -232,3 +232,15 @@
     display: none;
   }
 }
+
+@media screen and (max-width: 1023px) {
+  .session-close .session-close-button {
+    display: none;
+  }
+}
+
+@media screen and (min-width: 1024px) {
+  .session-close .user-box {
+    display: none;
+  }
+}

--- a/src/styles/session.css
+++ b/src/styles/session.css
@@ -136,8 +136,7 @@
 
 .user-box {
   font-size: 12px;
-  margin: 1rem;
-  padding: 0.5rem 0.75rem;
+  margin-right: 1rem;
   border-radius: 0.25rem;
   display: flex;
   justify-content: space-between;
@@ -225,8 +224,8 @@
   .session-close-mobile {
     display: block;
     position: absolute;
-    right: 0.5rem;
-    top: 1rem;
+    right: 1rem;
+    top: 2.5rem;
   }
 
   .session-close {

--- a/src/styles/session.css
+++ b/src/styles/session.css
@@ -93,6 +93,10 @@
   top: 1.25rem;
 }
 
+.session-close-mobile {
+  cursor: pointer;
+}
+
 .session-footer {
   display: flex;
   justify-content: flex-end;
@@ -141,11 +145,6 @@
   padding: 0.25rem;
   cursor: pointer;
   font-size: var(--x);
-}
-
-.session .close-signin {
-  cursor: pointer;
-  float: right;
 }
 
 @media screen and (min-width: 667px) {
@@ -198,11 +197,5 @@
 
   .session-footer button {
     width: 100%;
-  }
-}
-
-@media screen and (max-width: 1023px) {
-  .session-frame .session-close {
-    display: none;
   }
 }

--- a/src/styles/session.css
+++ b/src/styles/session.css
@@ -181,6 +181,10 @@
     display: none;
   }
 
+  .session-close-mobile {
+    display: none;
+  }
+
   .session-paragraph {
     display: none;
   }
@@ -216,5 +220,16 @@
 
   .session-footer button {
     width: 100%;
+  }
+
+  .session-close-mobile {
+    display: block;
+    position: absolute;
+    right: 0.5rem;
+    top: 1rem;
+  }
+
+  .session-close {
+    display: none;
   }
 }

--- a/tests/unit/specs/components/common/SessionFrame.spec.js
+++ b/tests/unit/specs/components/common/SessionFrame.spec.js
@@ -11,6 +11,9 @@ describe(`SessionFrame`, () => {
           go: jest.fn()
         }
       },
+      methods: {
+        watchWindowSize: () => {} // overwriting to not cause side effects when setting the data in tests
+      },
       stubs: [`router-link`]
     })
   })
@@ -22,5 +25,12 @@ describe(`SessionFrame`, () => {
   it(`should go back to Welcome when back arrow is clicked`, () => {
     wrapper.vm.goBack()
     expect(wrapper.vm.$router.go).toHaveBeenCalledWith(`-1`)
+  })
+
+  it(`shows a material icon to close if windows width drops below 1024px`, () => {
+    wrapper.setData({
+      desktop: false,
+    })
+    expect(wrapper.element).toMatchSnapshot()
   })
 })

--- a/tests/unit/specs/components/common/SessionFrame.spec.js
+++ b/tests/unit/specs/components/common/SessionFrame.spec.js
@@ -11,9 +11,6 @@ describe(`SessionFrame`, () => {
           go: jest.fn()
         }
       },
-      methods: {
-        watchWindowSize: () => {} // overwriting to not cause side effects when setting the data in tests
-      },
       stubs: [`router-link`]
     })
   })
@@ -25,12 +22,5 @@ describe(`SessionFrame`, () => {
   it(`should go back to Welcome when back arrow is clicked`, () => {
     wrapper.vm.goBack()
     expect(wrapper.vm.$router.go).toHaveBeenCalledWith(`-1`)
-  })
-
-  it(`shows a material icon to close if windows width drops below 1024px`, () => {
-    wrapper.setData({
-      desktop: false,
-    })
-    expect(wrapper.element).toMatchSnapshot()
   })
 })

--- a/tests/unit/specs/components/common/__snapshots__/SessionFrame.spec.js.snap
+++ b/tests/unit/specs/components/common/__snapshots__/SessionFrame.spec.js.snap
@@ -1,51 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`SessionFrame shows a material icon to close if windows width drops below 1024px 1`] = `
-<div
-  class="session-frame"
-  mode="out-in"
-  name="component-fade"
->
-  <router-link-stub
-    to="/"
-  >
-    <img
-      class="session-logo"
-      src="~assets/images/lunie-logo-white.svg"
-    />
-  </router-link-stub>
-   
-  <div
-    class="session-outer-container"
-  >
-    <div
-      class="session"
-    >
-      <a>
-        <i
-          class="material-icons circle back"
-        >
-          arrow_back
-        </i>
-      </a>
-       
-    </div>
-  </div>
-   
-  <div
-    class="session-close user-box"
-  >
-    <a>
-      <i
-        class="material-icons"
-      >
-        close
-      </i>
-    </a>
-  </div>
-</div>
-`;
-
 exports[`SessionFrame shows an overview of all wallets to sign in with from the extension 1`] = `
 <div
   class="session-frame"
@@ -79,9 +33,17 @@ exports[`SessionFrame shows an overview of all wallets to sign in with from the 
   </div>
    
   <div
-    class="session-close user-box"
+    class="session-close"
   >
-    <a>
+    <tmbtn-stub
+      class="session-close-button"
+      color="secondary"
+      value="Back to Lunie"
+    />
+     
+    <a
+      class="user-box"
+    >
       <i
         class="material-icons"
       >

--- a/tests/unit/specs/components/common/__snapshots__/SessionFrame.spec.js.snap
+++ b/tests/unit/specs/components/common/__snapshots__/SessionFrame.spec.js.snap
@@ -1,5 +1,51 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`SessionFrame shows a material icon to close if windows width drops below 1024px 1`] = `
+<div
+  class="session-frame"
+  mode="out-in"
+  name="component-fade"
+>
+  <router-link-stub
+    to="/"
+  >
+    <img
+      class="session-logo"
+      src="~assets/images/lunie-logo-white.svg"
+    />
+  </router-link-stub>
+   
+  <div
+    class="session-outer-container"
+  >
+    <div
+      class="session"
+    >
+      <a>
+        <i
+          class="material-icons circle back"
+        >
+          arrow_back
+        </i>
+      </a>
+       
+    </div>
+  </div>
+   
+  <div
+    class="session-close user-box"
+  >
+    <a>
+      <i
+        class="material-icons"
+      >
+        close
+      </i>
+    </a>
+  </div>
+</div>
+`;
+
 exports[`SessionFrame shows an overview of all wallets to sign in with from the extension 1`] = `
 <div
   class="session-frame"
@@ -33,12 +79,15 @@ exports[`SessionFrame shows an overview of all wallets to sign in with from the 
   </div>
    
   <div
-    class="session-close"
+    class="session-close user-box"
   >
-    <tmbtn-stub
-      color="secondary"
-      value="Back to Lunie"
-    />
+    <a>
+      <i
+        class="material-icons"
+      >
+        close
+      </i>
+    </a>
   </div>
 </div>
 `;

--- a/tests/unit/specs/components/common/__snapshots__/SessionFrame.spec.js.snap
+++ b/tests/unit/specs/components/common/__snapshots__/SessionFrame.spec.js.snap
@@ -32,10 +32,13 @@ exports[`SessionFrame shows an overview of all wallets to sign in with from the 
     </div>
   </div>
    
-  <tmbtn-stub
+  <div
     class="session-close"
-    color="secondary"
-    value="Back to Lunie"
-  />
+  >
+    <tmbtn-stub
+      color="secondary"
+      value="Back to Lunie"
+    />
+  </div>
 </div>
 `;

--- a/tests/unit/specs/components/common/__snapshots__/TmSessionHardware.spec.js.snap
+++ b/tests/unit/specs/components/common/__snapshots__/TmSessionHardware.spec.js.snap
@@ -26,9 +26,10 @@ exports[`TmSessionHardware should show a state indicator for different states of
         </div>
       </div>
     </div>
-  </div> <button class="button session-close" color="secondary">
-    Back to Lunie
-  </button>
+  </div>
+  <div class="session-close"><button class="button" color="secondary">
+      Back to Lunie
+    </button></div>
 </div>
 `;
 
@@ -58,9 +59,10 @@ exports[`TmSessionHardware should show a state indicator for different states of
         </div>
       </div>
     </div>
-  </div> <button class="button session-close" color="secondary">
-    Back to Lunie
-  </button>
+  </div>
+  <div class="session-close"><button class="button" color="secondary">
+      Back to Lunie
+    </button></div>
 </div>
 `;
 
@@ -86,9 +88,10 @@ exports[`TmSessionHardware should show a state indicator for different states of
         </div>
       </div>
     </div>
-  </div> <button class="button session-close" color="secondary">
-    Back to Lunie
-  </button>
+  </div>
+  <div class="session-close"><button class="button" color="secondary">
+      Back to Lunie
+    </button></div>
 </div>
 `;
 
@@ -180,14 +183,18 @@ exports[`TmSessionHardware shows the ledger conection view when there're errors 
     </div>
   </div>
    
-  <button
-    class="button session-close"
-    color="secondary"
+  <div
+    class="session-close"
   >
-    
+    <button
+      class="button"
+      color="secondary"
+    >
+      
   Back to Lunie
 
-  </button>
+    </button>
+  </div>
 </div>
 `;
 
@@ -273,13 +280,17 @@ exports[`TmSessionHardware shows the ledger conection view with no errors 1`] = 
     </div>
   </div>
    
-  <button
-    class="button session-close"
-    color="secondary"
+  <div
+    class="session-close"
   >
-    
+    <button
+      class="button"
+      color="secondary"
+    >
+      
   Back to Lunie
 
-  </button>
+    </button>
+  </div>
 </div>
 `;

--- a/tests/unit/specs/components/common/__snapshots__/TmSessionHardware.spec.js.snap
+++ b/tests/unit/specs/components/common/__snapshots__/TmSessionHardware.spec.js.snap
@@ -27,9 +27,9 @@ exports[`TmSessionHardware should show a state indicator for different states of
       </div>
     </div>
   </div>
-  <div class="session-close"><button class="button" color="secondary">
+  <div class="session-close"><button class="button session-close-button" color="secondary">
       Back to Lunie
-    </button></div>
+    </button> <a class="user-box"><i class="material-icons">close</i></a></div>
 </div>
 `;
 
@@ -60,9 +60,9 @@ exports[`TmSessionHardware should show a state indicator for different states of
       </div>
     </div>
   </div>
-  <div class="session-close"><button class="button" color="secondary">
+  <div class="session-close"><button class="button session-close-button" color="secondary">
       Back to Lunie
-    </button></div>
+    </button> <a class="user-box"><i class="material-icons">close</i></a></div>
 </div>
 `;
 
@@ -89,9 +89,9 @@ exports[`TmSessionHardware should show a state indicator for different states of
       </div>
     </div>
   </div>
-  <div class="session-close"><button class="button" color="secondary">
+  <div class="session-close"><button class="button session-close-button" color="secondary">
       Back to Lunie
-    </button></div>
+    </button> <a class="user-box"><i class="material-icons">close</i></a></div>
 </div>
 `;
 
@@ -187,13 +187,23 @@ exports[`TmSessionHardware shows the ledger conection view when there're errors 
     class="session-close"
   >
     <button
-      class="button"
+      class="button session-close-button"
       color="secondary"
     >
       
   Back to Lunie
 
     </button>
+     
+    <a
+      class="user-box"
+    >
+      <i
+        class="material-icons"
+      >
+        close
+      </i>
+    </a>
   </div>
 </div>
 `;
@@ -284,13 +294,23 @@ exports[`TmSessionHardware shows the ledger conection view with no errors 1`] = 
     class="session-close"
   >
     <button
-      class="button"
+      class="button session-close-button"
       color="secondary"
     >
       
   Back to Lunie
 
     </button>
+     
+    <a
+      class="user-box"
+    >
+      <i
+        class="material-icons"
+      >
+        close
+      </i>
+    </a>
   </div>
 </div>
 `;

--- a/tests/unit/specs/components/common/__snapshots__/TmSessionWelcome.spec.js.snap
+++ b/tests/unit/specs/components/common/__snapshots__/TmSessionWelcome.spec.js.snap
@@ -17,6 +17,17 @@ exports[`TmSessionWelcome has the expected html structure 1`] = `
       />
     </router-link-stub>
      
+    <router-link-stub
+      class="session-close-mobile user-box"
+      to="/"
+    >
+      <i
+        class="material-icons"
+      >
+        close
+      </i>
+    </router-link-stub>
+     
     <h2
       class="session-title welcome"
     >
@@ -97,6 +108,17 @@ exports[`TmSessionWelcome has the expected html structure when on mobile 1`] = `
         class="session-logo-mobile"
         src="~assets/images/lunie-logo-white.svg"
       />
+    </router-link-stub>
+     
+    <router-link-stub
+      class="session-close-mobile user-box"
+      to="/"
+    >
+      <i
+        class="material-icons"
+      >
+        close
+      </i>
     </router-link-stub>
      
     <h2


### PR DESCRIPTION
Closes #3199 

**Description:**

<!-- Briefly describe what you're adding or fixing with this PR -->
Added a close button for the whole sign in process that shows up in screens thinner than 1023px.

Here a screenshot:

![image](https://user-images.githubusercontent.com/40721795/69995575-a3544f80-1550-11ea-8677-0f0e7f5b80c4.png)

Now looking at it again I am thinking it would look better with the user-box class as the background :thinking: 
Yes, I think I will also add that (and probably a couple of tests are missing too, oops)

Thank you! 🚀

---

For contributor:

- [x] Added changes entries. Run `yarn changelog` for a guided process.
- [x] Reviewed `Files changed` in the github PR explorer
- [ ] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI
