### PR TITLE
Improve error control in PageProposal

### DIFF
--- a/changes/mario_3093-page-proposal-error-control
+++ b/changes/mario_3093-page-proposal-error-control
@@ -1,0 +1,1 @@
+[Fixed] [#3093](https://github.com/cosmos/lunie/issues/3093) Improve error control in PageProposal @mariopino

--- a/src/components/common/TmDataNotFound.vue
+++ b/src/components/common/TmDataNotFound.vue
@@ -12,7 +12,7 @@
 <script>
 import TmDataMsg from "common/TmDataMsg"
 export default {
-  name: `tm-data-error`,
+  name: `tm-data-not-found`,
   components: { TmDataMsg }
 }
 </script>

--- a/src/components/common/TmDataNotFound.vue
+++ b/src/components/common/TmDataNotFound.vue
@@ -1,13 +1,10 @@
 <template>
   <TmDataMsg icon="sentiment_very_dissatisfied">
     <div slot="title">
-      Aw shucks!
+      Not found!
     </div>
     <div slot="subtitle">
-      Even though you're connected a full node, we can't display this data for
-      you right now. Please try again later or
-      <a href="https://github.com/luniehq/lunie/issues">file a bug report</a>.
-      Apologies!
+      We could not find the requested resource
     </div>
   </TmDataMsg>
 </template>

--- a/src/components/governance/PageProposal.vue
+++ b/src/components/governance/PageProposal.vue
@@ -310,6 +310,7 @@ export default {
         }
       },
       update(data) {
+        /* istanbul ignore next */
         if (
           data.proposals.find(
             proposal => proposal.id === parseInt(this.proposalId, 10)
@@ -317,7 +318,6 @@ export default {
         ) {
           this.found = true
         }
-        /* istanbul ignore next */
         return data.proposals
       }
     },

--- a/src/components/governance/PageProposal.vue
+++ b/src/components/governance/PageProposal.vue
@@ -305,6 +305,7 @@ export default {
         `
       },
       variables() {
+        /* istanbul ignore next */
         return {
           networkId: this.network
         }
@@ -337,6 +338,7 @@ export default {
         }
       },
       skip() {
+        /* istanbul ignore next */
         return !this.found
       },
       result(data) {
@@ -354,6 +356,7 @@ export default {
         return data.governanceParameters
       },
       skip() {
+        /* istanbul ignore next */
         return !this.found
       },
       result(data) {
@@ -374,6 +377,7 @@ export default {
         }
       },
       skip() {
+        /* istanbul ignore next */
         return !this.address || !this.found
       },
       update(data) {

--- a/src/components/governance/PageProposal.vue
+++ b/src/components/governance/PageProposal.vue
@@ -2,9 +2,12 @@
   <TmPage data-title="Proposal" hide-header class="small">
     <TmDataLoading
       v-if="
-        $apollo.queries.proposal.loading || $apollo.queries.parameters.loading
+        $apollo.queries.proposals.loading ||
+          $apollo.queries.proposal.loading ||
+          $apollo.queries.parameters.loading
       "
     />
+    <TmDataNotFound v-else-if="!found" />
     <TmDataError v-else-if="error" />
     <template v-else>
       <div class="proposal">
@@ -188,6 +191,7 @@ import { atoms, percent, prettyInt } from "scripts/num"
 import { date, fromNow } from "src/filters"
 import TmBtn from "common/TmBtn"
 import TmDataError from "common/TmDataError"
+import TmDataNotFound from "common/TmDataNotFound"
 import TmDataLoading from "common/TmDataLoading"
 import TextBlock from "common/TextBlock"
 import ModalDeposit from "src/ActionModal/components/ModalDeposit"
@@ -206,6 +210,7 @@ export default {
     ModalDeposit,
     ModalVote,
     TmDataError,
+    TmDataNotFound,
     TmDataLoading,
     TmPage,
     TextBlock,
@@ -237,7 +242,8 @@ export default {
     parameters: {
       depositDenom: "TESTCOIN"
     },
-    error: undefined
+    error: undefined,
+    found: false
   }),
   computed: {
     ...mapGetters([`address`, `network`]),
@@ -304,6 +310,13 @@ export default {
         }
       },
       update(data) {
+        if (
+          data.proposals.find(
+            proposal => proposal.id === parseInt(this.proposalId, 10)
+          )
+        ) {
+          this.found = true
+        }
         /* istanbul ignore next */
         return data.proposals
       }
@@ -323,6 +336,9 @@ export default {
           id: +this.proposalId
         }
       },
+      skip() {
+        return !this.found
+      },
       result(data) {
         /* istanbul ignore next */
         this.error = data.error
@@ -336,6 +352,9 @@ export default {
       update(data) {
         /* istanbul ignore next */
         return data.governanceParameters
+      },
+      skip() {
+        return !this.found
       },
       result(data) {
         /* istanbul ignore next */
@@ -355,7 +374,7 @@ export default {
         }
       },
       skip() {
-        return !this.address
+        return !this.address || !this.found
       },
       update(data) {
         /* istanbul ignore next */

--- a/tests/unit/specs/components/common/__snapshots__/TmDataError.spec.js.snap
+++ b/tests/unit/specs/components/common/__snapshots__/TmDataError.spec.js.snap
@@ -36,7 +36,7 @@ exports[`TmDataError has the expected html structure 1`] = `
     you right now. Please try again later or
     
         <a
-          href="https://github.com/cosmos/voyager/issues"
+          href="https://github.com/luniehq/lunie/issues"
         >
           file a bug report
         </a>

--- a/tests/unit/specs/components/governance/PageProposal.spec.js
+++ b/tests/unit/specs/components/governance/PageProposal.spec.js
@@ -36,6 +36,10 @@ describe(`PageProposal`, () => {
     }
     const $apollo = {
       queries: {
+        proposals: {
+          loading: false,
+          error: undefined
+        },
         proposal: {
           loading: false,
           error: undefined
@@ -63,7 +67,8 @@ describe(`PageProposal`, () => {
     }
     wrapper = shallowMount(PageProposal, args)
     wrapper.setData({
-      proposal: proposals[2]
+      proposal: proposals[2],
+      found: true
     })
   })
 

--- a/tests/unit/specs/components/governance/__snapshots__/PageProposal.spec.js.snap
+++ b/tests/unit/specs/components/governance/__snapshots__/PageProposal.spec.js.snap
@@ -173,6 +173,6 @@ exports[`PageProposal shows an error if the proposal couldn't be found 1`] = `
   subtitle=""
   title=""
 >
-  <tmdataerror-stub />
+  <tmdatanotfound-stub />
 </tmpage-stub>
 `;


### PR DESCRIPTION
Closes #3093 

**Description:**

- Now it shows Not found when the proposal id is not found in proposal list. 
- Created new component TmDataNotFound
- Better graphql skip logic, saves a bunch of errors when proposal id not exist

Thank you! 🚀

---

For contributor:

- [ ] Added changes entries. Run `yarn changelog` for a guided process.
- [ ] Reviewed `Files changed` in the github PR explorer
- [ ] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI
