### PR TITLE
Fabo/retry on failed requests

### DIFF
--- a/changes/fabo_retry-on-failed-requests
+++ b/changes/fabo_retry-on-failed-requests
@@ -1,0 +1,1 @@
+[Added] Retry graphql fetches on failed attempts @faboweb

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "apollo-cache-inmemory": "^1.6.2",
     "apollo-link-batch-http": "1.2.13",
     "apollo-link-persisted-queries": "0.2.2",
+    "apollo-link-retry": "2.2.15",
     "apollo-link-ws": "1.0.19",
     "apollo-utilities": "1.3.2",
     "autosize": "^4.0.2",

--- a/src/gql/apollo.js
+++ b/src/gql/apollo.js
@@ -1,6 +1,7 @@
 import Vue from "vue"
 import { ApolloClient } from "apollo-boost"
 import { BatchHttpLink } from "apollo-link-batch-http"
+import { RetryLink } from "apollo-link-retry"
 import { createPersistedQueryLink } from "apollo-link-persisted-queries"
 import { WebSocketLink } from "apollo-link-ws"
 import { InMemoryCache } from "apollo-cache-inmemory"
@@ -25,7 +26,8 @@ const makeHttpLink = urlParams => {
   return createPersistedQueryLink().concat(
     new BatchHttpLink({
       uri
-    })
+    }),
+    new RetryLink()
   )
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1024,7 +1024,7 @@
     "@types/unist" "*"
     "@types/vfile-message" "*"
 
-"@types/zen-observable@^0.8.0":
+"@types/zen-observable@0.8.0", "@types/zen-observable@^0.8.0":
   version "0.8.0"
   resolved "https://registry.yarnpkg.com/@types/zen-observable/-/zen-observable-0.8.0.tgz#8b63ab7f1aa5321248aad5ac890a485656dcea4d"
   integrity sha512-te5lMAWii1uEJ4FwLjzdlbw3+n0FZNOvFXHxQDKeT0dilh7HOzdMzV2TrJVUzq8ep7J4Na8OUYPRLSQkJHAlrg==
@@ -1777,6 +1777,15 @@ apollo-link-persisted-queries@0.2.2:
   dependencies:
     apollo-link "^1.2.1"
     hash.js "^1.1.3"
+
+apollo-link-retry@2.2.15:
+  version "2.2.15"
+  resolved "https://registry.yarnpkg.com/apollo-link-retry/-/apollo-link-retry-2.2.15.tgz#4cc3202fcb6251fed6f6b57ade99b4b1ad05c619"
+  integrity sha512-ltwXGxm+2NXzskrk+GTofj66LQtcc9OGCjIxAPbjlvtHanpKJn8CviWq8dIsMiYGS9T9rGG/kPPx/VdJfcFb6w==
+  dependencies:
+    "@types/zen-observable" "0.8.0"
+    apollo-link "^1.2.13"
+    tslib "^1.9.3"
 
 apollo-link-ws@1.0.19:
   version "1.0.19"


### PR DESCRIPTION
Should help with a bunch of Sentry errors where the FE can't get a property of the result of a failed fetch.

I.e.:

https://monitoring.lunie.io:9000/lunie/frontend/issues/67
https://monitoring.lunie.io:9000/lunie/frontend/issues/72