### PR TITLE
Round total rewards to 6 decimal places

### DIFF
--- a/changes/mario_3376-fix-rewards-decimals
+++ b/changes/mario_3376-fix-rewards-decimals
@@ -1,0 +1,1 @@
+[Fixed] [#3376](https://github.com/cosmos/lunie/issues/3376) Round total rewards to 6 decimal places @mariopino

--- a/src/ActionModal/components/ModalWithdrawRewards.vue
+++ b/src/ActionModal/components/ModalWithdrawRewards.vue
@@ -63,7 +63,9 @@ export default {
       }
     },
     totalRewards() {
-      return this.rewards.reduce((sum, { amount }) => sum + Number(amount), 0)
+      return this.rewards
+        .reduce((sum, { amount }) => sum + Number(amount), 0)
+        .toFixed(6)
     },
     notifyMessage() {
       return {

--- a/tests/unit/specs/components/ActionModal/components/__snapshots__/ActionModal.spec.js.snap
+++ b/tests/unit/specs/components/ActionModal/components/__snapshots__/ActionModal.spec.js.snap
@@ -229,7 +229,9 @@ exports[`ActionModal should show the action modal on success 1`] = `
       success="true"
     >
       <div>
-        Successful transaction
+        
+            Successful transaction
+          
       </div>
        
       <div>

--- a/tests/unit/specs/components/ActionModal/components/__snapshots__/ModalWithdrawRewards.spec.js.snap
+++ b/tests/unit/specs/components/ActionModal/components/__snapshots__/ModalWithdrawRewards.spec.js.snap
@@ -39,7 +39,7 @@ exports[`ModalWithdrawRewards should show the withdraw rewards modal 1`] = `
       disabled="disabled"
       id="amount"
       type="number"
-      value="0"
+      value="0.000000"
     />
   </tmformgroup-stub>
 </actionmodal-stub>

--- a/tests/unit/specs/components/ActionModal/utils/ActionManager.spec.js
+++ b/tests/unit/specs/components/ActionModal/utils/ActionManager.spec.js
@@ -171,7 +171,7 @@ describe("ActionManager", () => {
     }
   })
 
-  describe("simulating and sending", async () => {
+  describe("simulating and sending", () => {
     beforeEach(async () => {
       const context = {
         url: "blah",


### PR DESCRIPTION
Closes #3376

**Description:**

Round total rewards to 6 decimal places.

Alternative solution: return total rewards from api.

Thank you! 🚀

---

For contributor:

- [ ] Added changes entries. Run `yarn changelog` for a guided process.
- [ ] Reviewed `Files changed` in the github PR explorer
- [ ] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI
