### PR TITLE
Ana/add back to validators button

### DIFF
--- a/changes/ana_add-go-back-to-validators-button
+++ b/changes/ana_add-go-back-to-validators-button
@@ -1,0 +1,1 @@
+[Added] [#3362](https://github.com/cosmos/lunie/pull/3362) Adds "Back to Validators" button in PageValidator @Bitcoinera

--- a/public/img/icons/arrow-icon.svg
+++ b/public/img/icons/arrow-icon.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 14 14">
+    <path fill="#7A88B8" fill-rule="nonzero" d="M7 0l1.234 1.234L3.35 6.125H14v1.75H3.351l4.883 4.891L7 14 0 7z"/>
+</svg>

--- a/src/components/staking/PageValidator.vue
+++ b/src/components/staking/PageValidator.vue
@@ -9,6 +9,15 @@
     class="small"
   >
     <template v-if="validator.operatorAddress" slot="managed-body">
+      <button
+        class="validators-list-button"
+        color="secondary"
+        @click="$router.push(`/validators`)"
+      >
+        <img src="/img/icons/arrow-icon.svg" />
+        <div style="width: 20px;display: inline-block"></div>
+        Back to Validators
+      </button>
       <div class="status-button-container">
         <div class="status-container">
           <span :class="validator.status | toLower" class="validator-status">
@@ -21,12 +30,6 @@
             {{ validator.statusDetailed }}
           </span>
         </div>
-        <TmBtn
-          class="validators-list-button"
-          value="Back to Validators"
-          color="secondary"
-          @click.native="$router.push(`/validators`)"
-        />
       </div>
       <tr class="li-validator">
         <td class="data-table__row__info">
@@ -401,9 +404,20 @@ export default {
 </script>
 <style scoped>
 .validators-list-button {
-  position: absolute;
-  right: 1.25rem;
-  top: 1.25rem;
+  margin: 0 0 20px 10px;
+  width: 177px;
+  height: 40px;
+  background-color: #272b48;
+  font-size: 14px;
+  color: #7a88b8;
+  border: 1px solid rgb(122, 136, 184, 0.1);
+  border-radius: 5px;
+}
+
+.validators-list-button:hover {
+  background: #445381;
+  color: #f1f3f7;
+  border-color: #445381;
 }
 
 .li-validator {

--- a/src/components/staking/PageValidator.vue
+++ b/src/components/staking/PageValidator.vue
@@ -412,6 +412,7 @@ export default {
   color: #7a88b8;
   border: 1px solid rgb(122, 136, 184, 0.1);
   border-radius: 5px;
+  cursor: pointer;
 }
 
 .validators-list-button:hover {
@@ -515,14 +516,6 @@ span {
     display: flex;
     flex-direction: column-reverse;
   }
-
-  .validators-list-button {
-    position: relative;
-    width: 150px;
-    margin-left: 1.25rem;
-    right: 0;
-    top: 0;
-  }
 }
 
 @media screen and (max-width: 667px) {
@@ -533,6 +526,12 @@ span {
 
   .button-container button {
     width: 50%;
+  }
+}
+
+@media screen and (min-width: 1024px) {
+  .validators-list-button {
+    display: none;
   }
 }
 </style>

--- a/src/components/staking/PageValidator.vue
+++ b/src/components/staking/PageValidator.vue
@@ -9,13 +9,24 @@
     class="small"
   >
     <template v-if="validator.operatorAddress" slot="managed-body">
-      <div class="status-container">
-        <span :class="validator.status | toLower" class="validator-status">
-          {{ validator.status }}
-        </span>
-        <span v-if="validator.statusDetailed" class="validator-status-detailed">
-          {{ validator.statusDetailed }}
-        </span>
+      <div class="status-button-container">
+        <div class="status-container">
+          <span :class="validator.status | toLower" class="validator-status">
+            {{ validator.status }}
+          </span>
+          <span
+            v-if="validator.statusDetailed"
+            class="validator-status-detailed"
+          >
+            {{ validator.statusDetailed }}
+          </span>
+        </div>
+        <TmBtn
+          class="validators-list-button"
+          value="Back to Validators"
+          color="secondary"
+          @click.native="$router.push(`/validators`)"
+        />
       </div>
       <tr class="li-validator">
         <td class="data-table__row__info">
@@ -389,6 +400,12 @@ export default {
 }
 </script>
 <style scoped>
+.validators-list-button {
+  position: absolute;
+  right: 1.25rem;
+  top: 1.25rem;
+}
+
 .li-validator {
   display: flex;
   justify-content: space-between;
@@ -478,8 +495,22 @@ span {
   margin-top: 0.4rem;
   font-size: 0.8rem;
 }
-</style>
-<style>
+
+@media screen and (max-width: 425px) {
+  .status-button-container {
+    display: flex;
+    flex-direction: column-reverse;
+  }
+
+  .validators-list-button {
+    position: relative;
+    width: 150px;
+    margin-left: 1.25rem;
+    right: 0;
+    top: 0;
+  }
+}
+
 @media screen and (max-width: 667px) {
   .button-container {
     width: 100%;


### PR DESCRIPTION
Closes #ISSUE

**Description:**

This is one of the simple improvements I have thought of lately. 

It is just a button in `PageValidator` to go back to the `ListValidators`.

Didn't take me almost any time to make it, no worries ;)

<!-- Briefly describe what you're adding or fixing with this PR -->
Some screenshots:

<img width="500px" src="https://user-images.githubusercontent.com/40721795/71603323-8e250d80-2b5c-11ea-9b47-db1d51bf9196.png" />

<img width="250px" src="https://user-images.githubusercontent.com/40721795/71603354-aac14580-2b5c-11ea-95cb-bc1a5be981db.png" />



Thank you! 🚀

---

For contributor:

- [x] Added changes entries. Run `yarn changelog` for a guided process.
- [x] Reviewed `Files changed` in the github PR explorer
- [ ] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI
