### PR TITLE
Ana/change svg icon for material icon

### DIFF
--- a/public/img/icons/arrow-icon.svg
+++ b/public/img/icons/arrow-icon.svg
@@ -1,3 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 14 14">
-    <path fill="#7A88B8" fill-rule="nonzero" d="M7 0l1.234 1.234L3.35 6.125H14v1.75H3.351l4.883 4.891L7 14 0 7z"/>
-</svg>

--- a/src/components/common/TmSessionExplore.vue
+++ b/src/components/common/TmSessionExplore.vue
@@ -175,7 +175,7 @@ export default {
     return {
       address: {
         required,
-        addressValidate: this.addressValidate,        
+        addressValidate: this.addressValidate,
         isNotAValidatorAddress: this.isNotAValidatorAddress,
         isAWhitelistedBech32Prefix: this.isAWhitelistedBech32Prefix
       }

--- a/src/components/staking/PageValidator.vue
+++ b/src/components/staking/PageValidator.vue
@@ -14,9 +14,11 @@
         color="secondary"
         @click="$router.push(`/validators`)"
       >
-        <img src="/img/icons/arrow-icon.svg" />
-        <div style="width: 20px;display: inline-block"></div>
-        Back to Validators
+        <div style="display:flex; flex-direction:row; align-items: center;">
+          <i class="material-icons arrow">arrow_back</i>
+          <div style="width: 20px;display: inline-block;"></div>
+          Back to Validators
+        </div>
       </button>
       <div class="status-button-container">
         <div class="status-container">

--- a/tests/unit/specs/components/ActionModal/components/ActionModal.spec.js
+++ b/tests/unit/specs/components/ActionModal/components/ActionModal.spec.js
@@ -185,7 +185,10 @@ describe(`ActionModal`, () => {
       new Error("some kind of error message")
     )
 
-    ActionModal.methods.onSendingFailed.call(self, new Error("some kind of error message"))
+    ActionModal.methods.onSendingFailed.call(
+      self,
+      new Error("some kind of error message")
+    )
     expect(self.submissionError).toEqual(`PREFIX: some kind of error message.`)
   })
 


### PR DESCRIPTION
Closes #ISSUE

**Description:**

This PR just changes the "Back to Validators" button by replacing the SVG arrow icon for a `material-icon` icon. (plus some linting)

<!-- Briefly describe what you're adding or fixing with this PR -->

Thank you! 🚀

---

For contributor:

- [ ] Added changes entries. Run `yarn changelog` for a guided process.
- [ ] Reviewed `Files changed` in the github PR explorer
- [ ] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI
