### PR TITLE
Ana/livepeer-activity-feature

### DIFF
--- a/changes/ana_livepeer-activity-feature
+++ b/changes/ana_livepeer-activity-feature
@@ -1,0 +1,1 @@
+[Changed] [#3356](https://github.com/cosmos/lunie/pull/3356) Now the TransactionMetadata component checks if transaction.fee does exist @Bitcoinera

--- a/src/components/transactions/TransactionMetadata.vue
+++ b/src/components/transactions/TransactionMetadata.vue
@@ -15,7 +15,7 @@
     <p v-if="transaction.memo">
       <i class="material-icons">message</i> Memo: {{ transaction.memo }}
     </p>
-    <p>
+    <p v-if="transaction.fee">
       Fee:
       <b>{{ transaction.fee.amount }}</b>
       <span> {{ transaction.fee.denom }}</span>


### PR DESCRIPTION
Closes #ISSUE

**Description:**

The only change I had to make was checking in `TransactionMetadata` if `transaction.fee` does exist.

But as I comment in my PR `ana/livepeer-activity-feature` for `lunie-api`, I think we really should make the FE more agnostic, and remove the current amount handling for transactions (too Tendermint dependent) and change the transaction types system to make it agnostic.

I can make separate PRs for both of these changes (undoubtedly best option).

<!-- Briefly describe what you're adding or fixing with this PR -->

Thank you! 🚀

---

For contributor:

- [ ] Added changes entries. Run `yarn changelog` for a guided process.
- [ ] Reviewed `Files changed` in the github PR explorer
- [ ] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI
