### PR TITLE
Fabo/deploy development builds

### DIFF
--- a/changes/fabo_deploy-development-builds
+++ b/changes/fabo_deploy-development-builds
@@ -1,0 +1,1 @@
+[Repository] Deploy previews in development mode @faboweb

--- a/public/netlify.toml
+++ b/public/netlify.toml
@@ -1,2 +1,3 @@
 [context.deploy-preview]
     SENTRY_DSN = ""
+    command = "yarn build --mode development"


### PR DESCRIPTION
Deploy previews in development mode

Alternative: Fix sourcemaps being unavailble in previews