### PR TITLE
Dont register Intercom user at init in mobile apps

### DIFF
--- a/changes/mario_3483-mobile-intercom-userid
+++ b/changes/mario_3483-mobile-intercom-userid
@@ -1,0 +1,1 @@
+[Added] [#3483](https://github.com/cosmos/lunie/issues/3483) Dont register Intercom user at init in mobile apps  @mariopino

--- a/src/vuex/modules/intercom.js
+++ b/src/vuex/modules/intercom.js
@@ -5,9 +5,6 @@ let intercom = null
 /* istanbul ignore next */
 if (config.mobileApp) {
   intercom = new Intercom()
-  intercom.registerIdentifiedUser({
-    userId: `lunie-app-${Math.floor(Math.random() * 10000 + 1).toString()}`
-  })
 }
 
 export default () => {


### PR DESCRIPTION
Closes #3483 

**Description:**

Don't register Intercom userId at init in mobile apps. The autogenerated userId is not very useful (app users are already tagged in support channel) and that way we don't flood the support channel.

Thank you! 🚀

---

For contributor:

- [ ] Added changes entries. Run `yarn changelog` for a guided process.
- [ ] Reviewed `Files changed` in the github PR explorer
- [ ] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI
