### PR TITLE
Ana/fix PageValidator continuous refreshing

### DIFF
--- a/changes/ana_fix-continuous-updating-page-validator
+++ b/changes/ana_fix-continuous-updating-page-validator
@@ -1,0 +1,1 @@
+[Fixed] [#3303](https://github.com/cosmos/lunie/pull/3303) Fix the continuous refreshing of the PageValidator component, which prevented from staking or doing any action at all @Bitcoinera

--- a/src/components/staking/PageValidator.vue
+++ b/src/components/staking/PageValidator.vue
@@ -2,7 +2,7 @@
   <TmPage
     :managed="true"
     :data-empty="!validator.operatorAddress"
-    :loading="$apollo.loading"
+    :loading="$apollo.queries.validator.loading"
     :loaded="loaded"
     :hide-header="true"
     data-title="Validator"


### PR DESCRIPTION
Closes #ISSUE
I just discovered this bug this morning

**Description:**
The `PageValidator` was constantly refreshing. It wasn't possible to delegate or do anything there since the component would always re-render.

![refreshing-api](https://user-images.githubusercontent.com/40721795/70849916-15982e80-1e85-11ea-81d7-5e8f0340f2fa.gif)

<!-- Briefly describe what you're adding or fixing with this PR -->
Changing `$apollo.loading` to `$apollo.queries.validator.loading` did the trick.

Thank you! 🚀

---

For contributor:

- [x] Added changes entries. Run `yarn changelog` for a guided process.
- [x] Reviewed `Files changed` in the github PR explorer
- [ ] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI
