### PR TITLE
Fabo/show tx error

### DIFF
--- a/changes/fabo_show-tx-error
+++ b/changes/fabo_show-tx-error
@@ -1,0 +1,1 @@
+[Added] Show errors if transaction fail @faboweb

--- a/src/ActionModal/utils/ActionManager.js
+++ b/src/ActionModal/utils/ActionManager.js
@@ -192,7 +192,7 @@ export default class ActionManager {
     if (result.success) {
       return { hash: result.hash }
     } else {
-      throw Error("Broadcast was not successfull")
+      throw Error("Broadcast was not successfull: " + result.error)
     }
   }
 


### PR DESCRIPTION
Closes #ISSUE

**Description:**

<!-- Briefly describe what you're adding or fixing with this PR -->

When a tx fails in the transaction service, the error will now be displayed to the user. This way the user can react better to issues.

Thank you! 🚀

---

For contributor:

- [ ] Added changes entries. Run `yarn changelog` for a guided process.
- [ ] Reviewed `Files changed` in the github PR explorer
- [ ] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI
