### PR TITLE
Ana/fix scrollbar in side menu

### DIFF
--- a/changes/ana_fix-scrollbar-in-side-menu
+++ b/changes/ana_fix-scrollbar-in-side-menu
@@ -1,0 +1,1 @@
+[Fixed] [#3304](https://github.com/cosmos/lunie/pull/3304) Fix scrollbar around AppMenu and weird resizing of the Help-Feedback button @Bitcoinera

--- a/src/components/common/AppHeader.vue
+++ b/src/components/common/AppHeader.vue
@@ -159,6 +159,7 @@ export default {
   .app-header > .container {
     position: fixed;
     height: 100%;
+    overflow: auto;
     background: var(--app-nav);
   }
 }

--- a/src/components/common/AppHeader.vue
+++ b/src/components/common/AppHeader.vue
@@ -159,7 +159,6 @@ export default {
   .app-header > .container {
     position: fixed;
     height: 100%;
-    overflow: scroll;
     background: var(--app-nav);
   }
 }

--- a/src/components/common/TmConnectedNetwork.vue
+++ b/src/components/common/TmConnectedNetwork.vue
@@ -218,7 +218,7 @@ export default {
   background: var(--success);
 }
 
-@media screen and (max-width: 767px) {
+@media screen and (max-width: 1023px) {
   .sidebar-bottom {
     max-width: 100%;
   }


### PR DESCRIPTION
Closes #ISSUE
I just encountered this bug this morning

**Description:**
There was a weird scrollbar around the `AppMenu` component and also the `Help/Feedback` button was behaving strangely when resizing the screen. Here the screenshots:

<img height="320px" src="https://user-images.githubusercontent.com/40721795/70851024-cf48cc80-1e90-11ea-8211-9450340d435d.png"/>

<img  width="310px" src="https://user-images.githubusercontent.com/40721795/70851031-d8399e00-1e90-11ea-9697-ccfa095a161b.png" />

Now it is fixed! :muscle: 

<!-- Briefly describe what you're adding or fixing with this PR -->

Thank you! 🚀

---

For contributor:

- [x] Added changes entries. Run `yarn changelog` for a guided process.
- [x] Reviewed `Files changed` in the github PR explorer
- [ ] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI
