### PR TITLE
[Simsala] automatic release created for v1.0.160

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,80 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 <!-- SIMSALA --> <!-- DON'T DELETE, used for automatic changelog updates -->
 
+## [1.0.160] - 2020-01-25
+
+### Added
+
+- [#3415](https://github.com/cosmos/lunie/issues/3415) added a parameter to persist API change @iambeone
+- [#3362](https://github.com/cosmos/lunie/pull/3362) Adds "Back to Validators" button in PageValidator @Bitcoinera
+- Show multiple wallet balances in UI @faboweb
+- [#3370](https://github.com/cosmos/lunie/pull/3370) Now it is possible to select different tokens to send in the SendModal for networks with multiple tokens @Bitcoinera
+- [#3365](https://github.com/cosmos/lunie/pull/3365) TmBalance now displays multiple tokens balances and has a currency selector to display total value in the selected fiat currency @Bitcoinera
+- Added EMoney account handling @faboweb
+- Allow address creation in all cosmos networks @faboweb
+- [#3392](https://github.com/cosmos/lunie/issues/3392) Use Ledger across networks @faboweb
+- Allow signing for Terra @faboweb
+- [#3364](https://github.com/cosmos/lunie/pull/3364) Track failing transactions clientside in Sentry @faboweb
+- Retry graphql fetches on failed attempts @faboweb
+- [#3375](https://github.com/cosmos/lunie/pull/3375) Allow user to show address on Ledger Nano @faboweb
+- [#3423](https://github.com/cosmos/lunie/issues/3423) Implement mobile Intercom using vuex store @mariopino
+- [#3425](https://github.com/cosmos/lunie/issues/3425) Refactor script to add Intercom API keys at the top-level capacitor config file. @mariopino
+- [#3440](https://github.com/cosmos/lunie/issues/3440) Upgrade capacitor-intercom module to v0.2.3  @mariopino
+- [#3450](https://github.com/cosmos/lunie/issues/3450) Update activity icons @mariopino
+
+### Changed
+
+- [#3415](https://github.com/cosmos/lunie/issues/3415) graphql url parameter changed to 'api' @iambeone
+- [#3398](https://github.com/cosmos/lunie/pull/3398) Replaces a phantom div in the "Back to Validators" button for padding, as it should have been from the beginning @Bitcoinera
+- [#3443](https://github.com/cosmos/lunie/pull/3443) Enables more networks in MessageConstructor and ledger.js @Bitcoinera
+- [#3438](https://github.com/cosmos/lunie/pull/3438) Now the session explore component filters for addresses belonging to the current network we are connected to  @Bitcoinera
+- [#3366](https://github.com/cosmos/lunie/pull/3366) Fix link in ActionModal for lunie browser extension  @Bitcoinera
+- [#3282](https://github.com/cosmos/lunie/issues/3282) Now the block links in the activity section are active or not depending on the feature_explorer feature flag of the network @Bitcoinera
+- [#3371](https://github.com/cosmos/lunie/pull/3371) Strengthen the validation for cosmos addresses signin @Bitcoinera
+- [#3349](https://github.com/cosmos/lunie/pull/3349) Now it is possible to also sign in with an Ethereum address @Bitcoinera
+- [#3349](https://github.com/cosmos/lunie/pull/3349) Now the Undelegations component filters for only pending undelegations @Bitcoinera
+- [#3454](https://github.com/cosmos/lunie/pull/3454) Deletes everything regarding the validator transactions message details @Bitcoinera
+- display ledger and extension instructions when these signing options are selected @jbibla
+
+### Fixed
+
+- [#3460](https://github.com/cosmos/lunie/pull/3460) Fix blocks query, delete amount field @Bitcoinera
+- [#3384](https://github.com/cosmos/lunie/pull/3384) Now fees in action modals for all enabled networks work. Micro denoms are properly set @Bitcoinera
+- [#3405](https://github.com/cosmos/lunie/issues/3405) Fixes sign out so the user is not signed back in upon refreshing the page @Bitcoinera
+- [#3306](https://github.com/cosmos/lunie/issues/3306) Fixes the waiting for extension button in the ActionModal. Now the captions don't overflow @Bitcoinera
+- [#3359](https://github.com/cosmos/lunie/pull/3359) Fixes address undefined for the "To address" in multisends @Bitcoinera
+- [#3390](https://github.com/cosmos/lunie/pull/3390) Fix ActionModal data being out of date if a live update of data happened @faboweb
+- Fix balances not in overview query anymore @faboweb
+- [#3364](https://github.com/cosmos/lunie/pull/3364) Improve handling of sequence querying in ActionModal @faboweb
+- Fixed denom not selected if only one balance @faboweb
+- [#3412](https://github.com/cosmos/lunie/issues/3412) Show transactions on EMoney and Terra @faboweb
+- Force index.html to not be cached @faboweb
+- Fix modals closing and reopening (issue with waiting for content to be loaded) @faboweb
+- [#3330](https://github.com/cosmos/lunie/issues/3330) send button is now disabled if extension is not installed @jbibla
+- there was a styling issue with the "show on ledger" button and it was being displayed for all signed in sessions, not just ledger sessions @jbibla
+- [#3096](https://github.com/cosmos/lunie/issues/3096) Fix redelegation to and from fields @mariopino
+- [#3280](https://github.com/cosmos/lunie/issues/3280) Replace toggles in all and active buttons in validators page. @mariopino
+- [#3326](https://github.com/cosmos/lunie/issues/3326) Enable Intercom in mobile apps @mariopino
+- [#3333](https://github.com/cosmos/lunie/issues/3333) Fix gas price input deselects itself after typing @mariopino
+- [#3339](https://github.com/cosmos/lunie/issues/3339) Fix session modal validation triggers on closing @mariopino
+- [#3376](https://github.com/cosmos/lunie/issues/3376) Round total rewards to 6 decimal places @mariopino
+
+### Security
+
+- Add X-Frame header @faboweb
+
+### Code Improvements
+
+- [#3402](https://github.com/cosmos/lunie/issues/3402) Get network information like address creation method and address prefixes from the API @faboweb
+
+### Repository
+
+- Add script to add intercom keys to capacitor @faboweb
+- [#3071](https://github.com/cosmos/lunie/issues/3071) Release on a new version from develop instead of merging master back to develop @faboweb
+- Cleaned packages @faboweb
+- Lint before push @faboweb
+- Set Lunie version for Sentry @faboweb
+
 ## [1.0.159] - 2020-01-18
 
 ### Added

--- a/changes/aleksei_graphql_parameter_change
+++ b/changes/aleksei_graphql_parameter_change
@@ -1,2 +1,0 @@
-[Changed] [#3415](https://github.com/cosmos/lunie/issues/3415) graphql url parameter changed to 'api' @iambeone
-[Added] [#3415](https://github.com/cosmos/lunie/issues/3415) added a parameter to persist API change @iambeone

--- a/changes/ana_add-go-back-to-validators-button
+++ b/changes/ana_add-go-back-to-validators-button
@@ -1,1 +1,0 @@
-[Added] [#3362](https://github.com/cosmos/lunie/pull/3362) Adds "Back to Validators" button in PageValidator @Bitcoinera

--- a/changes/ana_better-multiple-denoms-porfolio-version
+++ b/changes/ana_better-multiple-denoms-porfolio-version
@@ -1,1 +1,0 @@
-[Added] Show multiple wallet balances in UI @faboweb

--- a/changes/ana_destroy-phantom-back-to-validators-div
+++ b/changes/ana_destroy-phantom-back-to-validators-div
@@ -1,1 +1,0 @@
-[Changed] [#3398](https://github.com/cosmos/lunie/pull/3398) Replaces a phantom div in the "Back to Validators" button for padding, as it should have been from the beginning @Bitcoinera

--- a/changes/ana_emoney-sendmodal-multiple-denoms
+++ b/changes/ana_emoney-sendmodal-multiple-denoms
@@ -1,1 +1,0 @@
-[Added] [#3370](https://github.com/cosmos/lunie/pull/3370) Now it is possible to select different tokens to send in the SendModal for networks with multiple tokens @Bitcoinera

--- a/changes/ana_enable-other-networks-actions
+++ b/changes/ana_enable-other-networks-actions
@@ -1,1 +1,0 @@
-[Changed] [#3443](https://github.com/cosmos/lunie/pull/3443) Enables more networks in MessageConstructor and ledger.js @Bitcoinera

--- a/changes/ana_filter-login-addresses-per-network
+++ b/changes/ana_filter-login-addresses-per-network
@@ -1,1 +1,0 @@
-[Changed] [#3438](https://github.com/cosmos/lunie/pull/3438) Now the session explore component filters for addresses belonging to the current network we are connected to  @Bitcoinera

--- a/changes/ana_fix-cannot-query-amount-in-transaction
+++ b/changes/ana_fix-cannot-query-amount-in-transaction
@@ -1,1 +1,0 @@
-[Fixed] [#3460](https://github.com/cosmos/lunie/pull/3460) Fix blocks query, delete amount field @Bitcoinera

--- a/changes/ana_fix-fees-for-transactiondata
+++ b/changes/ana_fix-fees-for-transactiondata
@@ -1,1 +1,0 @@
-[Fixed] [#3384](https://github.com/cosmos/lunie/pull/3384) Now fees in action modals for all enabled networks work. Micro denoms are properly set @Bitcoinera

--- a/changes/ana_fix-lunie-browser-extension-link
+++ b/changes/ana_fix-lunie-browser-extension-link
@@ -1,1 +1,0 @@
-[Changed] [#3366](https://github.com/cosmos/lunie/pull/3366) Fix link in ActionModal for lunie browser extension  @Bitcoinera

--- a/changes/ana_fix-signout-fault
+++ b/changes/ana_fix-signout-fault
@@ -1,1 +1,0 @@
-[Fixed] [#3405](https://github.com/cosmos/lunie/issues/3405) Fixes sign out so the user is not signed back in upon refreshing the page @Bitcoinera

--- a/changes/ana_fix-waiting-for-extension-button
+++ b/changes/ana_fix-waiting-for-extension-button
@@ -1,1 +1,0 @@
-[Fixed] [#3306](https://github.com/cosmos/lunie/issues/3306) Fixes the waiting for extension button in the ActionModal. Now the captions don't overflow @Bitcoinera

--- a/changes/ana_handle-explorer-flag-for-blocks
+++ b/changes/ana_handle-explorer-flag-for-blocks
@@ -1,1 +1,0 @@
-[Changed] [#3282](https://github.com/cosmos/lunie/issues/3282) Now the block links in the activity section are active or not depending on the feature_explorer feature flag of the network @Bitcoinera

--- a/changes/ana_improve-cosmos-address-signin-validation
+++ b/changes/ana_improve-cosmos-address-signin-validation
@@ -1,1 +1,0 @@
-[Changed] [#3371](https://github.com/cosmos/lunie/pull/3371) Strengthen the validation for cosmos addresses signin @Bitcoinera

--- a/changes/ana_livepeer-explore-mode-fe
+++ b/changes/ana_livepeer-explore-mode-fe
@@ -1,2 +1,0 @@
-[Changed] [#3349](https://github.com/cosmos/lunie/pull/3349) Now it is possible to also sign in with an Ethereum address @Bitcoinera
-[Changed] [#3349](https://github.com/cosmos/lunie/pull/3349) Now the Undelegations component filters for only pending undelegations @Bitcoinera

--- a/changes/ana_multiple-denoms-in-porfolio
+++ b/changes/ana_multiple-denoms-in-porfolio
@@ -1,1 +1,0 @@
-[Added] [#3365](https://github.com/cosmos/lunie/pull/3365) TmBalance now displays multiple tokens balances and has a currency selector to display total value in the selected fiat currency @Bitcoinera

--- a/changes/ana_real-fix-multisend-address-undefined
+++ b/changes/ana_real-fix-multisend-address-undefined
@@ -1,1 +1,0 @@
-[Fixed] [#3359](https://github.com/cosmos/lunie/pull/3359) Fixes address undefined for the "To address" in multisends @Bitcoinera

--- a/changes/ana_remove-validators-tx-message-details
+++ b/changes/ana_remove-validators-tx-message-details
@@ -1,1 +1,0 @@
-[Changed] [#3454](https://github.com/cosmos/lunie/pull/3454) Deletes everything regarding the validator transactions message details @Bitcoinera

--- a/changes/fabo_add-emoney-account-creation
+++ b/changes/fabo_add-emoney-account-creation
@@ -1,1 +1,0 @@
-[Added] Added EMoney account handling @faboweb

--- a/changes/fabo_add-x-frame-header
+++ b/changes/fabo_add-x-frame-header
@@ -1,1 +1,0 @@
-[Security] Add X-Frame header @faboweb

--- a/changes/fabo_cross-account-signin
+++ b/changes/fabo_cross-account-signin
@@ -1,1 +1,0 @@
-[Added] Allow address creation in all cosmos networks @faboweb

--- a/changes/fabo_cross-network-ledger
+++ b/changes/fabo_cross-network-ledger
@@ -1,1 +1,0 @@
-[Added] [#3392](https://github.com/cosmos/lunie/issues/3392) Use Ledger across networks @faboweb

--- a/changes/fabo_cross-signing-2
+++ b/changes/fabo_cross-signing-2
@@ -1,1 +1,0 @@
-[Added] Allow signing for Terra @faboweb

--- a/changes/fabo_fetch-policy
+++ b/changes/fabo_fetch-policy
@@ -1,1 +1,0 @@
-[Fixed] [#3390](https://github.com/cosmos/lunie/pull/3390) Fix ActionModal data being out of date if a live update of data happened @faboweb

--- a/changes/fabo_fix-balance-issue
+++ b/changes/fabo_fix-balance-issue
@@ -1,1 +1,0 @@
-[Fixed] Fix balances not in overview query anymore @faboweb

--- a/changes/fabo_fix-sequence-issue
+++ b/changes/fabo_fix-sequence-issue
@@ -1,2 +1,0 @@
-[Fixed] [#3364](https://github.com/cosmos/lunie/pull/3364) Improve handling of sequence querying in ActionModal @faboweb
-[Added] [#3364](https://github.com/cosmos/lunie/pull/3364) Track failing transactions clientside in Sentry @faboweb

--- a/changes/fabo_fix-single-denom-send-modal
+++ b/changes/fabo_fix-single-denom-send-modal
@@ -1,1 +1,0 @@
-[Fixed] Fixed denom not selected if only one balance @faboweb

--- a/changes/fabo_fix-transactions-not-displaying-for-terra
+++ b/changes/fabo_fix-transactions-not-displaying-for-terra
@@ -1,1 +1,0 @@
-[Fixed] [#3412](https://github.com/cosmos/lunie/issues/3412) Show transactions on EMoney and Terra @faboweb

--- a/changes/fabo_force-refresh-on-index-htm
+++ b/changes/fabo_force-refresh-on-index-htm
@@ -1,1 +1,0 @@
-[Fixed] Force index.html to not be cached @faboweb

--- a/changes/fabo_get-network-info-from-api
+++ b/changes/fabo_get-network-info-from-api
@@ -1,1 +1,0 @@
-[Code Improvements] [#3402](https://github.com/cosmos/lunie/issues/3402) Get network information like address creation method and address prefixes from the API @faboweb

--- a/changes/fabo_improve-action-modal
+++ b/changes/fabo_improve-action-modal
@@ -1,1 +1,0 @@
-[Fixed] Fix modals closing and reopening (issue with waiting for content to be loaded) @faboweb

--- a/changes/fabo_intercom-key-script
+++ b/changes/fabo_intercom-key-script
@@ -1,1 +1,0 @@
-[Repository] Add script to add intercom keys to capacitor @faboweb

--- a/changes/fabo_publish-from-develop
+++ b/changes/fabo_publish-from-develop
@@ -1,1 +1,0 @@
-[Repository] [#3071](https://github.com/cosmos/lunie/issues/3071) Release on a new version from develop instead of merging master back to develop @faboweb

--- a/changes/fabo_remove-resolutions
+++ b/changes/fabo_remove-resolutions
@@ -1,2 +1,0 @@
-[Repository] Cleaned packages @faboweb
-[Repository] Lint before push @faboweb

--- a/changes/fabo_retry-on-failed-requests
+++ b/changes/fabo_retry-on-failed-requests
@@ -1,1 +1,0 @@
-[Added] Retry graphql fetches on failed attempts @faboweb

--- a/changes/fabo_set-version-for-sentry
+++ b/changes/fabo_set-version-for-sentry
@@ -1,1 +1,0 @@
-[Repository] Set Lunie version for Sentry @faboweb

--- a/changes/fabo_show-address-on-ledger
+++ b/changes/fabo_show-address-on-ledger
@@ -1,1 +1,0 @@
-[Added] [#3375](https://github.com/cosmos/lunie/pull/3375) Allow user to show address on Ledger Nano @faboweb

--- a/changes/jordan_3330-action-modal-flow
+++ b/changes/jordan_3330-action-modal-flow
@@ -1,2 +1,0 @@
-[Fixed] [#3330](https://github.com/cosmos/lunie/issues/3330) send button is now disabled if extension is not installed @jbibla
-[Changed] display ledger and extension instructions when these signing options are selected @jbibla

--- a/changes/jordan_show-on-ledger
+++ b/changes/jordan_show-on-ledger
@@ -1,1 +1,0 @@
-[Fixed] there was a styling issue with the "show on ledger" button and it was being displayed for all signed in sessions, not just ledger sessions @jbibla

--- a/changes/mario_3096-improve-redelegation
+++ b/changes/mario_3096-improve-redelegation
@@ -1,1 +1,0 @@
-[Fixed] [#3096](https://github.com/cosmos/lunie/issues/3096) Fix redelegation to and from fields @mariopino

--- a/changes/mario_3280-clicking-active-validators-select-both
+++ b/changes/mario_3280-clicking-active-validators-select-both
@@ -1,1 +1,0 @@
-[Fixed] [#3280](https://github.com/cosmos/lunie/issues/3280) Replace toggles in all and active buttons in validators page. @mariopino

--- a/changes/mario_3326-intercom-mobile-again
+++ b/changes/mario_3326-intercom-mobile-again
@@ -1,1 +1,0 @@
-[Fixed] [#3326](https://github.com/cosmos/lunie/issues/3326) Enable Intercom in mobile apps @mariopino

--- a/changes/mario_3333-gas-price-input-problems
+++ b/changes/mario_3333-gas-price-input-problems
@@ -1,1 +1,0 @@
-[Fixed] [#3333](https://github.com/cosmos/lunie/issues/3333) Fix gas price input deselects itself after typing @mariopino

--- a/changes/mario_3339-session-modal-validation-triggers-closing
+++ b/changes/mario_3339-session-modal-validation-triggers-closing
@@ -1,1 +1,0 @@
-[Fixed] [#3339](https://github.com/cosmos/lunie/issues/3339) Fix session modal validation triggers on closing @mariopino

--- a/changes/mario_3376-fix-rewards-decimals
+++ b/changes/mario_3376-fix-rewards-decimals
@@ -1,1 +1,0 @@
-[Fixed] [#3376](https://github.com/cosmos/lunie/issues/3376) Round total rewards to 6 decimal places @mariopino

--- a/changes/mario_3423-mobile-intercom-store
+++ b/changes/mario_3423-mobile-intercom-store
@@ -1,1 +1,0 @@
-[Added] [#3423](https://github.com/cosmos/lunie/issues/3423) Implement mobile Intercom using vuex store @mariopino

--- a/changes/mario_3425-refactor-intercom-keys-script
+++ b/changes/mario_3425-refactor-intercom-keys-script
@@ -1,1 +1,0 @@
-[Added] [#3425](https://github.com/cosmos/lunie/issues/3425) Refactor script to add Intercom API keys at the top-level capacitor config file. @mariopino

--- a/changes/mario_3440-upgrade-capacitor-intercom
+++ b/changes/mario_3440-upgrade-capacitor-intercom
@@ -1,1 +1,0 @@
-[Added] [#3440](https://github.com/cosmos/lunie/issues/3440) Upgrade capacitor-intercom module to v0.2.3  @mariopino

--- a/changes/mario_3450-update-tx-icons
+++ b/changes/mario_3450-update-tx-icons
@@ -1,1 +1,0 @@
-[Added] [#3450](https://github.com/cosmos/lunie/issues/3450) Update activity icons @mariopino

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lunie",
-  "version": "1.0.159",
+  "version": "1.0.160",
   "description": "Lunie is the staking and governance platform for proof-of-stake blockchains.",
   "author": "Lunie International Software Systems Inc. <hello@lunie.io>",
   "scripts": {
@@ -116,7 +116,7 @@
     "prettier": "^1.18.2",
     "sass": "^1.18.0",
     "sass-loader": "8.0.0",
-    "simsala": "0.0.18",
+    "simsala": "0.0.19",
     "stylelint": "12.0.1",
     "stylelint-config-standard": "19.0.0",
     "stylelint-webpack-plugin": "1.1.2",


### PR DESCRIPTION
Please manually test before merging this to master

### Added

- [#3415](https://github.com/cosmos/lunie/issues/3415) added a parameter to persist API change @iambeone
- [#3362](https://github.com/cosmos/lunie/pull/3362) Adds "Back to Validators" button in PageValidator @Bitcoinera
- Show multiple wallet balances in UI @faboweb
- [#3370](https://github.com/cosmos/lunie/pull/3370) Now it is possible to select different tokens to send in the SendModal for networks with multiple tokens @Bitcoinera
- [#3365](https://github.com/cosmos/lunie/pull/3365) TmBalance now displays multiple tokens balances and has a currency selector to display total value in the selected fiat currency @Bitcoinera
- Added EMoney account handling @faboweb
- Allow address creation in all cosmos networks @faboweb
- [#3392](https://github.com/cosmos/lunie/issues/3392) Use Ledger across networks @faboweb
- Allow signing for Terra @faboweb
- [#3364](https://github.com/cosmos/lunie/pull/3364) Track failing transactions clientside in Sentry @faboweb
- Retry graphql fetches on failed attempts @faboweb
- [#3375](https://github.com/cosmos/lunie/pull/3375) Allow user to show address on Ledger Nano @faboweb
- [#3423](https://github.com/cosmos/lunie/issues/3423) Implement mobile Intercom using vuex store @mariopino
- [#3425](https://github.com/cosmos/lunie/issues/3425) Refactor script to add Intercom API keys at the top-level capacitor config file. @mariopino
- [#3440](https://github.com/cosmos/lunie/issues/3440) Upgrade capacitor-intercom module to v0.2.3  @mariopino
- [#3450](https://github.com/cosmos/lunie/issues/3450) Update activity icons @mariopino

### Changed

- [#3415](https://github.com/cosmos/lunie/issues/3415) graphql url parameter changed to 'api' @iambeone
- [#3398](https://github.com/cosmos/lunie/pull/3398) Replaces a phantom div in the "Back to Validators" button for padding, as it should have been from the beginning @Bitcoinera
- [#3443](https://github.com/cosmos/lunie/pull/3443) Enables more networks in MessageConstructor and ledger.js @Bitcoinera
- [#3438](https://github.com/cosmos/lunie/pull/3438) Now the session explore component filters for addresses belonging to the current network we are connected to  @Bitcoinera
- [#3366](https://github.com/cosmos/lunie/pull/3366) Fix link in ActionModal for lunie browser extension  @Bitcoinera
- [#3282](https://github.com/cosmos/lunie/issues/3282) Now the block links in the activity section are active or not depending on the feature_explorer feature flag of the network @Bitcoinera
- [#3371](https://github.com/cosmos/lunie/pull/3371) Strengthen the validation for cosmos addresses signin @Bitcoinera
- [#3349](https://github.com/cosmos/lunie/pull/3349) Now it is possible to also sign in with an Ethereum address @Bitcoinera
- [#3349](https://github.com/cosmos/lunie/pull/3349) Now the Undelegations component filters for only pending undelegations @Bitcoinera
- [#3454](https://github.com/cosmos/lunie/pull/3454) Deletes everything regarding the validator transactions message details @Bitcoinera
- display ledger and extension instructions when these signing options are selected @jbibla

### Fixed

- [#3460](https://github.com/cosmos/lunie/pull/3460) Fix blocks query, delete amount field @Bitcoinera
- [#3384](https://github.com/cosmos/lunie/pull/3384) Now fees in action modals for all enabled networks work. Micro denoms are properly set @Bitcoinera
- [#3405](https://github.com/cosmos/lunie/issues/3405) Fixes sign out so the user is not signed back in upon refreshing the page @Bitcoinera
- [#3306](https://github.com/cosmos/lunie/issues/3306) Fixes the waiting for extension button in the ActionModal. Now the captions don't overflow @Bitcoinera
- [#3359](https://github.com/cosmos/lunie/pull/3359) Fixes address undefined for the "To address" in multisends @Bitcoinera
- [#3390](https://github.com/cosmos/lunie/pull/3390) Fix ActionModal data being out of date if a live update of data happened @faboweb
- Fix balances not in overview query anymore @faboweb
- [#3364](https://github.com/cosmos/lunie/pull/3364) Improve handling of sequence querying in ActionModal @faboweb
- Fixed denom not selected if only one balance @faboweb
- [#3412](https://github.com/cosmos/lunie/issues/3412) Show transactions on EMoney and Terra @faboweb
- Force index.html to not be cached @faboweb
- Fix modals closing and reopening (issue with waiting for content to be loaded) @faboweb
- [#3330](https://github.com/cosmos/lunie/issues/3330) send button is now disabled if extension is not installed @jbibla
- there was a styling issue with the "show on ledger" button and it was being displayed for all signed in sessions, not just ledger sessions @jbibla
- [#3096](https://github.com/cosmos/lunie/issues/3096) Fix redelegation to and from fields @mariopino
- [#3280](https://github.com/cosmos/lunie/issues/3280) Replace toggles in all and active buttons in validators page. @mariopino
- [#3326](https://github.com/cosmos/lunie/issues/3326) Enable Intercom in mobile apps @mariopino
- [#3333](https://github.com/cosmos/lunie/issues/3333) Fix gas price input deselects itself after typing @mariopino
- [#3339](https://github.com/cosmos/lunie/issues/3339) Fix session modal validation triggers on closing @mariopino
- [#3376](https://github.com/cosmos/lunie/issues/3376) Round total rewards to 6 decimal places @mariopino

### Security

- Add X-Frame header @faboweb

### Code Improvements

- [#3402](https://github.com/cosmos/lunie/issues/3402) Get network information like address creation method and address prefixes from the API @faboweb

### Repository

- Add script to add intercom keys to capacitor @faboweb
- [#3071](https://github.com/cosmos/lunie/issues/3071) Release on a new version from develop instead of merging master back to develop @faboweb
- Cleaned packages @faboweb
- Lint before push @faboweb
- Set Lunie version for Sentry @faboweb