### PR TITLE
Improve validator identicons

### DIFF
--- a/changes/mario_3269-fix-validator-identicons
+++ b/changes/mario_3269-fix-validator-identicons
@@ -1,0 +1,1 @@
+[Fixed] [#3269](https://github.com/cosmos/lunie/issues/3269) Improve behaviour of validator names / images @mariopino

--- a/src/components/staking/LiValidator.vue
+++ b/src/components/staking/LiValidator.vue
@@ -137,11 +137,10 @@ export default {
   font-weight: 500;
   color: var(--bright);
   display: inline-block;
-  max-width: 11rem;
+  max-width: 20rem;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-
 }
 .li-validator-image {
   border-radius: 0.25rem;
@@ -166,5 +165,10 @@ export default {
 .validator-status.active {
   color: var(--success);
   border-color: var(--success);
+}
+@media screen and (max-width: 768px) {
+  .li-validator-name {
+    max-width: 11rem;
+  }
 }
 </style>

--- a/src/components/staking/LiValidator.vue
+++ b/src/components/staking/LiValidator.vue
@@ -137,11 +137,18 @@ export default {
   font-weight: 500;
   color: var(--bright);
   display: inline-block;
+  max-width: 11rem;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+
 }
 .li-validator-image {
   border-radius: 0.25rem;
   height: 2.5rem;
   width: 2.5rem;
+  min-height: 2.5rem;
+  min-width: 2.5rem;
   border: 1px solid var(--bc-dim);
 }
 .validator-status {


### PR DESCRIPTION
Closes #3269

**Description:**

- Set fixed width and height for validator image / identicon.
- Set a maximum width for validator name: 20rem for desktop and 11rem for viewports widths smaller thant 768px.

Thank you! 🚀

---

For contributor:

- [ ] Added changes entries. Run `yarn changelog` for a guided process.
- [ ] Reviewed `Files changed` in the github PR explorer
- [ ] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI
