### PR TITLE
Fabo/fix ledger bug

### DIFF
--- a/changes/fabo_fix-ledger-bug
+++ b/changes/fabo_fix-ledger-bug
@@ -1,0 +1,1 @@
+[Fixed] Handle ledger app not being defined @faboweb

--- a/src/scripts/ledger.js
+++ b/src/scripts/ledger.js
@@ -24,7 +24,9 @@ export const getAddressFromLedger = async (networkId, apollo) => {
   } finally {
     // cleanup. if we leave this open, the next connection will brake for HID
     // TODO move this into the leder lib
-    ledger.cosmosApp.transport.close()
+    if (ledger && ledger.cosmosApp) {
+      ledger.cosmosApp.transport.close()
+    }
   }
 }
 
@@ -38,7 +40,9 @@ export async function showAddressOnLedger(networkId, apollo) {
   } finally {
     // cleanup. if we leave this open, the next connection will brake for HID
     // TODO move this into the leder lib
-    ledger.cosmosApp.transport.close()
+    if (ledger && ledger.cosmosApp) {
+      ledger.cosmosApp.transport.close()
+    }
   }
 }
 


### PR DESCRIPTION
the transport close was called on an empty object. I don't know yet why there wasn't an object.

see debugging here: https://monitoring.lunie.io:9000/lunie/frontend/issues/299/?query=is%3Aunresolved