### PR TITLE
[Simsala] automatic release created for v1.0.154

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,45 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 <!-- SIMSALA --> <!-- DON'T DELETE, used for automatic changelog updates -->
 
+## [1.0.154] - 2019-12-16
+
+### Added
+
+- [#3271](https://github.com/cosmos/lunie/issues/3271) Now the stake on the validator will automatically update on PageValidator @Bitcoinera
+- [#3260](https://github.com/cosmos/lunie/pull/3260) Few fixes to better integrate with the Livepeer network @Bitcoinera
+- Show errors if transaction fail @faboweb
+- added bitrise widgets to readme @jbibla
+- [#3069](https://github.com/cosmos/lunie/issues/3069) Add intercom link to TmDataError component @mariopino
+
+### Changed
+
+- Reduce gas price to counter gas estimation increase in API @faboweb
+- Use the url param for the API also for the transaction service @faboweb
+- the proposal description length was unreasonably small, now it is much larger @jbibla
+- switched the little x on the action modal to be a proper button @jbibla
+- made the edit memo button a link for a cleaner send modal @jbibla
+- added explanation and made error message clearer for new ledger updates @jbibla
+- the networks page now lives in the mobile app footer instead of in the mobile menu - this is more consistent @jbibla
+
+### Fixed
+
+- [#3303](https://github.com/cosmos/lunie/pull/3303) Fix the continuous refreshing of the PageValidator component, which prevented from staking or doing any action at all @Bitcoinera
+- [#3304](https://github.com/cosmos/lunie/pull/3304) Fix scrollbar around AppMenu and weird resizing of the Help-Feedback button @Bitcoinera
+- [#3283](https://github.com/cosmos/lunie/pull/3283) Now the signin close button redirects directly to root (`/`) @Bitcoinera
+- [#3255](https://github.com/cosmos/lunie/pull/3255) Hide menu when changing to block view from menu @colw
+- Fix failing sends @faboweb
+- Handle validator image being null @faboweb
+- Show correct feature flag url for HID support under Windows @faboweb
+- Consecutive transactions would fail as the sequence number wasn't updated @faboweb
+- Use v2 library for cosmos hub mainnet @faboweb
+- [#3205](https://github.com/cosmos/lunie/issues/3205) resolved keyboard and button issues on iOS forms @jbibla
+- added special styles for the notch and bottom bar on iPhone X and 11 @jbibla
+- the input suffix styles were broken on the delegation modal, but now they are fixed!  @jbibla
+- [#3079](https://github.com/cosmos/lunie/issues/3079) Improve proposals in deposit period @mariopino
+- [#3269](https://github.com/cosmos/lunie/issues/3269) Improve behaviour of validator names / images @mariopino
+- [#3270](https://github.com/cosmos/lunie/issues/3270) Fix no validator found appears instead of Data loading @mariopino
+- [#3292](https://github.com/cosmos/lunie/issues/3292) Fix TmDataLoading component registration in PageValidator @mariopino
+
 ## [1.0.153] - 2019-12-15
 
 ### Added

--- a/changes/ana_3271-stake-on-validator-should-automatically-update
+++ b/changes/ana_3271-stake-on-validator-should-automatically-update
@@ -1,1 +1,0 @@
-[Added] [#3271](https://github.com/cosmos/lunie/issues/3271) Now the stake on the validator will automatically update on PageValidator @Bitcoinera

--- a/changes/ana_fix-continuous-updating-page-validator
+++ b/changes/ana_fix-continuous-updating-page-validator
@@ -1,1 +1,0 @@
-[Fixed] [#3303](https://github.com/cosmos/lunie/pull/3303) Fix the continuous refreshing of the PageValidator component, which prevented from staking or doing any action at all @Bitcoinera

--- a/changes/ana_fix-scrollbar-in-side-menu
+++ b/changes/ana_fix-scrollbar-in-side-menu
@@ -1,1 +1,0 @@
-[Fixed] [#3304](https://github.com/cosmos/lunie/pull/3304) Fix scrollbar around AppMenu and weird resizing of the Help-Feedback button @Bitcoinera

--- a/changes/ana_livepeer-integration
+++ b/changes/ana_livepeer-integration
@@ -1,1 +1,0 @@
-[Added] [#3260](https://github.com/cosmos/lunie/pull/3260) Few fixes to better integrate with the Livepeer network @Bitcoinera

--- a/changes/ana_make-close-during-sign-in-close-straight
+++ b/changes/ana_make-close-during-sign-in-close-straight
@@ -1,1 +1,0 @@
-[Fixed] [#3283](https://github.com/cosmos/lunie/pull/3283) Now the signin close button redirects directly to root (`/`) @Bitcoinera

--- a/changes/colw_3255-mobile-hide-menu-show-block
+++ b/changes/colw_3255-mobile-hide-menu-show-block
@@ -1,1 +1,0 @@
-[Fixed] [#3255](https://github.com/cosmos/lunie/pull/3255) Hide menu when changing to block view from menu @colw

--- a/changes/fabo_fix-broadcasting-without-tx-api
+++ b/changes/fabo_fix-broadcasting-without-tx-api
@@ -1,1 +1,0 @@
-[Fixed] Fix failing sends @faboweb

--- a/changes/fabo_handle-image-null
+++ b/changes/fabo_handle-image-null
@@ -1,1 +1,0 @@
-[Fixed] Handle validator image being null @faboweb

--- a/changes/fabo_ledger-errors-fix
+++ b/changes/fabo_ledger-errors-fix
@@ -1,1 +1,0 @@
-[Fixed] Show correct feature flag url for HID support under Windows @faboweb

--- a/changes/fabo_reduce-gas-price
+++ b/changes/fabo_reduce-gas-price
@@ -1,1 +1,0 @@
-[Changed] Reduce gas price to counter gas estimation increase in API @faboweb

--- a/changes/fabo_show-tx-error
+++ b/changes/fabo_show-tx-error
@@ -1,1 +1,0 @@
-[Added] Show errors if transaction fail @faboweb

--- a/changes/fabo_update-sequence-number
+++ b/changes/fabo_update-sequence-number
@@ -1,1 +1,0 @@
-[Fixed] Consecutive transactions would fail as the sequence number wasn't updated @faboweb

--- a/changes/fabo_use-url-api-for-transactions
+++ b/changes/fabo_use-url-api-for-transactions
@@ -1,1 +1,0 @@
-[Changed] Use the url param for the API also for the transaction service @faboweb

--- a/changes/fabo_use-v2-lib-for-mainnet
+++ b/changes/fabo_use-v2-lib-for-mainnet
@@ -1,1 +1,0 @@
-[Fixed] Use v2 library for cosmos hub mainnet @faboweb

--- a/changes/jordan_3205-mobile-bugs
+++ b/changes/jordan_3205-mobile-bugs
@@ -1,4 +1,0 @@
-[Fixed] [#3205](https://github.com/cosmos/lunie/issues/3205) resolved keyboard and button issues on iOS forms @jbibla
-[Fixed] added special styles for the notch and bottom bar on iPhone X and 11 @jbibla
-[Changed] the proposal description length was unreasonably small, now it is much larger @jbibla
-[Fixed] the input suffix styles were broken on the delegation modal, but now they are fixed!  @jbibla

--- a/changes/jordan_action-modal-cancel-button
+++ b/changes/jordan_action-modal-cancel-button
@@ -1,2 +1,0 @@
-[Changed] switched the little x on the action modal to be a proper button @jbibla
-[Changed] made the edit memo button a link for a cleaner send modal @jbibla

--- a/changes/jordan_ledger-error
+++ b/changes/jordan_ledger-error
@@ -1,1 +1,0 @@
-[Changed] added explanation and made error message clearer for new ledger updates @jbibla

--- a/changes/jordan_network-links
+++ b/changes/jordan_network-links
@@ -1,1 +1,0 @@
-[Changed] the networks page now lives in the mobile app footer instead of in the mobile menu - this is more consistent @jbibla

--- a/changes/jordan_readme
+++ b/changes/jordan_readme
@@ -1,1 +1,0 @@
-[Added] added bitrise widgets to readme @jbibla

--- a/changes/mario_3069-add-intercom-error-message
+++ b/changes/mario_3069-add-intercom-error-message
@@ -1,1 +1,0 @@
-[Added] [#3069](https://github.com/cosmos/lunie/issues/3069) Add intercom link to TmDataError component @mariopino

--- a/changes/mario_3079-deposit-improvements
+++ b/changes/mario_3079-deposit-improvements
@@ -1,1 +1,0 @@
-[Fixed] [#3079](https://github.com/cosmos/lunie/issues/3079) Improve proposals in deposit period @mariopino

--- a/changes/mario_3269-fix-validator-identicons
+++ b/changes/mario_3269-fix-validator-identicons
@@ -1,1 +1,0 @@
-[Fixed] [#3269](https://github.com/cosmos/lunie/issues/3269) Improve behaviour of validator names / images @mariopino

--- a/changes/mario_3270-validator-not-found-instead-loading
+++ b/changes/mario_3270-validator-not-found-instead-loading
@@ -1,1 +1,0 @@
-[Fixed] [#3270](https://github.com/cosmos/lunie/issues/3270) Fix no validator found appears instead of Data loading @mariopino

--- a/changes/mario_3292-incorrect-tmdataloading-registration
+++ b/changes/mario_3292-incorrect-tmdataloading-registration
@@ -1,1 +1,0 @@
-[Fixed] [#3292](https://github.com/cosmos/lunie/issues/3292) Fix TmDataLoading component registration in PageValidator @mariopino

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lunie",
-  "version": "1.0.153",
+  "version": "1.0.154",
   "description": "Lunie is the staking and governance platform for proof-of-stake blockchains.",
   "author": "Lunie International Software Systems Inc. <hello@lunie.io>",
   "scripts": {

--- a/src/components/staking/PageValidator.vue
+++ b/src/components/staking/PageValidator.vue
@@ -21,7 +21,7 @@
       <tr class="li-validator">
         <td class="data-table__row__info">
           <Avatar
-            v-if="!validator.picture"
+            v-if="!validator.picture || validator.picture === 'null'"
             class="li-validator-image"
             alt="generic geometric symbol - generated avatar from address"
             :address="validator.operatorAddress"


### PR DESCRIPTION
Please manually test before merging this to master

### Added

- [#3271](https://github.com/cosmos/lunie/issues/3271) Now the stake on the validator will automatically update on PageValidator @Bitcoinera
- [#3260](https://github.com/cosmos/lunie/pull/3260) Few fixes to better integrate with the Livepeer network @Bitcoinera
- Show errors if transaction fail @faboweb
- added bitrise widgets to readme @jbibla
- [#3069](https://github.com/cosmos/lunie/issues/3069) Add intercom link to TmDataError component @mariopino

### Changed

- Reduce gas price to counter gas estimation increase in API @faboweb
- Use the url param for the API also for the transaction service @faboweb
- the proposal description length was unreasonably small, now it is much larger @jbibla
- switched the little x on the action modal to be a proper button @jbibla
- made the edit memo button a link for a cleaner send modal @jbibla
- added explanation and made error message clearer for new ledger updates @jbibla
- the networks page now lives in the mobile app footer instead of in the mobile menu - this is more consistent @jbibla

### Fixed

- [#3303](https://github.com/cosmos/lunie/pull/3303) Fix the continuous refreshing of the PageValidator component, which prevented from staking or doing any action at all @Bitcoinera
- [#3304](https://github.com/cosmos/lunie/pull/3304) Fix scrollbar around AppMenu and weird resizing of the Help-Feedback button @Bitcoinera
- [#3283](https://github.com/cosmos/lunie/pull/3283) Now the signin close button redirects directly to root (`/`) @Bitcoinera
- [#3255](https://github.com/cosmos/lunie/pull/3255) Hide menu when changing to block view from menu @colw
- Fix failing sends @faboweb
- Handle validator image being null @faboweb
- Show correct feature flag url for HID support under Windows @faboweb
- Consecutive transactions would fail as the sequence number wasn't updated @faboweb
- Use v2 library for cosmos hub mainnet @faboweb
- [#3205](https://github.com/cosmos/lunie/issues/3205) resolved keyboard and button issues on iOS forms @jbibla
- added special styles for the notch and bottom bar on iPhone X and 11 @jbibla
- the input suffix styles were broken on the delegation modal, but now they are fixed!  @jbibla
- [#3079](https://github.com/cosmos/lunie/issues/3079) Improve proposals in deposit period @mariopino
- [#3269](https://github.com/cosmos/lunie/issues/3269) Improve behaviour of validator names / images @mariopino
- [#3270](https://github.com/cosmos/lunie/issues/3270) Fix no validator found appears instead of Data loading @mariopino
- [#3292](https://github.com/cosmos/lunie/issues/3292) Fix TmDataLoading component registration in PageValidator @mariopino