### PR TITLE
Fabo/also check pending on release-candidates

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -285,7 +285,6 @@ workflows:
                 - release
                 - master
                 - develop
-                - /release-candidate.*/
 
       - security:
           requires:

--- a/changes/fabo_also-check-pending-on-develop
+++ b/changes/fabo_also-check-pending-on-develop
@@ -1,0 +1,1 @@
+[Repository] Check for changelog updates on release-candidates @faboweb


### PR DESCRIPTION
As seen here: https://github.com/luniehq/lunie/pull/3472 PRs to develop currently don't complete as the changelog check is not triggered. As a release or any hotfix always should have a changelog this PR enables the checks for release-candidates