### PR TITLE
Fabo/deploy previews in development mode

### DIFF
--- a/changes/develop
+++ b/changes/develop
@@ -1,0 +1,1 @@
+[Repository] [#3468](https://github.com/cosmos/lunie/issues/3468) Do not track issues in Sentry for deploy previews @faboweb

--- a/public/netlify.toml
+++ b/public/netlify.toml
@@ -1,2 +1,3 @@
 [context.deploy-preview]
     SENTRY_DSN = ""
+    command = "yarn build --mode development"

--- a/public/netlify.toml
+++ b/public/netlify.toml
@@ -1,0 +1,2 @@
+[context.deploy-preview]
+    SENTRY_DSN = ""


### PR DESCRIPTION
To make debugging of deployed previews easier, it would be nice to see the source code better.