### PR TITLE
Ana/fix address undefined error in Bech32

### DIFF
--- a/changes/ana_fix-prop-address-Undefined
+++ b/changes/ana_fix-prop-address-Undefined
@@ -1,0 +1,1 @@
+[Fixed] [#3357](https://github.com/cosmos/lunie/pull/3357) Not require address anymore in the Bech32 component @Bitcoinera

--- a/src/components/common/Bech32.vue
+++ b/src/components/common/Bech32.vue
@@ -25,7 +25,7 @@ export default {
   props: {
     address: {
       type: String,
-      required: true
+      required: false
     },
     longForm: {
       type: Boolean,


### PR DESCRIPTION
Closes #ISSUE
I just discovered this bug today

**Description:**

This was giving me trouble today as I was debugging. The field "address" was set to `required: true` in the `Bech32.vue` component and this was causing the same error about hundred times: `Expected type String with value "undefined" but got Undefined`.

I don't think it makes sense to have `address` as `required` since we are already filtering with `formatBech32` and if `address` is blank we simply mark it as `Adress Not Found`.

I didn't look into yet why all addresses appear as `undefined` but I presume it is related to the recent Cosmos upgrade, although I don't know for certain.

<img width="500px" src="https://user-images.githubusercontent.com/40721795/71422021-03856f80-267f-11ea-928f-9af828bb677c.png" />

<!-- Briefly describe what you're adding or fixing with this PR -->

Thank you! 🚀

---

For contributor:

- [ ] Added changes entries. Run `yarn changelog` for a guided process.
- [ ] Reviewed `Files changed` in the github PR explorer
- [ ] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI
