### PR TITLE
Aleksei/network selector style fix

### DIFF
--- a/changes/develop
+++ b/changes/develop
@@ -1,0 +1,1 @@
+[Changed] style fix for testnet selector @iambeone

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "lint": "vue-cli-service lint",
     "lint:style": "vue-cli-service lint:style",
     "release": "git fetch --all && git checkout origin/develop -B develop && git pull && git merge origin/master && git push -u origin develop && git push origin develop:release",
-    "serve": "vue-cli-service serve --port 9080",
+    "serve": "kill-port 9080 && vue-cli-service serve --port 9080",
     "serve:dist": "live-server --port=9080 --no-browser ./dist",
     "serve:mobile": "cross-env MOBILE_APP=true npm run serve",
     "serve:win": "vue-cli-service serve --port 9080",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "lint": "vue-cli-service lint",
     "lint:style": "vue-cli-service lint:style",
     "release": "git fetch --all && git checkout origin/develop -B develop && git pull && git merge origin/master && git push -u origin develop && git push origin develop:release",
-    "serve": "kill-port 9080 && vue-cli-service serve --port 9080",
+    "serve": "vue-cli-service serve --port 9080",
     "serve:dist": "live-server --port=9080 --no-browser ./dist",
     "serve:mobile": "cross-env MOBILE_APP=true npm run serve",
     "serve:win": "vue-cli-service serve --port 9080",

--- a/src/components/common/TmSessionExplore.vue
+++ b/src/components/common/TmSessionExplore.vue
@@ -67,18 +67,12 @@
         </TmFormGroup>
       </div>
       <div class="session-footer">
-        <TmFormGroup
-          class="field-checkbox"
-          field-id="sign-up-warning"
-          field-label
-        >
-          <div class="field-checkbox-input">
-            <label class="field-checkbox-label" for="select-testnet">
-              <input id="select-testnet" v-model="testnet" type="checkbox" />
-              Select testnet</label
-            >
-          </div>
-        </TmFormGroup>
+        <div class="field-checkbox-input">
+          <label class="field-checkbox-label" for="select-testnet">
+            <input id="select-testnet" v-model="testnet" type="checkbox" />
+            This is a testnet address</label
+          >
+        </div>
         <TmBtn value="Explore" />
       </div>
     </TmFormStruct>
@@ -313,11 +307,12 @@ export default {
 }
 
 .field-checkbox-label {
-  color: var(--link);
+  color: var(--txt);
+  line-height: 38px;
 }
 
 .field-checkbox-label:hover {
-  color: var(--link-hover);
+  color: var(--dim);
 }
 
 input[type="checkbox"] {

--- a/src/components/common/TmSessionSignIn.vue
+++ b/src/components/common/TmSessionSignIn.vue
@@ -43,20 +43,14 @@
           />
           <TmFormMsg v-if="error" type="custom" :msg="error" />
         </TmFormGroup>
-        <TmFormGroup
-          class="field-checkbox"
-          field-id="sign-up-warning"
-          field-label
-        >
-          <div class="field-checkbox-input">
-            <label class="field-checkbox-label" for="select-testnet">
-              <input id="select-testnet" v-model="testnet" type="checkbox" />
-              Select testnet</label
-            >
-          </div>
-        </TmFormGroup>
       </div>
       <div class="session-footer">
+        <div class="field-checkbox-input">
+          <label class="field-checkbox-label" for="select-testnet">
+            <input id="select-testnet" v-model="testnet" type="checkbox" />
+            This is a testnet address</label
+          >
+        </div>
         <TmBtn value="Sign In" />
       </div>
     </TmFormStruct>
@@ -192,10 +186,15 @@ export default {
 </script>
 <style scoped>
 .field-checkbox-label {
-  color: var(--link);
+  color: var(--txt);
+  line-height: 38px;
 }
+
 .field-checkbox-label:hover {
-  color: var(--link-hover);
+  color: var(--dim);
+}
+.session-footer {
+  justify-content: space-between;
 }
 input[type="checkbox"] {
   vertical-align: middle;

--- a/tests/unit/specs/components/common/__snapshots__/TmSessionExplore.spec.js.snap
+++ b/tests/unit/specs/components/common/__snapshots__/TmSessionExplore.spec.js.snap
@@ -186,27 +186,21 @@ exports[`TmSessionExplore shows a form to sign in with an address 1`] = `
     <div
       class="session-footer"
     >
-      <tmformgroup-stub
-        class="field-checkbox"
-        fieldid="sign-up-warning"
-        fieldlabel=""
+      <div
+        class="field-checkbox-input"
       >
-        <div
-          class="field-checkbox-input"
+        <label
+          class="field-checkbox-label"
+          for="select-testnet"
         >
-          <label
-            class="field-checkbox-label"
-            for="select-testnet"
-          >
-            <input
-              id="select-testnet"
-              type="checkbox"
-            />
-            
-            Select testnet
-          </label>
-        </div>
-      </tmformgroup-stub>
+          <input
+            id="select-testnet"
+            type="checkbox"
+          />
+          
+          This is a testnet address
+        </label>
+      </div>
        
       <tmbtn-stub
         value="Explore"

--- a/tests/unit/specs/components/common/__snapshots__/TmSessionSignIn.spec.js.snap
+++ b/tests/unit/specs/components/common/__snapshots__/TmSessionSignIn.spec.js.snap
@@ -50,33 +50,27 @@ exports[`TmSessionSignIn has the expected html structure 1`] = `
          
         <!---->
       </tmformgroup-stub>
-       
-      <tmformgroup-stub
-        class="field-checkbox"
-        fieldid="sign-up-warning"
-        fieldlabel=""
-      >
-        <div
-          class="field-checkbox-input"
-        >
-          <label
-            class="field-checkbox-label"
-            for="select-testnet"
-          >
-            <input
-              id="select-testnet"
-              type="checkbox"
-            />
-            
-            Select testnet
-          </label>
-        </div>
-      </tmformgroup-stub>
     </div>
      
     <div
       class="session-footer"
     >
+      <div
+        class="field-checkbox-input"
+      >
+        <label
+          class="field-checkbox-label"
+          for="select-testnet"
+        >
+          <input
+            id="select-testnet"
+            type="checkbox"
+          />
+          
+          This is a testnet address
+        </label>
+      </div>
+       
       <tmbtn-stub
         value="Sign In"
       />


### PR DESCRIPTION
Closes #ISSUE

**Description:**

Style fixes for `testnet address` checkbox in explore and sign-in steps
![image](https://user-images.githubusercontent.com/9531274/74079819-72b3f900-4a5e-11ea-90e3-533a051b76b7.png)
![image](https://user-images.githubusercontent.com/9531274/74079822-82cbd880-4a5e-11ea-9611-b35d62f29db4.png)
![image](https://user-images.githubusercontent.com/9531274/74079828-98d99900-4a5e-11ea-877a-90c0e8fcab4c.png)



Thank you! 🚀

---

For contributor:

- [ ] Added changes entries. Run `yarn changelog` for a guided process.
- [ ] Reviewed `Files changed` in the github PR explorer
- [ ] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI
