### PR TITLE
[Simsala] automatic release created for v1.0.161

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,33 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 <!-- SIMSALA --> <!-- DON'T DELETE, used for automatic changelog updates -->
 
+## [1.0.161] - 2020-01-28
+
+### Added
+
+- add terra network to tests @iambeone
+- [#3439](https://github.com/cosmos/lunie/pull/3439) Allow for network selection on account creation and import @bitcoinera
+- [#3432](https://github.com/cosmos/lunie/issues/3432) Finish tutorials @mariopino
+- [#3483](https://github.com/cosmos/lunie/issues/3483) Dont register Intercom user at init in mobile apps  @mariopino
+
+### Fixed
+
+- bugfix on creating and restoring account in different networks @iambeone
+- Bugs around networks sign-in in extension @iambeone
+- bugfix in tests @iambeone
+- [#3484](https://github.com/cosmos/lunie/pull/3484) Fixes missing denom when there are no balances in SendModal @Bitcoinera
+- Fix restaking using wrong subtotal for calculations @faboweb
+- [#3447](https://github.com/cosmos/lunie/issues/3447) Handle some failing GraphQL queries @faboweb
+- Handle network not being set in network selector (like in the extension) @faboweb
+
+### Repository
+
+- [#3468](https://github.com/cosmos/lunie/issues/3468) Do not track issues in Sentry for deploy previews @faboweb
+- Check for changelog updates on release-candidates @faboweb
+- Added script to add version to build files @faboweb
+- Deploy previews in development mode @faboweb
+- Fix publish was always triggered on develop @faboweb
+
 ## [1.0.160] - 2020-01-25
 
 ### Added

--- a/changes/aleksei_multinetwork_signin
+++ b/changes/aleksei_multinetwork_signin
@@ -1,2 +1,0 @@
-[Fixed] bugfix on creating and restoring account in different networks @iambeone
-[Fixed] Bugs around networks sign-in in extension @iambeone

--- a/changes/aleksei_testing
+++ b/changes/aleksei_testing
@@ -1,2 +1,0 @@
-[Fixed] bugfix in tests @iambeone
-[Added] add terra network to tests @iambeone

--- a/changes/ana_add-select-network-in-signup-flow
+++ b/changes/ana_add-select-network-in-signup-flow
@@ -1,1 +1,0 @@
-[Added] [#3439](https://github.com/cosmos/lunie/pull/3439) Allow for network selection on account creation and import @bitcoinera

--- a/changes/ana_fix-send-modal-missing-denom
+++ b/changes/ana_fix-send-modal-missing-denom
@@ -1,1 +1,0 @@
-[Fixed] [#3484](https://github.com/cosmos/lunie/pull/3484) Fixes missing denom when there are no balances in SendModal @Bitcoinera

--- a/changes/develop
+++ b/changes/develop
@@ -1,1 +1,0 @@
-[Repository] [#3468](https://github.com/cosmos/lunie/issues/3468) Do not track issues in Sentry for deploy previews @faboweb

--- a/changes/fabo_also-check-pending-on-develop
+++ b/changes/fabo_also-check-pending-on-develop
@@ -1,1 +1,0 @@
-[Repository] Check for changelog updates on release-candidates @faboweb

--- a/changes/fabo_create-version-josn
+++ b/changes/fabo_create-version-josn
@@ -1,1 +1,0 @@
-[Repository] Added script to add version to build files @faboweb

--- a/changes/fabo_deploy-development-builds
+++ b/changes/fabo_deploy-development-builds
@@ -1,1 +1,0 @@
-[Repository] Deploy previews in development mode @faboweb

--- a/changes/fabo_fix-publish-always-running
+++ b/changes/fabo_fix-publish-always-running
@@ -1,1 +1,0 @@
-[Repository] Fix publish was always triggered on develop @faboweb

--- a/changes/fabo_fix-restake-not-working
+++ b/changes/fabo_fix-restake-not-working
@@ -1,1 +1,0 @@
-[Fixed] Fix restaking using wrong subtotal for calculations @faboweb

--- a/changes/fabo_handle-some-failing-queries
+++ b/changes/fabo_handle-some-failing-queries
@@ -1,1 +1,0 @@
-[Fixed] [#3447](https://github.com/cosmos/lunie/issues/3447) Handle some failing GraphQL queries @faboweb

--- a/changes/fabo_select-network-in-extension
+++ b/changes/fabo_select-network-in-extension
@@ -1,1 +1,0 @@
-[Fixed] Handle network not being set in network selector (like in the extension) @faboweb

--- a/changes/mario_3432-finish-tutorials
+++ b/changes/mario_3432-finish-tutorials
@@ -1,1 +1,0 @@
-[Added] [#3432](https://github.com/cosmos/lunie/issues/3432) Finish tutorials @mariopino

--- a/changes/mario_3483-mobile-intercom-userid
+++ b/changes/mario_3483-mobile-intercom-userid
@@ -1,1 +1,0 @@
-[Added] [#3483](https://github.com/cosmos/lunie/issues/3483) Dont register Intercom user at init in mobile apps  @mariopino

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lunie",
-  "version": "1.0.160",
+  "version": "1.0.161",
   "description": "Lunie is the staking and governance platform for proof-of-stake blockchains.",
   "author": "Lunie International Software Systems Inc. <hello@lunie.io>",
   "scripts": {


### PR DESCRIPTION
Please manually test before merging this to master

### Added

- add terra network to tests @iambeone
- [#3439](https://github.com/cosmos/lunie/pull/3439) Allow for network selection on account creation and import @bitcoinera
- [#3432](https://github.com/cosmos/lunie/issues/3432) Finish tutorials @mariopino
- [#3483](https://github.com/cosmos/lunie/issues/3483) Dont register Intercom user at init in mobile apps  @mariopino

### Fixed

- bugfix on creating and restoring account in different networks @iambeone
- Bugs around networks sign-in in extension @iambeone
- bugfix in tests @iambeone
- [#3484](https://github.com/cosmos/lunie/pull/3484) Fixes missing denom when there are no balances in SendModal @Bitcoinera
- Fix restaking using wrong subtotal for calculations @faboweb
- [#3447](https://github.com/cosmos/lunie/issues/3447) Handle some failing GraphQL queries @faboweb
- Handle network not being set in network selector (like in the extension) @faboweb

### Repository

- [#3468](https://github.com/cosmos/lunie/issues/3468) Do not track issues in Sentry for deploy previews @faboweb
- Check for changelog updates on release-candidates @faboweb
- Added script to add version to build files @faboweb
- Deploy previews in development mode @faboweb
- Fix publish was always triggered on develop @faboweb