### PR TITLE
Ana/filter addresses per network in session explore

### DIFF
--- a/changes/ana_filter-login-addresses-per-network
+++ b/changes/ana_filter-login-addresses-per-network
@@ -1,0 +1,1 @@
+[Changed] [#3438](https://github.com/cosmos/lunie/pull/3438) Now the session explore component filters for addresses belonging to the current network we are connected to  @Bitcoinera

--- a/src/components/common/TmSessionExplore.vue
+++ b/src/components/common/TmSessionExplore.vue
@@ -74,6 +74,7 @@
 
 <script>
 import { mapState, mapGetters } from "vuex"
+import config from "src/../config"
 import { required } from "vuelidate/lib/validators"
 import TmBtn from "common/TmBtn"
 import SessionFrame from "common/SessionFrame"
@@ -107,9 +108,10 @@ export default {
     ...mapState([`session`]),
     ...mapGetters([`network`]),
     filteredAddresses() {
-      const networkPrefix = this.network.split(`-`)[0]
       return this.session.addresses
-        .filter(address => address.address.startsWith(networkPrefix))
+        .filter(address =>
+          address.address.startsWith(config.bech32Prefixes[this.network])
+        )
         .slice(-3)
     }
   },

--- a/src/components/common/TmSessionExplore.vue
+++ b/src/components/common/TmSessionExplore.vue
@@ -7,7 +7,7 @@
 
       <div v-if="session.addresses.length > 0" class="session-list">
         <div
-          v-for="account in session.addresses.slice(-3)"
+          v-for="account in filteredAddresses"
           :key="account.address"
           :title="account.address"
           @click="exploreWith(account.address)"
@@ -73,7 +73,7 @@
 </template>
 
 <script>
-import { mapState } from "vuex"
+import { mapState, mapGetters } from "vuex"
 import { required } from "vuelidate/lib/validators"
 import TmBtn from "common/TmBtn"
 import SessionFrame from "common/SessionFrame"
@@ -104,7 +104,14 @@ export default {
     error: ``
   }),
   computed: {
-    ...mapState([`session`])
+    ...mapState([`session`]),
+    ...mapGetters([`network`]),
+    filteredAddresses() {
+      const networkPrefix = this.network.split(`-`)[0]
+      return this.session.addresses
+        .filter(address => address.address.startsWith(networkPrefix))
+        .slice(-3)
+    }
   },
   mounted() {
     this.address = localStorage.getItem(`prevAddress`)

--- a/src/components/common/TmSessionExplore.vue
+++ b/src/components/common/TmSessionExplore.vue
@@ -34,7 +34,7 @@
       </div>
 
       <div class="session-main">
-        <TmFormGroup field-id="sign-in-name" field-label="Your Cosmos Address">
+        <TmFormGroup field-id="sign-in-name" field-label="Your Address">
           <TmField
             v-model="address"
             type="text"
@@ -48,7 +48,7 @@
           />
           <TmFormMsg
             v-else-if="$v.address.$error && !$v.address.addressValidate"
-            name="Your Cosmos Address"
+            name="Your Address"
             type="bech32"
           />
           <TmFormMsg
@@ -61,6 +61,11 @@
               $v.address.$error && !$v.address.isAWhitelistedBech32Prefix
             "
             name="You can only sign in with a regular address"
+            type="custom"
+          />
+          <TmFormMsg
+            v-else-if="$v.address.$error && !$v.address.isANetworkAddress"
+            name="This address doesn't belong to the network you are currently connected to"
             type="custom"
           />
         </TmFormGroup>
@@ -158,6 +163,13 @@ export default {
         return false
       }
     },
+    isANetworkAddress(param) {
+      if (param.startsWith(config.bech32Prefixes[this.network])) {
+        return true
+      } else {
+        return false
+      }
+    },
     getAddressIcon(addressType) {
       if (addressType === "explore") return `language`
       if (addressType === "ledger") return `vpn_key`
@@ -187,7 +199,8 @@ export default {
         required,
         addressValidate: this.addressValidate,
         isNotAValidatorAddress: this.isNotAValidatorAddress,
-        isAWhitelistedBech32Prefix: this.isAWhitelistedBech32Prefix
+        isAWhitelistedBech32Prefix: this.isAWhitelistedBech32Prefix,
+        isANetworkAddress: this.isANetworkAddress
       }
     }
   }

--- a/tests/unit/specs/components/common/TmSessionExplore.spec.js
+++ b/tests/unit/specs/components/common/TmSessionExplore.spec.js
@@ -12,6 +12,9 @@ describe(`TmSessionExplore`, () => {
     $store = {
       commit: jest.fn(),
       dispatch: jest.fn(() => true),
+      getters: {
+        network: "cosmos-hub"
+      },
       state: {
         session: {
           address: ``,

--- a/tests/unit/specs/components/common/TmSessionExplore.spec.js
+++ b/tests/unit/specs/components/common/TmSessionExplore.spec.js
@@ -13,7 +13,7 @@ describe(`TmSessionExplore`, () => {
       commit: jest.fn(),
       dispatch: jest.fn(() => true),
       getters: {
-        network: "cosmos-hub"
+        network: "cosmos-hub-testnet"
       },
       state: {
         session: {

--- a/tests/unit/specs/components/common/__snapshots__/TmSessionExplore.spec.js.snap
+++ b/tests/unit/specs/components/common/__snapshots__/TmSessionExplore.spec.js.snap
@@ -171,7 +171,7 @@ exports[`TmSessionExplore shows a form to sign in with an address 1`] = `
     >
       <tmformgroup-stub
         fieldid="sign-in-name"
-        fieldlabel="Your Cosmos Address"
+        fieldlabel="Your Address"
       >
         <tmfield-stub
           placeholder=""


### PR DESCRIPTION
Closes #3389 

**Description:**

This is just a temporary fix. I still think that the best UX is what I originally proposed to handle networks/sessions. That is, that when you choose an address, this directly connects you to the network it belongs to.

But yes, implementing this is definitely tricky :woman_shrugging: 

I think it requires a change on how we have the vuex modules working right now, on their architecture.

<img width="530px" src="https://user-images.githubusercontent.com/40721795/72680544-4b9b8480-3abb-11ea-93bc-aa4a16f3a01b.png">

Another thing I realized was if it makes sense to distinguish between addresses from `cosmos-hub-testnet` and `cosmos-hub-mainnet`. Here I think it would be cool to have like some kind of "Testnet" tag on the address UI.

I can add this now :wink: 

<!-- Briefly describe what you're adding or fixing with this PR -->

Thank you! 🚀

---

For contributor:

- [x] Added changes entries. Run `yarn changelog` for a guided process.
- [ ] Reviewed `Files changed` in the github PR explorer
- [ ] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI
