### PR TITLE
[Simsala] automatic release created for v1.0.162

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,43 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 <!-- SIMSALA --> <!-- DON'T DELETE, used for automatic changelog updates -->
 
+## [1.0.162] - 2020-02-03
+
+### Added
+
+- Network change on login with extension @iambeone
+- sign-in with the url parameters @iambeone
+
+### Changed
+
+- passing network id to extension in sign flow @iambeone
+- Change transactionGroup getting method @iambeone
+- Add no accounts alert on use extension step @iambeone
+- change create new account flow, remove select network step in default mode @iambeone
+- rewrite networkSort to fix network order change after selection @iambeone
+- [#3488](https://github.com/cosmos/lunie/pull/3488) Adds the isANetworkAddress validatin to the sign in with account @Bitcoinera
+- [#3488](https://github.com/cosmos/lunie/pull/3488) Adds the link to networks as part of the validation error message for isANetworkAddress @Bitcoinera
+- [#3505](https://github.com/cosmos/lunie/pull/3505) Logs Ledger connection errors to Sentry @Bitcoinera
+
+### Fixed
+
+- [#3488](https://github.com/cosmos/lunie/pull/3488) Fixes accounts not loading on refresh in TmSessionSignIn @Bitcoinera
+- Handle ledger app not being defined @faboweb
+- Fix tests not running @faboweb
+- Force refresh of the app if the local files are outdated @faboweb
+- Trying to fix transport undefined bug by updating ledger library @faboweb
+- correctly throw unknown ledger errors for webusb @faboweb
+
+### Code Improvements
+
+- [#3521](https://github.com/cosmos/lunie/pull/3521) Removes the hack used in NetworkItem to avoid displaying the loader in extension in SelectNetwork @Bitcoinera
+- [#3510](https://github.com/cosmos/lunie/pull/3510) Refactored NetworkItem to use network getter to be compatible with extension @bitcoinera
+- [#3526](https://github.com/cosmos/lunie/pull/3526) Updates the micro denom for e-Money to ungm @Bitcoinera
+
+### Repository
+
+- [#3517](https://github.com/cosmos/lunie/issues/3517) Wait for deploy preview to be available before starting e2e tests @faboweb
+
 ## [1.0.161] - 2020-01-28
 
 ### Added

--- a/changes/aleksei_extension_signin_fixes
+++ b/changes/aleksei_extension_signin_fixes
@@ -1,1 +1,0 @@
-[Changed] passing network id to extension in sign flow @iambeone

--- a/changes/aleksei_message_type_fix
+++ b/changes/aleksei_message_type_fix
@@ -1,1 +1,0 @@
-[Changed] Change transactionGroup getting method @iambeone

--- a/changes/aleksei_signin_fixes
+++ b/changes/aleksei_signin_fixes
@@ -1,5 +1,0 @@
-[Changed] Add no accounts alert on use extension step @iambeone
-[Changed] change create new account flow, remove select network step in default mode @iambeone
-[Added] Network change on login with extension @iambeone
-[Changed] rewrite networkSort to fix network order change after selection @iambeone
-[Added] sign-in with the url parameters @iambeone

--- a/changes/ana_delete-connection-hack-in-networkitem
+++ b/changes/ana_delete-connection-hack-in-networkitem
@@ -1,1 +1,0 @@
-[Code Improvements] [#3521](https://github.com/cosmos/lunie/pull/3521) Removes the hack used in NetworkItem to avoid displaying the loader in extension in SelectNetwork @Bitcoinera

--- a/changes/ana_improve-signin-validation-for-cross-network
+++ b/changes/ana_improve-signin-validation-for-cross-network
@@ -1,3 +1,0 @@
-[Changed] [#3488](https://github.com/cosmos/lunie/pull/3488) Adds the isANetworkAddress validatin to the sign in with account @Bitcoinera
-[Changed] [#3488](https://github.com/cosmos/lunie/pull/3488) Adds the link to networks as part of the validation error message for isANetworkAddress @Bitcoinera
-[Fixed] [#3488](https://github.com/cosmos/lunie/pull/3488) Fixes accounts not loading on refresh in TmSessionSignIn @Bitcoinera

--- a/changes/ana_log-ledger-error-in-sentry
+++ b/changes/ana_log-ledger-error-in-sentry
@@ -1,1 +1,0 @@
-[Changed] [#3505](https://github.com/cosmos/lunie/pull/3505) Logs Ledger connection errors to Sentry @Bitcoinera

--- a/changes/ana_replace-connection-module-for-extension
+++ b/changes/ana_replace-connection-module-for-extension
@@ -1,1 +1,0 @@
-[Code Improvements] [#3510](https://github.com/cosmos/lunie/pull/3510) Refactored NetworkItem to use network getter to be compatible with extension @bitcoinera

--- a/changes/ana_replace-x3ngm-for-ungm
+++ b/changes/ana_replace-x3ngm-for-ungm
@@ -1,1 +1,0 @@
-[Code Improvements] [#3526](https://github.com/cosmos/lunie/pull/3526) Updates the micro denom for e-Money to ungm @Bitcoinera

--- a/changes/fabo_fix-ledger-bug
+++ b/changes/fabo_fix-ledger-bug
@@ -1,1 +1,0 @@
-[Fixed] Handle ledger app not being defined @faboweb

--- a/changes/fabo_fix-tests-not-running
+++ b/changes/fabo_fix-tests-not-running
@@ -1,1 +1,0 @@
-[Fixed] Fix tests not running @faboweb

--- a/changes/fabo_force-reload
+++ b/changes/fabo_force-reload
@@ -1,1 +1,0 @@
-[Fixed] Force refresh of the app if the local files are outdated @faboweb

--- a/changes/fabo_ledger-update
+++ b/changes/fabo_ledger-update
@@ -1,1 +1,0 @@
-[Fixed] Trying to fix transport undefined bug by updating ledger library @faboweb

--- a/changes/fabo_throw-ledger-error
+++ b/changes/fabo_throw-ledger-error
@@ -1,1 +1,0 @@
-[Fixed] correctly throw unknown ledger errors for webusb @faboweb

--- a/changes/fabo_wait-for-preview
+++ b/changes/fabo_wait-for-preview
@@ -1,1 +1,0 @@
-[Repository] [#3517](https://github.com/cosmos/lunie/issues/3517) Wait for deploy preview to be available before starting e2e tests @faboweb

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lunie",
-  "version": "1.0.161",
+  "version": "1.0.162",
   "description": "Lunie is the staking and governance platform for proof-of-stake blockchains.",
   "author": "Lunie International Software Systems Inc. <hello@lunie.io>",
   "scripts": {

--- a/src/components/common/TmSessionExplore.vue
+++ b/src/components/common/TmSessionExplore.vue
@@ -217,9 +217,9 @@ export default {
       if (addressType === "extension") return `Lunie Browser Extension`
       if (addressType === "local") return `Mobile App`
     },
-    exploreWith(address) {
+    async exploreWith(address) {
       this.address = address
-      this.onSubmit()
+      await this.onSubmit()
     },
     isEthereumAddress(address) {
       return isEthereumAddress(address)


### PR DESCRIPTION
Please manually test before merging this to master

### Added

- Network change on login with extension @iambeone
- sign-in with the url parameters @iambeone

### Changed

- passing network id to extension in sign flow @iambeone
- Change transactionGroup getting method @iambeone
- Add no accounts alert on use extension step @iambeone
- change create new account flow, remove select network step in default mode @iambeone
- rewrite networkSort to fix network order change after selection @iambeone
- [#3488](https://github.com/cosmos/lunie/pull/3488) Adds the isANetworkAddress validatin to the sign in with account @Bitcoinera
- [#3488](https://github.com/cosmos/lunie/pull/3488) Adds the link to networks as part of the validation error message for isANetworkAddress @Bitcoinera
- [#3505](https://github.com/cosmos/lunie/pull/3505) Logs Ledger connection errors to Sentry @Bitcoinera

### Fixed

- [#3488](https://github.com/cosmos/lunie/pull/3488) Fixes accounts not loading on refresh in TmSessionSignIn @Bitcoinera
- Handle ledger app not being defined @faboweb
- Fix tests not running @faboweb
- Force refresh of the app if the local files are outdated @faboweb
- Trying to fix transport undefined bug by updating ledger library @faboweb
- correctly throw unknown ledger errors for webusb @faboweb

### Code Improvements

- [#3521](https://github.com/cosmos/lunie/pull/3521) Removes the hack used in NetworkItem to avoid displaying the loader in extension in SelectNetwork @Bitcoinera
- [#3510](https://github.com/cosmos/lunie/pull/3510) Refactored NetworkItem to use network getter to be compatible with extension @bitcoinera
- [#3526](https://github.com/cosmos/lunie/pull/3526) Updates the micro denom for e-Money to ungm @Bitcoinera

### Repository

- [#3517](https://github.com/cosmos/lunie/issues/3517) Wait for deploy preview to be available before starting e2e tests @faboweb