### PR TITLE
Ana/fix query balances in tmbalance

### DIFF
--- a/src/ActionModal/components/SendModal.vue
+++ b/src/ActionModal/components/SendModal.vue
@@ -235,9 +235,6 @@ export default {
       }
     }
   },
-  mounted() {
-    this.$apollo.queries.balance.refetch()
-  },
   methods: {
     open() {
       this.$refs.actionModal.open()

--- a/src/components/common/TmBalance.vue
+++ b/src/components/common/TmBalance.vue
@@ -46,7 +46,7 @@
         />
       </div>
 
-      <SendModal ref="SendModal" :denoms="getAllDenoms" />
+      <SendModal ref="SendModal" :denoms="getAllDenoms" :balances="balances" />
       <ModalWithdrawRewards ref="ModalWithdrawRewards" />
     </div>
   </div>
@@ -73,7 +73,8 @@ export default {
   data() {
     return {
       overview: {},
-      stakingDenom: ""
+      stakingDenom: "",
+      balances: []
     }
   },
   computed: {
@@ -84,8 +85,8 @@ export default {
       return this.overview.totalRewards > 0
     },
     getAllDenoms() {
-      if (this.overview.balances) {
-        const balances = this.overview.balances
+      if (this.balances) {
+        const balances = this.balances
         return balances.map(({ denom }) => denom)
       } else {
         return [this.stakingDenom]
@@ -107,10 +108,6 @@ export default {
           overview(networkId: $networkId, address: $address) {
             totalRewards
             liquidStake
-            balances {
-              denom
-              amount
-            }
             totalStake
           }
         }
@@ -130,7 +127,33 @@ export default {
         }
       },
       skip() {
+        /* istanbul ignore next */
         return !this.address
+      }
+    },
+    balances: {
+      query: gql`
+        query BalancesSendModal($networkId: String!, $address: String!) {
+          balances(networkId: $networkId, address: $address) {
+            amount
+            denom
+          }
+        }
+      `,
+      skip() {
+        /* istanbul ignore next */
+        return !this.address
+      },
+      variables() {
+        /* istanbul ignore next */
+        return {
+          networkId: this.network,
+          address: this.address
+        }
+      },
+      update(data) {
+        /* istanbul ignore next */
+        return data.balances
       }
     },
     stakingDenom: {
@@ -143,6 +166,7 @@ export default {
         }
       `,
       variables() {
+        /* istanbul ignore next */
         return {
           networkId: this.network
         }
@@ -155,11 +179,13 @@ export default {
     $subscribe: {
       blockAdded: {
         variables() {
+          /* istanbul ignore next */
           return {
             networkId: this.network
           }
         },
         query() {
+          /* istanbul ignore next */
           return gql`
             subscription($networkId: String!) {
               blockAdded(networkId: $networkId) {

--- a/tests/unit/specs/components/common/__snapshots__/TmBalance.spec.js.snap
+++ b/tests/unit/specs/components/common/__snapshots__/TmBalance.spec.js.snap
@@ -51,7 +51,8 @@ exports[`TmBalance do not show available atoms when the user has none in the fir
     </div>
      
     <sendmodal-stub
-      denoms="ATOM"
+      balances=""
+      denoms=""
     />
      
     <modalwithdrawrewards-stub />
@@ -129,7 +130,8 @@ exports[`TmBalance show the balance header when signed in 1`] = `
     </div>
      
     <sendmodal-stub
-      denoms="ATOM"
+      balances=""
+      denoms=""
     />
      
     <modalwithdrawrewards-stub />


### PR DESCRIPTION
Closes #ISSUE

**Description:**

I made a mistake in the last PR `multiple-denoms-in-sendmodal`.

With so many different branches I forgot that we are querying for balances separately, and not inside overview.

This is fixed in this PR but I don't like the fact that `balances` are now being queried both in TmBalance and SendModal. I have another version where I pass `balances` as props to SendModal, but tests fail there.

I will look more into it tomorrow.

<!-- Briefly describe what you're adding or fixing with this PR -->

Thank you! 🚀

---

For contributor:

- [ ] Added changes entries. Run `yarn changelog` for a guided process.
- [ ] Reviewed `Files changed` in the github PR explorer
- [ ] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI
