### PR TITLE
ana/fix property reset of null

### DIFF
--- a/src/ActionModal/components/DelegationModal.vue
+++ b/src/ActionModal/components/DelegationModal.vue
@@ -272,7 +272,9 @@ export default {
       return !this.$v.$invalid
     },
     clear() {
-      this.$v.$reset()
+      if (this.$v) {
+        this.$v.$reset()
+      }
 
       this.selectedIndex = 0
       this.amount = 0


### PR DESCRIPTION
Closes #ISSUE
I just found this error yesterday

**Description:**

A really strange error I don't yet understand why it was happening. When you were in the middle of staking on a validator (through the `DelegationModal`) and suddenly the modal suddenly hid away (this was happening to me because of the solved bug of the `PageValidator` component ever updating) or you just click again in the `Stake` button, this error was triggered and the `DelegationModal` wasn't successfully resetted:

<img width="500px" src="https://user-images.githubusercontent.com/40721795/70861582-484b3100-1f30-11ea-889a-36d878108902.png" />

<!-- Briefly describe what you're adding or fixing with this PR -->
I fixed it with just a simple `if` to make sure that `this.$v` does exist when calling `this.$v.$reset()`.

I tried all the other modals and the error doesn't reproduce there when restarting the action in the middle of it. As I said, I don't yet understand why this was happening in this particular modal.

Thank you! 🚀

---

For contributor:

- [ ] Added changes entries. Run `yarn changelog` for a guided process.
- [x] Reviewed `Files changed` in the github PR explorer
- [ ] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI
