### PR TITLE
Dont show dust delegations in PageValidator and Portfolio

### DIFF
--- a/changes/mario_3009-dust-amount-delegations
+++ b/changes/mario_3009-dust-amount-delegations
@@ -1,0 +1,1 @@
+[Fixed] [#3009](https://github.com/cosmos/lunie/issues/3009) Dont show dust delegations in PageValidator and Portfolio @mariopino

--- a/src/components/staking/LiValidator.vue
+++ b/src/components/staking/LiValidator.vue
@@ -1,5 +1,6 @@
 <template>
   <tr
+    v-if="delegation.amount >= SMALLEST"
     class="li-validator"
     :data-name="validator.name"
     @click="
@@ -60,7 +61,7 @@
 </template>
 
 <script>
-import { percent, shortDecimals, atoms } from "scripts/num"
+import { percent, shortDecimals, atoms, SMALLEST } from "scripts/num"
 import Avatar from "common/Avatar"
 export default {
   name: `li-validator`,
@@ -96,6 +97,9 @@ export default {
       default: () => "returns"
     }
   },
+  data: () => ({
+    SMALLEST
+  }),
   methods: {
     percent
   }

--- a/src/components/staking/LiValidator.vue
+++ b/src/components/staking/LiValidator.vue
@@ -1,6 +1,5 @@
 <template>
   <tr
-    v-if="delegation.amount >= SMALLEST"
     class="li-validator"
     :data-name="validator.name"
     @click="

--- a/src/components/staking/PageValidator.vue
+++ b/src/components/staking/PageValidator.vue
@@ -35,7 +35,7 @@
             <h3 class="li-validator-name">
               {{ validator.name }}
             </h3>
-            <div v-if="delegation.amount">
+            <div v-if="delegation.amount >= SMALLEST">
               <h4>{{ delegation.amount | fullDecimals }}</h4>
               <h5 v-if="rewards">
                 +{{ rewards.amount | fullDecimals | noBlanks }}
@@ -49,7 +49,7 @@
         <TmBtn id="delegation-btn" value="Stake" @click.native="onDelegation" />
         <TmBtn
           id="undelegation-btn"
-          :disabled="delegation.amount === 0"
+          :disabled="delegation.amount < SMALLEST"
           value="Unstake"
           type="secondary"
           @click.native="onUndelegation"
@@ -161,7 +161,13 @@
 <script>
 import moment from "moment"
 import { mapGetters, mapState } from "vuex"
-import { atoms, shortDecimals, fullDecimals, percent } from "scripts/num"
+import {
+  atoms,
+  shortDecimals,
+  fullDecimals,
+  percent,
+  SMALLEST
+} from "scripts/num"
 import { noBlanks, fromNow } from "src/filters"
 import refetchNetworkOnly from "scripts/refetch-network-only"
 import TmBtn from "common/TmBtn"
@@ -214,7 +220,8 @@ export default {
     rewards: 0,
     delegation: {},
     error: false,
-    loaded: false
+    loaded: false,
+    SMALLEST
   }),
   computed: {
     ...mapState([`session`]),

--- a/tests/unit/specs/components/staking/LiValidator.spec.js
+++ b/tests/unit/specs/components/staking/LiValidator.spec.js
@@ -44,8 +44,12 @@ describe(`LiValidator`, () => {
     picture: "picture.jpg",
     name: "",
     userShares: {
-      amount: 123
+      amount: 123456789
     }
+  }
+
+  const delegation = {
+    amount: 123456789
   }
 
   const index = 1
@@ -65,6 +69,7 @@ describe(`LiValidator`, () => {
       localVue,
       propsData: {
         validator,
+        delegation,
         index,
         showOnMobile: "returns"
       },

--- a/tests/unit/specs/components/staking/__snapshots__/LiValidator.spec.js.snap
+++ b/tests/unit/specs/components/staking/__snapshots__/LiValidator.spec.js.snap
@@ -46,7 +46,15 @@ exports[`LiValidator has the expected html structure 1`] = `
       
       </h3>
        
-      <!---->
+      <div>
+        <h4>
+          
+          123,456,789
+        
+        </h4>
+         
+        <!---->
+      </div>
     </div>
   </td>
    


### PR DESCRIPTION
Closes #3009 

**Description:**

- Dont show delegations and disable undelegate button for delegation amounts smaller than `SMALLER` constant in in PageValidator.
- Dont show validators with delegation amounts smaller than `SMALLER` constant in and Portfolio.

Thank you! 🚀

---

For contributor:

- [ ] Added changes entries. Run `yarn changelog` for a guided process.
- [ ] Reviewed `Files changed` in the github PR explorer
- [ ] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI
