### PR TITLE
Ana/correct job location

### DIFF
--- a/src/components/common/PageCareers.vue
+++ b/src/components/common/PageCareers.vue
@@ -21,7 +21,7 @@
         Open Positions
       </h2>
       <p>
-        The following are full-time roles based in Toronto or Berlin.
+        The following are our 100% remote full-time roles.
       </p>
       <ul class="jobs-list">
         <li>


### PR DESCRIPTION
Closes #ISSUE

**Description:**

In the jobs description in `PageCareers` it stated that the open positions are based in both Toronto and Berlin, but the reality is that we work remotely :woman_shrugging:  ?

Of course, I don't know if you are searching for people based in your locations for those specific roles.

I just wanted to point this out.

<!-- Briefly describe what you're adding or fixing with this PR -->

Thank you! 🚀

---

For contributor:

- [ ] Added changes entries. Run `yarn changelog` for a guided process.
- [ ] Reviewed `Files changed` in the github PR explorer
- [ ] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI
