### PR TITLE
Fabo/add script to add intercom keys

### DIFF
--- a/changes/fabo_intercom-key-script
+++ b/changes/fabo_intercom-key-script
@@ -1,0 +1,1 @@
+[Repository] Add script to add intercom keys to capacitor @faboweb

--- a/tasks/add-intercom-key.js
+++ b/tasks/add-intercom-key.js
@@ -1,0 +1,37 @@
+const fs = require("fs")
+
+const iosConfigPath = "ios/App/App/capacitor.config.json"
+const androidConfigPath = "android/app/src/main/assets/capacitor.config.json"
+
+/*
+ * this script adds the required intercom keys to the capacitor configs
+ * this is done in this script to avoid checking the keys into GitHub
+ */
+
+function main() {
+  const intercomAppId = process.argv[2]
+  const androidKey = process.argv[3]
+  const iosKey = process.argv[4]
+
+  const iosConfig = JSON.parse(fs.readFileSync(iosConfigPath))
+  if (!iosConfig.plugins) {
+    iosConfigPath.plugins = {}
+  }
+  iosConfig.plugins.IntercomPlugin = {
+    "ios-apiKey": iosKey,
+    "ios-appId": intercomAppId
+  }
+  fs.writeFileSync(iosConfigPath, JSON.stringify(iosConfig))
+
+  const androidConfig = JSON.parse(fs.readFileSync(androidConfigPath))
+  if (!androidConfig.plugins) {
+    androidConfig.plugins = {}
+  }
+  androidConfig.plugins.IntercomPlugin = {
+    "android-apiKey": androidKey,
+    "android-appId": intercomAppId
+  }
+  fs.writeFileSync(androidConfigPath, JSON.stringify(androidConfig))
+}
+
+main()


### PR DESCRIPTION
run script with `node tasks/add-intercom-key.js INTERCOM_APP_ID INTERCOM_ANDROID_KEY INTERCOM_IOS_KEY`