### PR TITLE
RTM: Prevent bad amounts to be send

### DIFF
--- a/changes/mario_3476-prevent-bad-amounts-to-be-send
+++ b/changes/mario_3476-prevent-bad-amounts-to-be-send
@@ -1,0 +1,1 @@
+[Fixed] [#3476](https://github.com/cosmos/lunie/issues/3476) Prevent bad amounts to be send to backend @mariopino

--- a/src/ActionModal/components/ActionModal.vue
+++ b/src/ActionModal/components/ActionModal.vue
@@ -653,8 +653,7 @@ export default {
       this.submissionError = null
 
       if (this.transactionData === {}) {
-        const error = new Error(`Error in transaction data`)
-        this.onSendingFailed(error)
+        this.onSendingFailed(new Error(`Error in transaction data`))
         return
       }
 

--- a/src/ActionModal/components/ActionModal.vue
+++ b/src/ActionModal/components/ActionModal.vue
@@ -708,6 +708,7 @@ export default {
       this.$apollo.queries.overview.refetch()
     },
     onSendingFailed(error) {
+      /* istanbul ignore next */
       Sentry.withScope(scope => {
         scope.setExtra("signMethod", this.selectedSignMethod)
         scope.setExtra("transactionData", this.transactionData)
@@ -766,13 +767,11 @@ export default {
       },
       /* istanbul ignore next */
       update(data) {
-        /* istanbul ignore next */
         if (!data.overview) {
           return {
             totalRewards: 0
           }
         }
-        /* istanbul ignore next */
         return {
           ...data.overview,
           totalRewards: Number(data.overview.totalRewards)
@@ -801,44 +800,39 @@ export default {
           }
         }
       `,
+      /* istanbul ignore next */
       variables() {
-        /* istanbul ignore next */
         return {
           networkId: this.networkId
         }
       },
+      /* istanbul ignore next */
       update(data) {
-        /* istanbul ignore next */
         return data.network
       }
     },
     $subscribe: {
       userTransactionAdded: {
+        /* istanbul ignore next */
         variables() {
-          /* istanbul ignore next */
           return {
             networkId: this.networkId,
             address: this.session.address
           }
         },
+        /* istanbul ignore next */
         skip() {
-          /* istanbul ignore next */
           return !this.txHash
         },
         query: UserTransactionAdded,
+        /* istanbul ignore next */
         result({ data }) {
-          /* istanbul ignore next */
           const { hash, height, success, log } = data.userTransactionAdded
-          /* istanbul ignore next */
           if (hash === this.txHash) {
-            /* istanbul ignore next */
             this.includedHeight = height
-            /* istanbul ignore next */
             if (success) {
-              /* istanbul ignore next */
               this.onTxIncluded()
             } else {
-              /* istanbul ignore next */
               this.onSendingFailed(new Error(log))
             }
           }

--- a/src/ActionModal/components/ActionModal.vue
+++ b/src/ActionModal/components/ActionModal.vue
@@ -762,6 +762,7 @@ export default {
         }
       },
       update(data) {
+        /* istanbul ignore next */
         if (!data.overview) {
           return {
             totalRewards: 0

--- a/src/ActionModal/components/ActionModal.vue
+++ b/src/ActionModal/components/ActionModal.vue
@@ -653,7 +653,8 @@ export default {
       this.submissionError = null
 
       if (this.transactionData === {}) {
-        this.onSendingFailed(`Error in transaction data`)
+        const error = new Error(`Error in transaction data`)
+        this.onSendingFailed(error)
         return
       }
 

--- a/src/ActionModal/components/ActionModal.vue
+++ b/src/ActionModal/components/ActionModal.vue
@@ -652,7 +652,10 @@ export default {
     async submit() {
       this.submissionError = null
 
-      if (this.transactionData === {}) {
+      if (
+        Object.entries(this.transactionData).length === 0 &&
+        this.transactionData.constructor === Object
+      ) {
         this.onSendingFailed(new Error(`Error in transaction data`))
         return
       }
@@ -754,13 +757,14 @@ export default {
           }
         }
       `,
+      /* istanbul ignore next */
       variables() {
-        /* istanbul ignore next */
         return {
           networkId: this.networkId,
           address: this.session.address
         }
       },
+      /* istanbul ignore next */
       update(data) {
         /* istanbul ignore next */
         if (!data.overview) {
@@ -774,8 +778,8 @@ export default {
           totalRewards: Number(data.overview.totalRewards)
         }
       },
+      /* istanbul ignore next */
       skip() {
-        /* istanbul ignore next */
         return !this.session.address
       }
     },
@@ -805,7 +809,6 @@ export default {
       },
       update(data) {
         /* istanbul ignore next */
-
         return data.network
       }
     },

--- a/src/ActionModal/components/ActionModal.vue
+++ b/src/ActionModal/components/ActionModal.vue
@@ -651,6 +651,12 @@ export default {
     },
     async submit() {
       this.submissionError = null
+
+      if (this.transactionData === {}) {
+        this.onSendingFailed(`Error in transaction data`)
+        return
+      }
+
       this.trackEvent(`event`, `submit`, this.title, this.selectedSignMethod)
 
       const { type, memo, ...properties } = this.transactionData

--- a/src/ActionModal/components/DelegationModal.vue
+++ b/src/ActionModal/components/DelegationModal.vue
@@ -230,7 +230,7 @@ export default {
       return this.fromOptions[this.fromSelectedIndex].address
     },
     transactionData() {
-      if (!this.targetValidator.operatorAddress || Number.isNaN(this.amount))
+      if (!this.targetValidator.operatorAddress || isNaN(this.amount))
         return {}
 
       if (this.isRedelegation) {

--- a/src/ActionModal/components/DelegationModal.vue
+++ b/src/ActionModal/components/DelegationModal.vue
@@ -230,7 +230,8 @@ export default {
       return this.fromOptions[this.fromSelectedIndex].address
     },
     transactionData() {
-      if (!this.targetValidator.operatorAddress) return {}
+      if (!this.targetValidator.operatorAddress || Number.isNaN(this.amount))
+        return {}
 
       if (this.isRedelegation) {
         return {

--- a/src/ActionModal/components/ModalDeposit.vue
+++ b/src/ActionModal/components/ModalDeposit.vue
@@ -102,6 +102,7 @@ export default {
     ...mapGetters([`network`]),
     ...mapGetters({ userAddress: `address` }),
     transactionData() {
+      if (Number.isNaN(this.amount)) return {}
       return {
         type: transaction.DEPOSIT,
         proposalId: this.proposalId,

--- a/src/ActionModal/components/ModalDeposit.vue
+++ b/src/ActionModal/components/ModalDeposit.vue
@@ -102,7 +102,7 @@ export default {
     ...mapGetters([`network`]),
     ...mapGetters({ userAddress: `address` }),
     transactionData() {
-      if (Number.isNaN(this.amount) || !this.proposalId || !this.denom) {
+      if (isNaN(this.amount) || !this.proposalId || !this.denom) {
         return {}
       }
       return {
@@ -168,9 +168,11 @@ export default {
         }
       `,
       skip() {
+        /* istanbul ignore next */
         return !this.userAddress
       },
       variables() {
+        /* istanbul ignore next */
         return {
           networkId: this.network,
           address: this.userAddress,
@@ -178,6 +180,7 @@ export default {
         }
       },
       update(data) {
+        /* istanbul ignore next */
         return data.balance || { amount: 0 }
       }
     }

--- a/src/ActionModal/components/ModalDeposit.vue
+++ b/src/ActionModal/components/ModalDeposit.vue
@@ -102,7 +102,9 @@ export default {
     ...mapGetters([`network`]),
     ...mapGetters({ userAddress: `address` }),
     transactionData() {
-      if (Number.isNaN(this.amount)) return {}
+      if (Number.isNaN(this.amount) || !this.proposalId || !this.denom) {
+        return {}
+      }
       return {
         type: transaction.DEPOSIT,
         proposalId: this.proposalId,

--- a/src/ActionModal/components/ModalDeposit.vue
+++ b/src/ActionModal/components/ModalDeposit.vue
@@ -167,20 +167,20 @@ export default {
           }
         }
       `,
+      /* istanbul ignore next */
       skip() {
-        /* istanbul ignore next */
         return !this.userAddress
       },
+      /* istanbul ignore next */
       variables() {
-        /* istanbul ignore next */
         return {
           networkId: this.network,
           address: this.userAddress,
           denom: this.denom
         }
       },
+      /* istanbul ignore next */
       update(data) {
-        /* istanbul ignore next */
         return data.balance || { amount: 0 }
       }
     }

--- a/src/ActionModal/components/ModalPropose.vue
+++ b/src/ActionModal/components/ModalPropose.vue
@@ -160,6 +160,7 @@ export default {
     ...mapGetters([`network`]),
     ...mapGetters({ userAddress: `address` }),
     transactionData() {
+      if (Number.isNaN(this.amount)) return {}
       return {
         type: transaction.SUBMIT_PROPOSAL,
         proposalType: this.type,

--- a/src/ActionModal/components/ModalPropose.vue
+++ b/src/ActionModal/components/ModalPropose.vue
@@ -160,7 +160,15 @@ export default {
     ...mapGetters([`network`]),
     ...mapGetters({ userAddress: `address` }),
     transactionData() {
-      if (Number.isNaN(this.amount)) return {}
+      if (
+        Number.isNaN(this.amount) ||
+        !this.type ||
+        !this.title ||
+        !this.description ||
+        !this.denom
+      ) {
+        return {}
+      }
       return {
         type: transaction.SUBMIT_PROPOSAL,
         proposalType: this.type,

--- a/src/ActionModal/components/ModalPropose.vue
+++ b/src/ActionModal/components/ModalPropose.vue
@@ -161,7 +161,7 @@ export default {
     ...mapGetters({ userAddress: `address` }),
     transactionData() {
       if (
-        Number.isNaN(this.amount) ||
+        isNaN(this.amount) ||
         !this.type ||
         !this.title ||
         !this.description ||

--- a/src/ActionModal/components/SendModal.vue
+++ b/src/ActionModal/components/SendModal.vue
@@ -202,7 +202,7 @@ export default {
       return { amount: 0 }
     },
     transactionData() {
-      if (Number.isNaN(this.amount) || !this.address || !this.selectedToken) {
+      if (isNaN(this.amount) || !this.address || !this.selectedToken) {
         return {}
       }
       return {

--- a/src/ActionModal/components/SendModal.vue
+++ b/src/ActionModal/components/SendModal.vue
@@ -202,7 +202,9 @@ export default {
       return { amount: 0 }
     },
     transactionData() {
-      if (Number.isNaN(this.amount)) return {}
+      if (Number.isNaN(this.amount) || !this.address || !this.selectedToken) {
+        return {}
+      }
       return {
         type: transaction.SEND,
         toAddress: this.address,

--- a/src/ActionModal/components/SendModal.vue
+++ b/src/ActionModal/components/SendModal.vue
@@ -338,9 +338,11 @@ export default {
           }
         }
       `,
+      /* istanbul ignore next */
       skip() {
         return !this.userAddress
       },
+      /* istanbul ignore next */
       variables() {
         return {
           networkId: this.network,
@@ -372,20 +374,20 @@ export default {
     },
     $subscribe: {
       userTransactionAdded: {
+        /* istanbul ignore next */
         variables() {
-          /* istanbul ignore next */
           return {
             networkId: this.network,
             address: this.userAddress
           }
         },
+        /* istanbul ignore next */
         skip() {
-          /* istanbul ignore next */
           return !this.userAddress
         },
         query: UserTransactionAdded,
+        /* istanbul ignore next */
         result() {
-          /* istanbul ignore next */
           this.$apollo.queries.balances.refetch()
         }
       }

--- a/src/ActionModal/components/SendModal.vue
+++ b/src/ActionModal/components/SendModal.vue
@@ -202,6 +202,7 @@ export default {
       return { amount: 0 }
     },
     transactionData() {
+      if (Number.isNaN(this.amount)) return {}
       return {
         type: transaction.SEND,
         toAddress: this.address,

--- a/src/ActionModal/components/UndelegationModal.vue
+++ b/src/ActionModal/components/UndelegationModal.vue
@@ -169,7 +169,7 @@ export default {
     transactionData() {
       if (this.isRedelegation) {
         if (
-          Number.isNaN(this.amount) ||
+          isNaN(this.amount) ||
           !this.sourceValidator.operatorAddress ||
           !this.toSelectedIndex ||
           !this.denom
@@ -185,7 +185,7 @@ export default {
         }
       } else {
         if (
-          Number.isNaN(this.amount) ||
+          isNaN(this.amount) ||
           !this.sourceValidator.operatorAddress ||
           !this.denom
         ) {

--- a/src/ActionModal/components/UndelegationModal.vue
+++ b/src/ActionModal/components/UndelegationModal.vue
@@ -167,10 +167,15 @@ export default {
       return delegation ? Number(delegation.amount) : 0
     },
     transactionData() {
-      if (!this.sourceValidator.operatorAddress || Number.isNaN(this.amount))
-        return {}
-
       if (this.isRedelegation) {
+        if (
+          Number.isNaN(this.amount) ||
+          !this.sourceValidator.operatorAddress ||
+          !this.toSelectedIndex ||
+          !this.denom
+        ) {
+          return {}
+        }
         return {
           type: transaction.REDELEGATE,
           validatorSourceAddress: this.sourceValidator.operatorAddress,
@@ -179,6 +184,13 @@ export default {
           denom: toMicroDenom(this.denom)
         }
       } else {
+        if (
+          Number.isNaN(this.amount) ||
+          !this.sourceValidator.operatorAddress ||
+          !this.denom
+        ) {
+          return {}
+        }
         return {
           type: transaction.UNDELEGATE,
           validatorAddress: this.sourceValidator.operatorAddress,

--- a/src/ActionModal/components/UndelegationModal.vue
+++ b/src/ActionModal/components/UndelegationModal.vue
@@ -167,7 +167,8 @@ export default {
       return delegation ? Number(delegation.amount) : 0
     },
     transactionData() {
-      if (!this.sourceValidator.operatorAddress) return {}
+      if (!this.sourceValidator.operatorAddress || Number.isNaN(this.amount))
+        return {}
 
       if (this.isRedelegation) {
         return {

--- a/src/ActionModal/components/UndelegationModal.vue
+++ b/src/ActionModal/components/UndelegationModal.vue
@@ -321,19 +321,19 @@ export default {
           }
         }
       `,
+      /* istanbul ignore next */
       skip() {
-        /* istanbul ignore next */
         return !this.address
       },
+      /* istanbul ignore next */
       variables() {
-        /* istanbul ignore next */
         return {
           networkId: this.network,
           delegatorAddress: this.address
         }
       },
+      /* istanbul ignore next */
       update(data) {
-        /* istanbul ignore next */
         return data.delegations
       }
     },
@@ -346,9 +346,11 @@ export default {
           }
         }
       `,
+      /* istanbul ignore next */
       skip() {
         return !this.userAddress
       },
+      /* istanbul ignore next */
       variables() {
         return {
           networkId: this.network,
@@ -356,6 +358,7 @@ export default {
           denom: this.denom
         }
       },
+      /* istanbul ignore next */
       update(data) {
         return data.balance || { amount: 0 }
       }
@@ -370,14 +373,14 @@ export default {
         }
       `,
       fetchPolicy: "cache-first",
+      /* istanbul ignore next */
       variables() {
-        /* istanbul ignore next */
         return {
           networkId: this.network
         }
       },
+      /* istanbul ignore next */
       update(data) {
-        /* istanbul ignore next */
         return data.network ? data.network.stakingDenom : ""
       }
     },
@@ -392,34 +395,34 @@ export default {
           }
         }
       `,
+      /* istanbul ignore next */
       variables() {
-        /* istanbul ignore next */
         return {
           networkId: this.network
         }
       },
+      /* istanbul ignore next */
       update(data) {
-        /* istanbul ignore next */
         return data.validators || []
       }
     },
 
     $subscribe: {
       userTransactionAdded: {
+        /* istanbul ignore next */
         variables() {
-          /* istanbul ignore next */
           return {
             networkId: this.network,
             address: this.userAddress
           }
         },
+        /* istanbul ignore next */
         skip() {
-          /* istanbul ignore next */
           return !this.userAddress
         },
         query: UserTransactionAdded,
+        /* istanbul ignore next */
         result() {
-          /* istanbul ignore next */
           this.$apollo.queries.delegations.refetch()
         }
       }

--- a/src/scripts/num.js
+++ b/src/scripts/num.js
@@ -89,6 +89,7 @@ export function atoms(number = 0) {
 export function uatoms(number = 0) {
   return BigNumber(number)
     .times(1e6)
+    .toFixed(0)
     .toString()
 }
 

--- a/tests/unit/specs/components/ActionModal/components/ActionModal.spec.js
+++ b/tests/unit/specs/components/ActionModal/components/ActionModal.spec.js
@@ -568,10 +568,10 @@ describe(`ActionModal`, () => {
       expect(wrapper.vm.txHash).toBe("HASH1234HASH")
     })
 
-    it(`should submit transaction using transactino api`, async () => {
+    it(`should submit transaction using transaction api`, async () => {
       const transactionProperties = {
         type: "MsgSend",
-        toAddress: "comsos12345",
+        toAddress: "cosmos12345",
         amounts: [
           {
             amount: "10",
@@ -629,6 +629,43 @@ describe(`ActionModal`, () => {
 
       expect(wrapper.html()).toContain("Transaction failed: invalid request.")
       expect(wrapper.vm.step).toBe("sign")
+    })
+
+    it(`Should call onSendingFailed if transaction data is empty`, async () => {
+      const ActionManagerSend = jest
+        .fn()
+        .mockRejectedValue(new Error(`Error in transaction data`))
+      const $store = { dispatch: jest.fn() }
+      const self = {
+        $store,
+        $apollo,
+        actionManager: {
+          setContext: () => {},
+          simulate: () => 12345,
+          send: ActionManagerSend,
+          simulateTxAPI: jest.fn(),
+          sendTxAPI: jest.fn().mockResolvedValue({ hash: 12345 })
+        },
+        transactionData: {},
+        network: {
+          stakingDenom: "ATOM"
+        },
+        submissionErrorPrefix: `PREFIX`,
+        trackEvent: jest.fn(),
+        connectLedger: () => {},
+        onSendingFailed: jest.fn(),
+        createContext: jest.fn()
+      }
+      await ActionModal.methods.submit.call(self)
+      expect(self.onSendingFailed).toHaveBeenCalledWith(
+        new Error(`Error in transaction data`)
+      )
+
+      ActionModal.methods.onSendingFailed.call(
+        self,
+        new Error(`Error in transaction data`)
+      )
+      expect(self.submissionError).toEqual(`PREFIX: Error in transaction data.`)
     })
   })
 

--- a/tests/unit/specs/components/ActionModal/components/ActionModal.spec.js
+++ b/tests/unit/specs/components/ActionModal/components/ActionModal.spec.js
@@ -192,6 +192,37 @@ describe(`ActionModal`, () => {
     expect(self.submissionError).toEqual(`PREFIX: some kind of error message.`)
   })
 
+  it(`should trigger onSendingFailed if transaction data is empty`, async () => {
+    const ActionManagerSend = jest
+      .fn()
+      .mockRejectedValue(new Error(`some kind of error message`))
+    const $store = { dispatch: jest.fn() }
+    const self = {
+      $store,
+      $apollo,
+      actionManager: {
+        setContext: () => {},
+        simulate: () => 12345,
+        send: ActionManagerSend,
+        simulateTxAPI: jest.fn(),
+        sendTxAPI: jest.fn().mockResolvedValue({ hash: 12345 })
+      },
+      transactionData: {},
+      network: {
+        stakingDenom: "ATOM"
+      },
+      submissionErrorPrefix: `PREFIX`,
+      trackEvent: jest.fn(),
+      connectLedger: () => {},
+      onSendingFailed: jest.fn(),
+      createContext: jest.fn()
+    }
+    await ActionModal.methods.submit.call(self)
+    expect(self.onSendingFailed).toHaveBeenCalledWith(
+      new Error(`Error in transaction data`)
+    )
+  })
+
   it(`should default to submissionError being null`, () => {
     expect(wrapper.vm.submissionError).toBe(null)
   })

--- a/tests/unit/specs/components/ActionModal/components/DelegationModal.spec.js
+++ b/tests/unit/specs/components/ActionModal/components/DelegationModal.spec.js
@@ -161,6 +161,13 @@ describe(`DelegationModal`, () => {
       })
     })
 
+    it("should return empty transaction data if amount is NaN", () => {
+      wrapper.setData({
+        amount: `NaN`
+      })
+      expect(wrapper.vm.transactionData).toEqual({})
+    })
+
     it("should return correct notification message for delegating", () => {
       expect(wrapper.vm.notifyMessage).toEqual({
         title: `Successfully staked!`,

--- a/tests/unit/specs/components/ActionModal/components/ModalDeposit.spec.js
+++ b/tests/unit/specs/components/ActionModal/components/ModalDeposit.spec.js
@@ -117,6 +117,13 @@ describe(`ModalDeposit`, () => {
     })
   })
 
+  it("should return empty transaction data if amount is NaN", () => {
+    wrapper.setData({
+      amount: `NaN`
+    })
+    expect(wrapper.vm.transactionData).toEqual({})
+  })
+
   it("should return notification message", () => {
     wrapper.setData({
       amount: 2

--- a/tests/unit/specs/components/ActionModal/components/ModalPropose.spec.js
+++ b/tests/unit/specs/components/ActionModal/components/ModalPropose.spec.js
@@ -176,6 +176,13 @@ describe(`ModalPropose`, () => {
       })
     })
 
+    it("should return empty transaction data if amount is NaN", () => {
+      wrapper.setData({
+        amount: `NaN`
+      })
+      expect(wrapper.vm.transactionData).toEqual({})
+    })
+
     it("should return correct notification message for delegating", () => {
       expect(wrapper.vm.notifyMessage).toEqual({
         title: `Successful proposal submission!`,

--- a/tests/unit/specs/components/ActionModal/components/SendModal.spec.js
+++ b/tests/unit/specs/components/ActionModal/components/SendModal.spec.js
@@ -185,6 +185,17 @@ describe(`SendModal`, () => {
     expect(wrapper.vm.transactionData).toEqual({})
   })
 
+  it(`sends an event on success`, () => {
+    const self = {
+      $emit: jest.fn()
+    }
+    SendModal.methods.onSuccess.call(self)
+    expect(self.$emit).toHaveBeenCalledWith(
+      "success",
+      expect.objectContaining({})
+    )
+  })
+
   it("should return notification message", () => {
     wrapper.setProps({
       denom: `STAKE`

--- a/tests/unit/specs/components/ActionModal/components/SendModal.spec.js
+++ b/tests/unit/specs/components/ActionModal/components/SendModal.spec.js
@@ -174,6 +174,17 @@ describe(`SendModal`, () => {
     })
   })
 
+  it("should return empty transaction data if amount is NaN", () => {
+    wrapper.setProps({
+      denom: `STAKE`
+    })
+    wrapper.setData({
+      address: `cosmos12345`,
+      amount: `NaN`
+    })
+    expect(wrapper.vm.transactionData).toEqual({})
+  })
+
   it("should return notification message", () => {
     wrapper.setProps({
       denom: `STAKE`

--- a/tests/unit/specs/components/ActionModal/components/UndelegationModal.spec.js
+++ b/tests/unit/specs/components/ActionModal/components/UndelegationModal.spec.js
@@ -164,6 +164,13 @@ describe(`UndelegationModal`, () => {
       })
     })
 
+    it("should return empty transaction data if amount is NaN", () => {
+      wrapper.setData({
+        amount: `NaN`
+      })
+      expect(wrapper.vm.transactionData).toEqual({})
+    })
+
     it("should return correct notification message", () => {
       expect(wrapper.vm.notifyMessage).toEqual({
         title: `Successfully restaked!`,

--- a/tests/unit/specs/components/ActionModal/components/UndelegationModal.spec.js
+++ b/tests/unit/specs/components/ActionModal/components/UndelegationModal.spec.js
@@ -130,6 +130,13 @@ describe(`UndelegationModal`, () => {
       })
     })
 
+    it("should return empty transaction data if amount is NaN", () => {
+      wrapper.setData({
+        amount: `NaN`
+      })
+      expect(wrapper.vm.transactionData).toEqual({})
+    })
+
     it("should return correct notification message", () => {
       expect(wrapper.vm.notifyMessage).toEqual({
         title: `Successfully unstaked!`,


### PR DESCRIPTION
Closes #3476 

**Description:**

* Prevent sending to the backend txs with NaN amount values.
* Modify `uatom()` function to return an integer value.

Should we implement checks for all parameters needed to build the transaction in all `transactionData()` computed fields?

I think it's a good idea to avoid pass to backend tx that will fail anyway. Maybe we can also send a sentry error if any of the tx params it's not correct, just to help us to figure out what's happening here.

Thank you! 🚀

---

For contributor:

- [ ] Added changes entries. Run `yarn changelog` for a guided process.
- [ ] Reviewed `Files changed` in the github PR explorer
- [ ] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI
