### PR TITLE
Ana/fix missing denom when no balances

### DIFF
--- a/changes/ana_fix-send-modal-missing-denom
+++ b/changes/ana_fix-send-modal-missing-denom
@@ -1,0 +1,1 @@
+[Fixed] [#3484](https://github.com/cosmos/lunie/pull/3484) Fixes missing denom when there are no balances in SendModal @Bitcoinera

--- a/src/ActionModal/components/ModalWithdrawRewards.vue
+++ b/src/ActionModal/components/ModalWithdrawRewards.vue
@@ -125,8 +125,8 @@ export default {
         }
       },
       update(data) {
-        /* istanbul ignore next */
-        return data.network.stakingDenom
+        if (data.network) return data.network.stakingDenom
+        return ""
       }
     }
   }

--- a/src/ActionModal/components/SendModal.vue
+++ b/src/ActionModal/components/SendModal.vue
@@ -186,7 +186,8 @@ export default {
     editMemo: false,
     isFirstLoad: true,
     selectedToken: ``,
-    balances: []
+    balances: [],
+    denom: ``
   }),
   computed: {
     ...mapGetters([`network`]),
@@ -238,8 +239,12 @@ export default {
       }
     },
     balances: function(balances) {
-      if (balances.length === 0) return
-      this.selectedToken = balances[0].denom
+      // in case the account has no balances we will display the staking denom received from the denom query
+      if (balances.length === 0) {
+        this.selectedToken = this.denom
+      } else {
+        this.selectedToken = balances[0].denom
+      }
     }
   },
   mounted() {
@@ -338,6 +343,27 @@ export default {
           networkId: this.network,
           address: this.userAddress
         }
+      }
+    },
+    denom: {
+      query: gql`
+        query NetworksDelegationModal($networkId: String!) {
+          network(id: $networkId) {
+            id
+            stakingDenom
+          }
+        }
+      `,
+      fetchPolicy: "cache-first",
+      /* istanbul ignore next */
+      variables() {
+        return {
+          networkId: this.network
+        }
+      },
+      /* istanbul ignore next */
+      update(data) {
+        return data.network.stakingDenom
       }
     },
     $subscribe: {

--- a/src/ActionModal/components/SendModal.vue
+++ b/src/ActionModal/components/SendModal.vue
@@ -363,7 +363,8 @@ export default {
       },
       /* istanbul ignore next */
       update(data) {
-        return data.network.stakingDenom
+        if (data.network) return data.network.stakingDenom
+        return ""
       }
     },
     $subscribe: {

--- a/src/components/governance/PageProposal.vue
+++ b/src/components/governance/PageProposal.vue
@@ -381,8 +381,8 @@ export default {
         return !this.address || !this.found
       },
       update(data) {
-        /* istanbul ignore next */
-        return data.vote.option
+        if (data.vote) return data.vote.option
+        return undefined
       },
       result(data) {
         /* istanbul ignore next */

--- a/src/components/staking/PageValidator.vue
+++ b/src/components/staking/PageValidator.vue
@@ -284,6 +284,11 @@ export default {
         }
       },
       update(result) {
+        if (!result.delegation) {
+          return {
+            amount: 0
+          }
+        }
         /* istanbul ignore next */
         return {
           ...result.delegation,
@@ -336,6 +341,8 @@ export default {
         }
       },
       update(result) {
+        if (!result.validator) return {}
+
         /* istanbul ignore next */
         this.loaded = true
         /* istanbul ignore next */


### PR DESCRIPTION
Closes #ISSUE

**Description:**

@iambeone just discovered this bug happening throughout all our platforms. When an account has no balances, the denom in the SendModal is missing.

<img width="340px" height="460px" src="https://user-images.githubusercontent.com/40721795/73204740-c873d180-413f-11ea-8235-432d6004f996.png">

This PR fixing it by querying "network" from apollo to get its `stakingDenom`.

When there are no balances, it will default to the stakingDenom as `selectedToken`. 


<!-- Briefly describe what you're adding or fixing with this PR -->

Thank you! 🚀

---

For contributor:

- [x] Added changes entries. Run `yarn changelog` for a guided process.
- [ ] Reviewed `Files changed` in the github PR explorer
- [ ] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI
