### PR TITLE
Fix no validator found appears instead of Data loading

### DIFF
--- a/changes/mario_3270-validator-not-found-instead-loading
+++ b/changes/mario_3270-validator-not-found-instead-loading
@@ -1,0 +1,1 @@
+[Fixed] [#3270](https://github.com/cosmos/lunie/issues/3270) Fix no validator found appears instead of Data loading @mariopino

--- a/src/components/staking/PageValidator.vue
+++ b/src/components/staking/PageValidator.vue
@@ -8,7 +8,8 @@
     data-title="Validator"
     class="small"
   >
-    <template v-if="validator.operatorAddress" slot="managed-body">
+    <TmDataLoading v-if="$apollo.loading" />
+    <template v-else-if="validator.operatorAddress" slot="managed-body">
       <div class="status-container">
         <span :class="validator.status | toLower" class="validator-status">
           {{ validator.status }}

--- a/src/components/staking/PageValidator.vue
+++ b/src/components/staking/PageValidator.vue
@@ -8,7 +8,7 @@
     data-title="Validator"
     class="small"
   >
-    <TmDataLoading v-if="$apollo.loading" />
+    <TmDataLoading v-if="$apollo.queries.validator.loading" />
     <template v-else-if="validator.operatorAddress" slot="managed-body">
       <div class="status-container">
         <span :class="validator.status | toLower" class="validator-status">


### PR DESCRIPTION
Closes #3270 3270

**Description:**

Just to add TmDataLoading component to PageValidator.vue and display it when `$apollo.queries.validator.loading`.

Thank you! 🚀

---

For contributor:

- [ ] Added changes entries. Run `yarn changelog` for a guided process.
- [ ] Reviewed `Files changed` in the github PR explorer
- [ ] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI
