### PR TITLE
Ana/handle blocks links according to explorer feature

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,15 +15,15 @@ commands:
     steps:
       - restore_cache:
           keys:
-            - v5-dependencies-root-{{ checksum "yarn.lock" }}
-            - v5-dependencies-root-
+            - v6-dependencies-root-{{ checksum "yarn.lock" }}
+            - v6-dependencies-root-
 
       - run: yarn install
       - save_cache:
           paths:
             - yarn.lock
             - node_modules
-          key: v5-dependencies-root-{{ checksum "yarn.lock" }}
+          key: v6-dependencies-root-{{ checksum "yarn.lock" }}
 
   # use npm as the extension install happens in the mashine image which doesn't have yarn
   npm-install-extension:

--- a/changes/ana_handle-explorer-flag-for-blocks
+++ b/changes/ana_handle-explorer-flag-for-blocks
@@ -1,0 +1,1 @@
+[Changed] [#3282](https://github.com/cosmos/lunie/issues/3282) Now the block links in the activity section are active or not depending on the feature_explorer feature flag of the network @Bitcoinera

--- a/package.json
+++ b/package.json
@@ -119,6 +119,7 @@
     "stylelint": "12.0.1",
     "stylelint-config-standard": "19.0.0",
     "stylelint-webpack-plugin": "1.1.2",
+    "vue-jest": "3.0.5",
     "vue-template-compiler": "^2.6.10",
     "webpack": "4.41.5"
   },

--- a/src/components/transactions/TransactionMetadata.vue
+++ b/src/components/transactions/TransactionMetadata.vue
@@ -3,10 +3,13 @@
     <p>
       Block
       <router-link
+        v-if="checkFeatureAvailable()"
         :to="{ name: `block`, params: { height: transaction.height } }"
       >
         #{{ transaction.height | prettyInt }}</router-link
-      >&nbsp;<i class="material-icons">access_time</i>&nbsp;{{ date }}
+      >
+      <span v-else>#{{ transaction.height | prettyInt }}</span>
+      &nbsp;<i class="material-icons">access_time</i>&nbsp;{{ date }}
     </p>
     <p v-if="transaction.undelegationEndTime">
       Liquid date:
@@ -27,6 +30,8 @@
 </template>
 
 <script>
+import { mapGetters } from "vuex"
+import gql from "graphql-tag"
 import moment from "moment"
 import { atoms, viewDenom } from "scripts/num.js"
 import { prettyInt } from "scripts/num"
@@ -44,7 +49,11 @@ export default {
       required: true
     }
   },
+  data: () => ({
+    network: {}
+  }),
   computed: {
+    ...mapGetters({ networkId: `network` }),
     date() {
       const momentTime = moment(this.transaction.timestamp)
       return momentTime.format(`HH:mm:ss`)
@@ -53,6 +62,32 @@ export default {
   methods: {
     getUndelegationEndTime() {
       return moment(new Date(this.transaction.undelegationEndTime))
+    },
+    checkFeatureAvailable() {
+      const feature = `feature_explorer`
+      return this.network[feature] === true
+    }
+  },
+  apollo: {
+    network: {
+      query: gql`
+        query NetworkActionModal($networkId: String!) {
+          network(id: $networkId) {
+            id
+            feature_explorer
+          }
+        }
+      `,
+      variables() {
+        /* istanbul ignore next */
+        return {
+          networkId: this.networkId
+        }
+      },
+      update(data) {
+        /* istanbul ignore next */
+        return data.network
+      }
     }
   }
 }

--- a/tests/unit/specs/components/transactions/__snapshots__/TransactionMetadata.spec.js.snap
+++ b/tests/unit/specs/components/transactions/__snapshots__/TransactionMetadata.spec.js.snap
@@ -8,12 +8,10 @@ exports[`TransactionMetadata renders correct transaction metadata 1`] = `
     
     Block
     
-    <router-link-stub
-      to="[object Object]"
-    >
-      
+    <span>
       #1,234,567
-    </router-link-stub>
+    </span>
+    
      
     <i
       class="material-icons"

--- a/yarn.lock
+++ b/yarn.lock
@@ -12632,7 +12632,7 @@ vue-infinite-scroll@^2.0.2:
   resolved "https://registry.yarnpkg.com/vue-infinite-scroll/-/vue-infinite-scroll-2.0.2.tgz#ca37a91fe92ee0ad3b74acf8682c00917144b711"
   integrity sha512-n+YghR059YmciANGJh9SsNWRi1YZEBVlODtmnb/12zI+4R72QZSWd+EuZ5mW6auEo/yaJXgxzwsuhvALVnm73A==
 
-vue-jest@^3.0.5:
+vue-jest@3.0.5, vue-jest@^3.0.5:
   version "3.0.5"
   resolved "https://registry.yarnpkg.com/vue-jest/-/vue-jest-3.0.5.tgz#d6f124b542dcbff207bf9296c19413f4c40b70c9"
   integrity sha512-xWDxde91pDqYBGDlODENZ3ezPgw+IQFoVDtf+5Awlg466w3KvMSqWzs8PxcTeTr+wmAHi0j+a+Lm3R7aUJa1jA==


### PR DESCRIPTION
Closes #3282 

**Description:**

Now depending on the `feature_explorer` of the given network the blocks links are either enabled or not. 

This makes so much sense because before an user could click on those links and find empty blocks with no data whatsoever in them.

<!-- Briefly describe what you're adding or fixing with this PR -->

Thank you! 🚀

---

For contributor:

- [x] Added changes entries. Run `yarn changelog` for a guided process.
- [ ] Reviewed `Files changed` in the github PR explorer
- [ ] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI
