### PR TITLE
Ana/add create account in testnets

### DIFF
--- a/changes/ana_can-create-account-in-testnet
+++ b/changes/ana_can-create-account-in-testnet
@@ -1,0 +1,1 @@
+[Changed] [#3542](https://github.com/cosmos/lunie/pull/3542) Now it is possible to create an account in Lunie when connected to a testnet @Bitcoinera

--- a/src/components/common/TmSessionSignUp.vue
+++ b/src/components/common/TmSessionSignUp.vue
@@ -109,8 +109,10 @@ export default {
       }
     },
     isTestnet() {
-      // this.networks is undefined here O.o why??
-      return this.networks.filter(({ id }) => id === this.network)[0].testnet
+      const selectedNetwork = this.networks.find(
+        ({ id }) => id === this.network
+      )
+      return selectedNetwork ? selectedNetwork.testnet : false
     }
   },
   methods: {

--- a/src/components/common/TmSessionSignUp.vue
+++ b/src/components/common/TmSessionSignUp.vue
@@ -5,11 +5,7 @@
         Create a new address
       </h2>
       <div
-        v-if="
-          !session.insecureMode &&
-            !session.mobile &&
-            !(network.slice(-7) === `testnet`)
-        "
+        v-if="!session.insecureMode && !session.mobile && !isTestnet"
         class="session-main"
       >
         <InsecureModeWarning />
@@ -62,6 +58,7 @@
 </template>
 
 <script>
+import gql from "graphql-tag"
 import { mapState, mapGetters } from "vuex"
 import { required, minLength } from "vuelidate/lib/validators"
 import TmBtn from "common/TmBtn"
@@ -97,6 +94,9 @@ export default {
     InsecureModeWarning,
     Steps
   },
+  data: () => ({
+    networks: []
+  }),
   computed: {
     ...mapState([`session`, `signup`]),
     ...mapGetters([`network`]),
@@ -107,6 +107,10 @@ export default {
       set(value) {
         this.$store.commit(`updateField`, { field: `signUpName`, value })
       }
+    },
+    isTestnet() {
+      // this.networks is undefined here O.o why??
+      return this.networks.filter(({ id }) => id === this.network)[0].testnet
     }
   },
   methods: {
@@ -114,6 +118,22 @@ export default {
       this.$v.$touch()
       if (this.$v.$error) return
       this.$router.push(`/create/password`)
+    }
+  },
+  apollo: {
+    networks: {
+      query: gql`
+        query Networks {
+          networks {
+            id
+            testnet
+          }
+        }
+      `,
+      /* istanbul ignore next */
+      update(data) {
+        return data.networks || []
+      }
     }
   },
   validations: () => ({

--- a/src/components/common/TmSessionSignUp.vue
+++ b/src/components/common/TmSessionSignUp.vue
@@ -4,7 +4,14 @@
       <h2 class="session-title">
         Create a new address
       </h2>
-      <div v-if="!session.insecureMode && !session.mobile" class="session-main">
+      <div
+        v-if="
+          !session.insecureMode &&
+            !session.mobile &&
+            !(network.slice(-7) === `testnet`)
+        "
+        class="session-main"
+      >
         <InsecureModeWarning />
       </div>
       <div v-else>
@@ -55,7 +62,7 @@
 </template>
 
 <script>
-import { mapState } from "vuex"
+import { mapState, mapGetters } from "vuex"
 import { required, minLength } from "vuelidate/lib/validators"
 import TmBtn from "common/TmBtn"
 import TmFormGroup from "common/TmFormGroup"
@@ -92,6 +99,7 @@ export default {
   },
   computed: {
     ...mapState([`session`, `signup`]),
+    ...mapGetters([`network`]),
     fieldName: {
       get() {
         return this.$store.state.signup.signUpName

--- a/tests/unit/specs/components/common/TmSessionSignUp.spec.js
+++ b/tests/unit/specs/components/common/TmSessionSignUp.spec.js
@@ -87,3 +87,4 @@ describe(`TmSessionSignUp`, () => {
     expect(wrapper.vm.$router.push).toHaveBeenCalledWith(`/create/password`)
   })
 })
+

--- a/tests/unit/specs/components/common/TmSessionSignUp.spec.js
+++ b/tests/unit/specs/components/common/TmSessionSignUp.spec.js
@@ -25,6 +25,9 @@ describe(`TmSessionSignUp`, () => {
       dispatch: jest.fn(),
       mutations: {
         updateField: jest.fn()
+      },
+      getters: {
+        network: `cosmos-hub-mainnet`
       }
     }
 
@@ -86,5 +89,17 @@ describe(`TmSessionSignUp`, () => {
     await wrapper.vm.onSubmit()
     expect(wrapper.vm.$router.push).toHaveBeenCalledWith(`/create/password`)
   })
-})
 
+  it(`isTesnet should return false if current network is mainnet`, () => {
+    const self = {
+      networks: [
+        {
+          id: `cosmos-hub-mainnet`,
+          testnet: false
+        }
+      ]
+    }
+    const isTesnet = TmSessionSignUp.computed.isTestnet.call(self)
+    expect(isTesnet).toBe(false)
+  })
+})


### PR DESCRIPTION
Closes #ISSUE

**Description:**

All the intellectual property rights go to @jbibla 😜

OK, you probably want my solution here too much either because I used _that_ "funky" string destructuring to tell if a network is a testnet or not.

But I mean, to do this check in this component I would need to call Apollo and this is much cheaper computaniolly speaking...

Another option would be to pass this info (testnet or not) as a param through routing.

Do you have any other better solution?



<!-- Briefly describe what you're adding or fixing with this PR -->

Thank you! 🚀

---

For contributor:

- [ ] Added changes entries. Run `yarn changelog` for a guided process.
- [ ] Reviewed `Files changed` in the github PR explorer
- [ ] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI
