### PR TITLE
Ana/reduce parallel withdraw to max 4 validators

### DIFF
--- a/changes/ana_reduce-max-parallel-withdraw
+++ b/changes/ana_reduce-max-parallel-withdraw
@@ -1,0 +1,1 @@
+[Changed] [#3355](https://github.com/cosmos/lunie/pull/3355) Max parallel withdraws are now 4 instead of 5 @Bitcoinera

--- a/src/ActionModal/components/ActionModal.vue
+++ b/src/ActionModal/components/ActionModal.vue
@@ -153,7 +153,7 @@
             <div v-if="!extension.enabled">
               Please install the Lunie Browser Extension from the
               <a
-                href="https://chrome.google.com/webstore/category/extensions?ref=lunie"
+                href="http://bit.ly/lunie-ext"
                 target="_blank"
                 rel="noopener norefferer"
                 >Chrome Web Store</a

--- a/src/ActionModal/components/ModalWithdrawRewards.vue
+++ b/src/ActionModal/components/ModalWithdrawRewards.vue
@@ -12,7 +12,7 @@
     :disable="validatorsWithRewards"
   >
     <span class="form-message notice withdraw-limit">
-      Lunie will only withdraw rewards from 5 validators at a time because of a
+      Lunie will only withdraw rewards from 4 validators at a time because of a
       limitation with the Ledger Nano&nbsp;S.
     </span>
     <TmFormGroup

--- a/src/ActionModal/utils/ActionManager.js
+++ b/src/ActionModal/utils/ActionManager.js
@@ -248,7 +248,7 @@ function getTop4RewardsValidators(bondDenom, rewards) {
   const byBalance = (a, b) => b.amount - a.amount
   const validatorList = rewards
     .sort(byBalance)
-    .slice(0, 4) // Just the top 5
+    .slice(0, 4) // Just the top 4
     .map(({ validator }) => validator.operatorAddress)
 
   return validatorList

--- a/src/ActionModal/utils/ActionManager.js
+++ b/src/ActionModal/utils/ActionManager.js
@@ -160,7 +160,7 @@ export default class ActionManager {
 
     let txMessages = []
     if (type === transaction.WITHDRAW) {
-      const validators = getTop5RewardsValidators(
+      const validators = getTop4RewardsValidators(
         context.bondDenom,
         context.rewards
       )
@@ -205,7 +205,7 @@ export default class ActionManager {
   }
 
   async createWithdrawTransaction() {
-    const addresses = getTop5RewardsValidators(
+    const addresses = getTop4RewardsValidators(
       this.context.bondDenom,
       this.context.rewards
     )
@@ -243,12 +243,12 @@ function toMicroAtomString(amount) {
 }
 
 // // limitation of the block, so we pick the top 5 rewards and inform the user.
-function getTop5RewardsValidators(bondDenom, rewards) {
+function getTop4RewardsValidators(bondDenom, rewards) {
   // Compares the amount in a [address1, {denom: amount}] array
   const byBalance = (a, b) => b.amount - a.amount
   const validatorList = rewards
     .sort(byBalance)
-    .slice(0, 5) // Just the top 5
+    .slice(0, 4) // Just the top 5
     .map(({ validator }) => validator.operatorAddress)
 
   return validatorList

--- a/tests/unit/specs/components/ActionModal/components/__snapshots__/ModalWithdrawRewards.spec.js.snap
+++ b/tests/unit/specs/components/ActionModal/components/__snapshots__/ModalWithdrawRewards.spec.js.snap
@@ -18,7 +18,7 @@ exports[`ModalWithdrawRewards should show the withdraw rewards modal 1`] = `
     class="form-message notice withdraw-limit"
   >
     
-    Lunie will only withdraw rewards from 5 validators at a time because of a
+    Lunie will only withdraw rewards from 4 validators at a time because of a
     limitation with the Ledger Nano S.
   
   </span>

--- a/tests/unit/specs/components/ActionModal/utils/ActionManager.spec.js
+++ b/tests/unit/specs/components/ActionModal/utils/ActionManager.spec.js
@@ -426,7 +426,7 @@ describe("ActionManager", () => {
       )
       mockMsgWithdraw.mockClear()
       await actionManager.send("memo", withdrawTx.txMetaData)
-      expect(mockMsgWithdraw).toBeCalledTimes(5)
+      expect(mockMsgWithdraw).toBeCalledTimes(4)
 
       expect(MsgSendFn).toHaveBeenCalledWith(
         {


### PR DESCRIPTION
Closes #ISSUE

**Description:**

Reduces the threshold for max parallel withdraws from 5 to 4

<!-- Briefly describe what you're adding or fixing with this PR -->

Thank you! 🚀

---

For contributor:

- [x] Added changes entries. Run `yarn changelog` for a guided process.
- [x] Reviewed `Files changed` in the github PR explorer
- [ ] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI
