### PR TITLE
Ana/3271 stake on validator should automatically update

### DIFF
--- a/changes/ana_3271-stake-on-validator-should-automatically-update
+++ b/changes/ana_3271-stake-on-validator-should-automatically-update
@@ -1,0 +1,1 @@
+[Added] [#3271](https://github.com/cosmos/lunie/issues/3271) Now the stake on the validator will automatically update on PageValidator @Bitcoinera

--- a/src/components/staking/PageValidator.vue
+++ b/src/components/staking/PageValidator.vue
@@ -369,7 +369,6 @@ export default {
         },
         query: UserTransactionAdded,
         result({ data }) {
-          console.log('TRANSACTION DATA', data)
           /* istanbul ignore next */
           if (data.userTransactionAdded.success) {
             refetchNetworkOnly(this.$apollo.queries.delegation)

--- a/src/components/staking/PageValidator.vue
+++ b/src/components/staking/PageValidator.vue
@@ -360,12 +360,8 @@ export default {
           /* istanbul ignore next */
           return {
             networkId: this.network,
-            address: this.address
+            address: this.userAddress
           }
-        },
-        skip() {
-          /* istanbul ignore next */
-          return !this.address
         },
         query: UserTransactionAdded,
         result({ data }) {

--- a/src/components/staking/PageValidator.vue
+++ b/src/components/staking/PageValidator.vue
@@ -171,7 +171,7 @@ import Avatar from "common/Avatar"
 import Bech32 from "common/Bech32"
 import TmPage from "common/TmPage"
 import gql from "graphql-tag"
-import { ValidatorProfile } from "src/gql"
+import { ValidatorProfile, UserTransactionAdded } from "src/gql"
 
 function getStatusText(statusDetailed) {
   switch (statusDetailed) {
@@ -353,6 +353,27 @@ export default {
         },
         result() {
           refetchNetworkOnly(this.$apollo.queries.rewards)
+        }
+      },
+      userTransactionAdded: {
+        variables() {
+          /* istanbul ignore next */
+          return {
+            networkId: this.network,
+            address: this.address
+          }
+        },
+        skip() {
+          /* istanbul ignore next */
+          return !this.address
+        },
+        query: UserTransactionAdded,
+        result({ data }) {
+          console.log('TRANSACTION DATA', data)
+          /* istanbul ignore next */
+          if (data.userTransactionAdded.success) {
+            refetchNetworkOnly(this.$apollo.queries.delegation)
+          }
         }
       }
     }


### PR DESCRIPTION
Closes #3271 
**Description:**

Now when we stake on a validator we'll see how our stake on it automatically updates (on `PageValidator` and this was already working in `Portfolio`)

I also considered implementing the same for `TableValidators`, the last component where we see the validator and our stake, but I think this is would be too complicated from the computational load point of view for a very tiny UX improvement. It is not worth it, I think.

<!-- Briefly describe what you're adding or fixing with this PR -->

Thank you! 🚀

---

For contributor:

- [x] Added changes entries. Run `yarn changelog` for a guided process.
- [x] Reviewed `Files changed` in the github PR explorer
- [ ] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI
