### PR TITLE
Ana/fix blocks section

### DIFF
--- a/changes/ana_fix-cannot-query-amount-in-transaction
+++ b/changes/ana_fix-cannot-query-amount-in-transaction
@@ -1,0 +1,1 @@
+[Fixed] [#3460](https://github.com/cosmos/lunie/pull/3460) Fix blocks query, delete amount field @Bitcoinera

--- a/src/components/network/PageBlock.vue
+++ b/src/components/network/PageBlock.vue
@@ -134,7 +134,6 @@ export default {
               }
               signature
               value
-              amount
             }
             proposer_address
           }


### PR DESCRIPTION
Closes #ISSUE

**Description:**

Sorry guys, I kind of messed up again :laughing: I deleted the amount field from transactions and did check that all transactions queries in the FE didn't have this field. But overlooked "blocks".

So now in production blocks are not working...

Simple fix though. After merging this we should release I think:

<img width="540px" src="https://user-images.githubusercontent.com/40721795/72966611-a7b61f80-3dbf-11ea-9403-6926e8923a40.png">


<!-- Briefly describe what you're adding or fixing with this PR -->

Thank you! 🚀

---

For contributor:

- [ ] Added changes entries. Run `yarn changelog` for a guided process.
- [ ] Reviewed `Files changed` in the github PR explorer
- [ ] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI
