### PR TITLE
Ana/fix session per network

### DIFF
--- a/changes/ana_fix-session-per-network
+++ b/changes/ana_fix-session-per-network
@@ -1,0 +1,1 @@
+[Fixed] [#3354](https://github.com/cosmos/lunie/pull/3354) Fix session per network so it signs in to the current network @Bitcoinera

--- a/src/vuex/modules/connection.js
+++ b/src/vuex/modules/connection.js
@@ -52,8 +52,8 @@ export default function ({ apollo }) {
     async setNetwork({ commit, dispatch }, network) {
       dispatch(`signOut`)
       dispatch(`persistNetwork`, network)
-      dispatch(`checkForPersistedSession`) // check for persisted session on that network
       commit("setNetworkId", network.id)
+      dispatch(`checkForPersistedSession`) // check for persisted session on that network
       console.info(`Connecting to: ${network.id}`)
     }
   }


### PR DESCRIPTION
Closes #ISSUE
I didn't open an issue for this. I just fixed it.

**Description:**
Before the session per network was always one network behind from the current one (it was taking the last one selected instead of the just selected). It was just a matter of ordering the code.

The bug before this fix:

![session-per-network](https://user-images.githubusercontent.com/40721795/71373171-8ee6fe00-25b6-11ea-894c-40f06053dd51.gif)

<!-- Briefly describe what you're adding or fixing with this PR -->

Thank you! 🚀

---

For contributor:

- [x] Added changes entries. Run `yarn changelog` for a guided process.
- [ ] Reviewed `Files changed` in the github PR explorer
- [ ] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI
