### PR TITLE
Fabo/3314 session per network

### DIFF
--- a/changes/fabo_3314-session-per-network
+++ b/changes/fabo_3314-session-per-network
@@ -1,0 +1,1 @@
+[Added] [#3314](https://github.com/cosmos/lunie/issues/3314) Keep sessions per network @faboweb

--- a/src/components/network/NetworkList.vue
+++ b/src/components/network/NetworkList.vue
@@ -32,21 +32,10 @@ export default {
     ...mapState([`connection`])
   },
   methods: {
-    selectNetworkHandler(network) {
-      let confirm = this.confirmModalOpen()
-      if (this.connection.network !== network.id && confirm) {
-        this.$store.dispatch(`setNetwork`, network)
-      }
-    },
-    confirmModalOpen() {
-      let confirm = false
-      if (this.session.signedIn) {
-        confirm = window.confirm(
-          `By switching the network you will get signed out of your current address: ${this.$store.state.session.address}`
-        )
-        return confirm
-      } else {
-        return true
+    async selectNetworkHandler(network) {
+      if (this.connection.network !== network.id) {
+        await this.$store.dispatch(`setNetwork`, network)
+        this.$store.dispatch(`checkForPersistedSession`)
       }
     }
   }

--- a/src/components/network/NetworkList.vue
+++ b/src/components/network/NetworkList.vue
@@ -34,8 +34,7 @@ export default {
   methods: {
     async selectNetworkHandler(network) {
       if (this.connection.network !== network.id) {
-        await this.$store.dispatch(`setNetwork`, network)
-        this.$store.dispatch(`checkForPersistedSession`)
+        this.$store.dispatch(`setNetwork`, network)
       }
     }
   }

--- a/src/initializeApp.js
+++ b/src/initializeApp.js
@@ -45,9 +45,10 @@ export default function init(urlParams, env = process.env) {
   setOptions(urlParams, store)
 
   store.dispatch(`loadLocalPreferences`)
-  store.dispatch(`checkForPersistedSession`)
+  store.dispatch(`checkForPersistedNetwork`).then(() => {
+    store.dispatch(`checkForPersistedSession`)
+  })
   store.dispatch(`checkForPersistedAddresses`)
-  store.dispatch(`checkForPersistedNetwork`)
 
   listenToExtensionMessages(store)
 

--- a/src/vuex/modules/connection.js
+++ b/src/vuex/modules/connection.js
@@ -1,7 +1,7 @@
 import config from "src/../config"
 import { Networks } from "../../gql"
 
-export default function({ apollo }) {
+export default function ({ apollo }) {
   const state = {
     stopConnecting: false,
     connected: true, // TODO do connection test
@@ -52,6 +52,7 @@ export default function({ apollo }) {
     async setNetwork({ commit, dispatch }, network) {
       dispatch(`signOut`)
       dispatch(`persistNetwork`, network)
+      dispatch(`checkForPersistedSession`) // check for persisted session on that network
       commit("setNetworkId", network.id)
       console.info(`Connecting to: ${network.id}`)
     }

--- a/src/vuex/modules/session.js
+++ b/src/vuex/modules/session.js
@@ -88,8 +88,13 @@ export default ({ apollo }) => {
   }
 
   const actions = {
-    async checkForPersistedSession({ dispatch }) {
-      const session = localStorage.getItem(`session`)
+    async checkForPersistedSession({
+      dispatch,
+      rootState: {
+        connection: { network }
+      }
+    }) {
+      const session = localStorage.getItem(sessionKey(network))
       if (session) {
         const { address, sessionType } = JSON.parse(session)
         await dispatch(`signIn`, { address, sessionType })
@@ -101,8 +106,11 @@ export default ({ apollo }) => {
         await commit(`setUserAddresses`, JSON.parse(addresses))
       }
     },
-    async persistSession(store, { address, sessionType }) {
-      localStorage.setItem(`session`, JSON.stringify({ address, sessionType }))
+    async persistSession(store, { address, sessionType, networkId }) {
+      localStorage.setItem(
+        sessionKey(networkId),
+        JSON.stringify({ address, sessionType })
+      )
     },
     async persistAddresses(store, { addresses }) {
       localStorage.setItem(`addresses`, JSON.stringify(addresses))
@@ -122,7 +130,14 @@ export default ({ apollo }) => {
       }
     },
     async signIn(
-      { state, commit, dispatch },
+      {
+        state,
+        commit,
+        dispatch,
+        rootState: {
+          connection: { network }
+        }
+      },
       { address, sessionType = `ledger` }
     ) {
       if (state.signedIn) {
@@ -136,7 +151,8 @@ export default ({ apollo }) => {
 
       dispatch(`persistSession`, {
         address,
-        sessionType
+        sessionType,
+        networkId: network
       })
       const addresses = state.addresses
       dispatch(`persistAddresses`, {
@@ -215,4 +231,8 @@ export default ({ apollo }) => {
     mutations,
     actions
   }
+}
+
+function sessionKey(networkId) {
+  return `session_${networkId}`
 }

--- a/tests/unit/specs/components/network/NetworkList.spec.js
+++ b/tests/unit/specs/components/network/NetworkList.spec.js
@@ -71,16 +71,4 @@ describe(`NetworkList`, () => {
     wrapper.find(".select-network-item.selected").trigger("click")
     expect(wrapper.vm.$store.dispatch).not.toHaveBeenCalledWith()
   })
-
-  it(`shows windows about switching networks`, async () => {
-    wrapper.setData({
-      session: {
-        signedIn: true
-      }
-    })
-    const spy = jest.spyOn(window, `confirm`).mockImplementationOnce(() => {})
-    wrapper.find(".select-network-item:not(.selected)").trigger("click")
-    expect(spy).toHaveBeenCalled()
-    spy.mockRestore()
-  })
 })

--- a/tests/unit/specs/store/session.spec.js
+++ b/tests/unit/specs/store/session.spec.js
@@ -114,7 +114,14 @@ describe(`Module: Session`, () => {
       const sessionType = `local`
       const address = `cosmos15ky9du8a2wlstz6fpx3p4mqpjyrm5ctpesxxn9`
       await actions.signIn(
-        { state, commit, dispatch },
+        {
+          state,
+          commit,
+          dispatch,
+          rootState: {
+            connection: { network: "fabo-net" }
+          }
+        },
         { address, sessionType }
       )
       expect(commit).toHaveBeenCalledWith(
@@ -135,7 +142,14 @@ describe(`Module: Session`, () => {
       const commit = jest.fn()
       const dispatch = jest.fn()
       await actions.signIn(
-        { state, commit, dispatch },
+        {
+          state,
+          commit,
+          dispatch,
+          rootState: {
+            connection: { network: "fabo-net" }
+          }
+        },
         { sessionType: `ledger`, address }
       )
       expect(commit).toHaveBeenCalledWith(`setUserAddress`, address)
@@ -153,7 +167,14 @@ describe(`Module: Session`, () => {
       const commit = jest.fn()
       const dispatch = jest.fn()
       await actions.signIn(
-        { state, commit, dispatch },
+        {
+          state,
+          commit,
+          dispatch,
+          rootState: {
+            connection: { network: "fabo-net" }
+          }
+        },
         { sessionType: `explore`, address }
       )
       expect(commit).toHaveBeenCalledWith(`setUserAddress`, address)
@@ -172,7 +193,14 @@ describe(`Module: Session`, () => {
       const dispatch = jest.fn()
       state.signedIn = true
       await actions.signIn(
-        { state, commit, dispatch },
+        {
+          state,
+          commit,
+          dispatch,
+          rootState: {
+            connection: { network: "fabo-net" }
+          }
+        },
         { sessionType: `explore`, address }
       )
 
@@ -195,7 +223,14 @@ describe(`Module: Session`, () => {
         }
       ]
       await actions.signIn(
-        { state, commit, dispatch },
+        {
+          state,
+          commit,
+          dispatch,
+          rootState: {
+            connection: { network: "fabo-net" }
+          }
+        },
         { sessionType: `explore`, address }
       )
       expect(dispatch).toHaveBeenCalledWith(`persistAddresses`, {
@@ -212,7 +247,8 @@ describe(`Module: Session`, () => {
       })
       expect(dispatch).toHaveBeenCalledWith(`persistSession`, {
         address: `cosmos1z8mzakma7vnaajysmtkwt4wgjqr2m84tzvyfkz`,
-        sessionType: `explore`
+        sessionType: `explore`,
+        networkId: "fabo-net"
       })
       expect(dispatch).toHaveBeenCalledWith(`rememberAddress`, {
         address: `cosmos1z8mzakma7vnaajysmtkwt4wgjqr2m84tzvyfkz`,
@@ -274,7 +310,7 @@ describe(`Module: Session`, () => {
   })
 
   it(`should enable error collection`, async () => {
-    jest.spyOn(console, `log`).mockImplementationOnce(() => {})
+    jest.spyOn(console, `log`).mockImplementationOnce(() => { })
     const commit = jest.fn()
     const dispatch = jest.fn()
     await actions.setErrorCollection(
@@ -290,7 +326,7 @@ describe(`Module: Session`, () => {
   })
 
   it(`should disable error collection`, async () => {
-    jest.spyOn(console, `log`).mockImplementationOnce(() => {})
+    jest.spyOn(console, `log`).mockImplementationOnce(() => { })
     const commit = jest.fn()
     const dispatch = jest.fn()
     await actions.setErrorCollection(
@@ -306,7 +342,7 @@ describe(`Module: Session`, () => {
   })
 
   it(`should disable analytics collection`, async () => {
-    jest.spyOn(console, `log`).mockImplementationOnce(() => {})
+    jest.spyOn(console, `log`).mockImplementationOnce(() => { })
     const commit = jest.fn()
     const dispatch = jest.fn()
     await actions.setAnalyticsCollection(
@@ -384,8 +420,11 @@ describe(`Module: Session`, () => {
 
   describe(`persistance`, () => {
     it(`persists the session in localstorage`, async () => {
-      await actions.persistSession({}, { address: `xxx`, sessionType: `local` })
-      expect(localStorage.getItem(`session`)).toEqual(
+      await actions.persistSession(
+        {},
+        { address: `xxx`, sessionType: `local`, networkId: "fabo-net" }
+      )
+      expect(localStorage.getItem(`session_fabo-net`)).toEqual(
         JSON.stringify({
           address: `xxx`,
           sessionType: `local`
@@ -396,7 +435,14 @@ describe(`Module: Session`, () => {
     it(`persists the session on sign in`, async () => {
       const dispatch = jest.fn()
       await actions.signIn(
-        { state, commit: jest.fn(), dispatch },
+        {
+          state,
+          commit: jest.fn(),
+          dispatch,
+          rootState: {
+            connection: { network: "fabo-net" }
+          }
+        },
         {
           address: `cosmos15ky9du8a2wlstz6fpx3p4mqpjyrm5ctpesxxn9`,
           sessionType: `local`
@@ -404,12 +450,20 @@ describe(`Module: Session`, () => {
       )
       expect(dispatch).toHaveBeenCalledWith(`persistSession`, {
         address: `cosmos15ky9du8a2wlstz6fpx3p4mqpjyrm5ctpesxxn9`,
-        sessionType: `local`
+        sessionType: `local`,
+        networkId: "fabo-net"
       })
 
       dispatch.mockClear()
       await actions.signIn(
-        { state, commit: jest.fn(), dispatch },
+        {
+          state,
+          commit: jest.fn(),
+          dispatch,
+          rootState: {
+            connection: { network: "fabo-net" }
+          }
+        },
         {
           address: `cosmos15ky9du8a2wlstz6fpx3p4mqpjyrm5ctpesxxn9`,
           sessionType: `ledger`
@@ -417,28 +471,39 @@ describe(`Module: Session`, () => {
       )
       expect(dispatch).toHaveBeenCalledWith(`persistSession`, {
         address: `cosmos15ky9du8a2wlstz6fpx3p4mqpjyrm5ctpesxxn9`,
-        sessionType: `ledger`
+        sessionType: `ledger`,
+        networkId: "fabo-net"
       })
     })
 
     it(`signs the user in if a session was found`, async () => {
       const dispatch = jest.fn()
       localStorage.setItem(
-        `session`,
+        `session_fabo-net`,
         JSON.stringify({
           address: `xxx`,
           sessionType: `local`
         })
       )
-      await actions.checkForPersistedSession({ dispatch })
+      await actions.checkForPersistedSession({
+        dispatch,
+        rootState: {
+          connection: { network: "fabo-net" }
+        }
+      })
       expect(dispatch).toHaveBeenCalledWith(`signIn`, {
         address: `xxx`,
         sessionType: `local`
       })
 
       dispatch.mockClear()
-      localStorage.removeItem(`session`)
-      await actions.checkForPersistedSession({ dispatch })
+      localStorage.removeItem(`session_fabo-net`)
+      await actions.checkForPersistedSession({
+        dispatch,
+        rootState: {
+          connection: { network: "fabo-net" }
+        }
+      })
       expect(dispatch).not.toHaveBeenCalled()
     })
   })


### PR DESCRIPTION
Closes #3314 

**Description:**

<!-- Briefly describe what you're adding or fixing with this PR -->

Stores sessions in a key like `session_cosmos-hub-mainnet` per network and checks for sessions on a network switch.

missing tests

Thank you! 🚀

---

For contributor:

- [ ] Added changes entries. Run `yarn changelog` for a guided process.
- [ ] Reviewed `Files changed` in the github PR explorer
- [ ] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI
