### PR TITLE
Ana/add better validation for cosmos addresses

### DIFF
--- a/changes/ana_improve-cosmos-address-signin-validation
+++ b/changes/ana_improve-cosmos-address-signin-validation
@@ -1,0 +1,1 @@
+[Changed] [#3371](https://github.com/cosmos/lunie/pull/3371) Strengthen the validation for cosmos addresses signin @Bitcoinera

--- a/src/components/common/TmSessionExplore.vue
+++ b/src/components/common/TmSessionExplore.vue
@@ -58,9 +58,9 @@
           />
           <TmFormMsg
             v-else-if="
-              $v.address.$error && !$v.address.isNotAnyOtherCosmosAddress
+              $v.address.$error && !$v.address.isAWhitelistedBech32Prefix
             "
-            name="You can only sign in with a regular Cosmos address, starting with 'cosmos1'"
+            name="You can only sign in with a regular address"
             type="custom"
           />
         </TmFormGroup>
@@ -134,12 +134,13 @@ export default {
         return false
       }
     },
-    isNotAnyOtherCosmosAddress(param) {
+    isAWhitelistedBech32Prefix(param) {
       if (
-        param.substring(0, 9) !== "cosmospub" &&
-        param.substring(0, 13) !== "cosmosvalcons" &&
-        param.substring(0, 16) !== "cosmosvalconspub" &&
-        param.substring(0, 16) !== "cosmosvaloperpub"
+        param.substring(0, 7) === "cosmos1" ||
+        param.substring(0, 6) === "terra1" ||
+        param.substring(0, 5) === "xrn:1" ||
+        param.substring(0, 7) === "emoney1" ||
+        param.substring(0, 16) === "0x"
       ) {
         return true
       } else {
@@ -169,7 +170,7 @@ export default {
         required,
         bech32Validate: this.bech32Validate,
         isNotAValidatorAddress: this.isNotAValidatorAddress,
-        isNotAnyOtherCosmosAddress: this.isNotAnyOtherCosmosAddress
+        isAWhitelistedBech32Prefix: this.isAWhitelistedBech32Prefix
       }
     }
   }

--- a/src/components/common/TmSessionExplore.vue
+++ b/src/components/common/TmSessionExplore.vue
@@ -141,7 +141,7 @@ export default {
         param.substring(0, 6) === "terra1" ||
         param.substring(0, 5) === "xrn:1" ||
         param.substring(0, 7) === "emoney1" ||
-        param.substring(0, 16) === "0x"
+        param.substring(0, 2) === "0x"
       ) {
         return true
       } else {

--- a/src/components/common/TmSessionExplore.vue
+++ b/src/components/common/TmSessionExplore.vue
@@ -56,6 +56,13 @@
             name="You can't sign in with a validator address"
             type="custom"
           />
+          <TmFormMsg
+            v-else-if="
+              $v.address.$error && !$v.address.isNotAnyOtherCosmosAddress
+            "
+            name="You can only sign in with a regular Cosmos address, starting with 'cosmos1'"
+            type="custom"
+          />
         </TmFormGroup>
       </div>
       <div class="session-footer">
@@ -127,6 +134,18 @@ export default {
         return false
       }
     },
+    isNotAnyOtherCosmosAddress(param) {
+      if (
+        param.substring(0, 9) !== "cosmospub" &&
+        param.substring(0, 13) !== "cosmosvalcons" &&
+        param.substring(0, 16) !== "cosmosvalconspub" &&
+        param.substring(0, 16) !== "cosmosvaloperpub"
+      ) {
+        return true
+      } else {
+        return false
+      }
+    },
     getAddressIcon(addressType) {
       if (addressType === "explore") return `language`
       if (addressType === "ledger") return `vpn_key`
@@ -149,7 +168,8 @@ export default {
       address: {
         required,
         bech32Validate: this.bech32Validate,
-        isNotAValidatorAddress: this.isNotAValidatorAddress
+        isNotAValidatorAddress: this.isNotAValidatorAddress,
+        isNotAnyOtherCosmosAddress: this.isNotAnyOtherCosmosAddress
       }
     }
   }

--- a/tests/unit/specs/components/common/TmSessionExplore.spec.js
+++ b/tests/unit/specs/components/common/TmSessionExplore.spec.js
@@ -88,6 +88,15 @@ describe(`TmSessionExplore`, () => {
     expect(wrapper.find(`.tm-form-msg-error`)).toBeDefined()
   })
 
+  it(`should show error if address is a "cosmospub" address`, () => {
+    wrapper.setData({
+      address: `cosmospub1addwnpepqgadvwk7ev0kk2x0tua0hrt056p8tqpv35r0mwydz45ytxp3wfaz5e7nxun`
+    })
+    wrapper.vm.onSubmit()
+    expect($store.commit.mock.calls[1]).toBeUndefined()
+    expect(wrapper.find(`.tm-form-msg-error`)).toBeDefined()
+  })
+
   it(`should show the last account used`, () => {
     localStorage.setItem(`prevAddress`, `cosmos1xxx`)
 


### PR DESCRIPTION
Closes #ISSUE

**Description:**

I was looking through the Sentry errors and found one was due to an user trying to log in as an address starting with `cosmospub`. [Here](https://monitoring.lunie.io:9000/lunie/frontend/issues/69/?referrer=slack) is the link to the error: 

<img width="510px" src="https://user-images.githubusercontent.com/40721795/71770367-078d7900-2f2c-11ea-9b7f-4c7958eca5f5.png" />


This PR fixes similar future errors by improving the validation in the `TmSessionExplore` component.
 It is true that it seems that only the "cosmospub" addresses were missing, since I tried `cosmosvalcons`, `cosmosvaloperpub` and so on and the validation for `bech32` is enough in those other cases. Still, I added these other cases just to stay on the safe side and really make sure that users can only log in as regular `cosmos1` addresses.

Again, this is only cosmos focused and now that we will soon have `session` enabled for other networks maybe we need to tweak this a bit.

<!-- Briefly describe what you're adding or fixing with this PR -->

Thank you! 🚀

---

For contributor:

- [x] Added changes entries. Run `yarn changelog` for a guided process.
- [x] Reviewed `Files changed` in the github PR explorer
- [ ] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI
