### PR TITLE
Ana/fix lunie browser extension link

### DIFF
--- a/changes/ana_fix-lunie-browser-extension-link
+++ b/changes/ana_fix-lunie-browser-extension-link
@@ -1,0 +1,1 @@
+[Changed] [#3366](https://github.com/cosmos/lunie/pull/3366) Fix link in ActionModal for lunie browser extension  @Bitcoinera

--- a/src/ActionModal/components/ActionModal.vue
+++ b/src/ActionModal/components/ActionModal.vue
@@ -153,7 +153,7 @@
             <div v-if="!extension.enabled">
               Please install the Lunie Browser Extension from the
               <a
-                href="https://chrome.google.com/webstore/category/extensions?ref=lunie"
+                href="http://bit.ly/lunie-ext"
                 target="_blank"
                 rel="noopener norefferer"
                 >Chrome Web Store</a


### PR DESCRIPTION
Closes #ISSUE

**Description:**

Following a conversation of an user I realized that the link in `ActionModal` for the Lunie Extension Browser was wrong. Was only directing to the "extensions" category of the Chrome webstore, making it impossible for users to find our extension.

Here is the simple fix.

<!-- Briefly describe what you're adding or fixing with this PR -->

Thank you! 🚀

---

For contributor:

- [x] Added changes entries. Run `yarn changelog` for a guided process.
- [x] Reviewed `Files changed` in the github PR explorer
- [ ] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI
