### PR TITLE
Upgrade capacitor-intercom module to v0.2.3

### DIFF
--- a/changes/mario_3440-upgrade-capacitor-intercom
+++ b/changes/mario_3440-upgrade-capacitor-intercom
@@ -1,0 +1,1 @@
+[Added] [#3440](https://github.com/cosmos/lunie/issues/3440) Upgrade capacitor-intercom module to v0.2.3  @mariopino

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "lunie",
-  "version": "1.0.156",
+  "version": "1.0.158",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -4869,9 +4869,9 @@
       "integrity": "sha512-/V0XetN7s1Mk3NO7x2wxPZYv0pLMQtGAhecuOuKR88beiYCUle1AbCcFZNLu+4NVzi9RVHS0rXtIgzPEaKidLw=="
     },
     "capacitor-intercom": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/capacitor-intercom/-/capacitor-intercom-0.2.2.tgz",
-      "integrity": "sha512-FY8NuXW5SbP9Hs/HVqoUaLgI1CqlJnEQPniv5SvNdos/W1zZIhU7yebjBdQdn5SuIobuaiWMddg9c/+UagaJKg==",
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/capacitor-intercom/-/capacitor-intercom-0.2.3.tgz",
+      "integrity": "sha512-1A1r8oIHBsJTcKnn6yZKKH1Zr58L3KznvZ6sps61XGqbidXcjCBuN7YNUxYLPVlv7FpghY2bMSBjCt0v51QGFg==",
       "requires": {
         "@capacitor/core": "^1.4.0"
       },

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "bech32": "^1.1.3",
     "bignumber.js": "^8.1.1",
     "camelcase": "^5.3.0",
-    "capacitor-intercom": "0.2.2",
+    "capacitor-intercom": "0.2.3",
     "core-js": "^2.6.5",
     "cosmos-apiV0": "npm:@lunie/cosmos-api@0.1.x",
     "cosmos-apiV2": "npm:@lunie/cosmos-api@0.2.x",


### PR DESCRIPTION
Closes #3440 

**Description:**

The author has upgraded the module to use the latest Android Intercom component.

That release fixes the display methods wasn't working due to the use of older Intercom versions.

Thank you! 🚀

---

For contributor:

- [ ] Added changes entries. Run `yarn changelog` for a guided process.
- [ ] Reviewed `Files changed` in the github PR explorer
- [ ] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI
