### PR TITLE
WIP: Ana/livepeer handle getselfstake separately

### DIFF
--- a/src/components/staking/PageValidator.vue
+++ b/src/components/staking/PageValidator.vue
@@ -348,7 +348,7 @@ export default {
       query: gql`
         query SelfStakePageValidator(
           $networkId: String!
-          $validator: Validator!
+          $validator: Validator! --> This is what I am struggling to figure out
         ) {
           selfStake(networkId: $networkId, validator: $validator) {
             amount

--- a/src/components/staking/PageValidator.vue
+++ b/src/components/staking/PageValidator.vue
@@ -175,7 +175,7 @@ import Avatar from "common/Avatar"
 import Bech32 from "common/Bech32"
 import TmPage from "common/TmPage"
 import gql from "graphql-tag"
-import { ValidatorProfile, UserTransactionAdded, SelfStake } from "src/gql"
+import { ValidatorProfile, UserTransactionAdded } from "src/gql"
 
 function getStatusText(statusDetailed) {
   switch (statusDetailed) {
@@ -345,11 +345,20 @@ export default {
       }
     },
     selfStake: {
-      query: SelfStake,
+      query: gql`
+        query SelfStakePageValidator(
+          $networkId: String!
+          $validator: Validator!
+        ) {
+          selfStake(networkId: $networkId, validator: $validator) {
+            amount
+          }
+        }
+      `,
       variables() {
         return {
           networkId: this.network,
-          operatorAddress: this.$route.params.validator
+          validator: this.validator
         }
       },
       update: result => {

--- a/src/components/staking/PageValidator.vue
+++ b/src/components/staking/PageValidator.vue
@@ -103,8 +103,8 @@
         <li>
           <h4>Self Stake</h4>
           <span id="page-profile__self-bond">
-            {{ validator.selfStake | shortDecimals }} /
-            {{ (validator.selfStake / validator.tokens) | percent }}
+            {{ selfStake.amount | shortDecimals }} /
+            {{ (selfStake.amount / validator.tokens) | percent }}
           </span>
         </li>
         <li>
@@ -175,7 +175,7 @@ import Avatar from "common/Avatar"
 import Bech32 from "common/Bech32"
 import TmPage from "common/TmPage"
 import gql from "graphql-tag"
-import { ValidatorProfile, UserTransactionAdded } from "src/gql"
+import { ValidatorProfile, UserTransactionAdded, SelfStake } from "src/gql"
 
 function getStatusText(statusDetailed) {
   switch (statusDetailed) {
@@ -217,6 +217,7 @@ export default {
     validator: {},
     rewards: 0,
     delegation: {},
+    selfStake: 0,
     error: false,
     loaded: false
   }),
@@ -341,6 +342,21 @@ export default {
       },
       result(queryResult) {
         this.loaded = !!queryResult.data.validator
+      }
+    },
+    selfStake: {
+      query: SelfStake,
+      variables() {
+        return {
+          networkId: this.network,
+          operatorAddress: this.$route.params.validator
+        }
+      },
+      update: result => {
+        return result.selfStake
+      },
+      result(queryResult) {
+        this.loaded = !!queryResult.data.selfStake
       }
     },
     $subscribe: {

--- a/src/gql/index.js
+++ b/src/gql/index.js
@@ -89,14 +89,6 @@ export const DelegationsForDelegator = schema => gql`
   }
 `
 
-export const SelfStake = gql`
-  query SelfStake($networkId: String!, $operatorAddress: String!) {
-    selfStake(networkId: $networkId, operatorAddress: $operatorAddress) {
-      amount
-    }
-  }
-`
-
 export const Networks = gql`
   query Networks {
     networks {

--- a/src/gql/index.js
+++ b/src/gql/index.js
@@ -89,6 +89,14 @@ export const DelegationsForDelegator = schema => gql`
   }
 `
 
+export const SelfStake = gql`
+  query SelfStake($networkId: String!, $operatorAddress: String!) {
+    selfStake(networkId: $networkId, operatorAddress: $operatorAddress) {
+      amount
+    }
+  }
+`
+
 export const Networks = gql`
   query Networks {
     networks {


### PR DESCRIPTION
Closes #ISSUE

**Description:**
This PR should fix, together with the PR with the same name for the API (#238), the problem of the slow loading of validators in Livepeer.

The big issue I have encountered here is that it is kind of hard to handle Objects as inputs in GraphQL. So that is why this PR is a work in progress. I don't know how to write the `selfStake` query in `PageValidator` to allow a validator Object as a parameter.

<!-- Briefly describe what you're adding or fixing with this PR -->

Thank you! 🚀

---

For contributor:

- [ ] Added changes entries. Run `yarn changelog` for a guided process.
- [ ] Reviewed `Files changed` in the github PR explorer
- [ ] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI
