### PR TITLE
Jordan/network links

### DIFF
--- a/changes/jordan_network-links
+++ b/changes/jordan_network-links
@@ -1,0 +1,1 @@
+[Changed] the networks page now lives in the mobile app footer instead of in the mobile menu - this is more consistent @jbibla

--- a/src/components/common/AppMenu.vue
+++ b/src/components/common/AppMenu.vue
@@ -69,7 +69,7 @@
       </router-link>
 
       <router-link
-        class="app-menu-item"
+        class="app-menu-item hide-xs"
         to="/networks"
         exact="exact"
         title="Networks"

--- a/src/components/common/MobileMenu.vue
+++ b/src/components/common/MobileMenu.vue
@@ -34,6 +34,17 @@
         Activity
       </h2>
     </router-link>
+    <router-link
+      class="mobile-menu-item"
+      to="/networks"
+      exact="exact"
+      title="Networks"
+    >
+      <i class="material-icons">public</i>
+      <h2 class="app-menu-title">
+        Networks
+      </h2>
+    </router-link>
   </menu>
 </template>
 


### PR DESCRIPTION
**Description:**

- the networks page now lives in the mobile app footer instead of on the mobile menu. this  addresses a long-standing inconsistency and makes the networks page more accessible
<!-- Briefly describe what you're adding or fixing with this PR -->

Thank you! 🚀

---

For contributor:

- [ ] Added changes entries. Run `yarn changelog` for a guided process.
- [ ] Reviewed `Files changed` in the github PR explorer
- [ ] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI
