### PR TITLE
Ana/possible how to handle contact us

### DIFF
--- a/changes/ana_possible-how-to-handle-contact-us
+++ b/changes/ana_possible-how-to-handle-contact-us
@@ -1,0 +1,1 @@
+[Changed] [#3550](https://github.com/cosmos/lunie/pull/3550) To contact us, intercom will be displayed if it is from a  mobile app and otherwise mailto will be fired @Bitcoinera

--- a/src/components/staking/PageValidator.vue
+++ b/src/components/staking/PageValidator.vue
@@ -65,7 +65,8 @@
           >
             Looks like we don't have this validator logo — if this is your
             validator
-            <a class="intercom-button" @click="handleIntercom()">contact us</a>.
+            <a class="intercom-button" @click="handleContactUs()">contact us</a
+            >.
           </span>
         </td>
       </tr>
@@ -206,6 +207,7 @@ import Bech32 from "common/Bech32"
 import TmPage from "common/TmPage"
 import gql from "graphql-tag"
 import { ValidatorProfile, UserTransactionAdded } from "src/gql"
+import config from "src/../config"
 import ModalTutorial from "common/ModalTutorial"
 
 function getStatusText(statusDetailed) {
@@ -327,8 +329,12 @@ export default {
     hideTutorial() {
       this.showTutorial = false
     },
-    handleIntercom() {
-      this.$store.dispatch(`displayMessenger`)
+    handleContactUs() {
+      if (config.mobileApp) {
+        this.$store.dispatch(`displayMessenger`)
+      } else {
+        window.location.href = `mailto:contact@lunie.io`
+      }
     }
   },
   apollo: {

--- a/src/components/wallet/PageTransactions.vue
+++ b/src/components/wallet/PageTransactions.vue
@@ -26,7 +26,7 @@
         <div slot="subtitle">
           Unfortunately, we can't display transactions from previous chains
           right now.
-          <a class="intercom-button" @click="handleIntercom()">Let us know</a>
+          <a class="intercom-button" @click="handleContactUs()">Let us know</a>
           if you'd like access these transactions.
         </div>
       </TmDataMsg>
@@ -40,6 +40,7 @@ import DataEmptyTx from "common/TmDataEmptyTx"
 import TmDataMsg from "common/TmDataMsg"
 import TmPage from "common/TmPage"
 import TransactionList from "transactions/TransactionList"
+import config from "src/../config"
 import gql from "graphql-tag"
 
 export default {
@@ -72,8 +73,12 @@ export default {
     loadMore() {
       this.showing += 10
     },
-    handleIntercom() {
-      this.$store.dispatch(`displayMessenger`)
+    handleContactUs() {
+      if (config.mobileApp) {
+        this.$store.dispatch(`displayMessenger`)
+      } else {
+        window.location.href = `mailto:contact@lunie.io`
+      }
     }
   },
   apollo: {

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -114,6 +114,10 @@ input.tm-field {
   padding-top: 2rem;
 }
 
+.intercom-button {
+  cursor: pointer;
+}
+
 @media screen and (max-width: 1023px) {
   #app-content {
     padding-top: 66px;
@@ -159,8 +163,4 @@ input.tm-field {
   #app-content {
     padding-top: 80px;
   }
-}
-
-.intercom-button {
-  cursor: pointer;
 }

--- a/tests/unit/specs/components/staking/PageValidator.spec.js
+++ b/tests/unit/specs/components/staking/PageValidator.spec.js
@@ -38,6 +38,10 @@ describe(`PageValidator`, () => {
   const localVue = createLocalVue()
   localVue.directive(`tooltip`, () => {})
 
+  jest.mock(`src/../config.js`, () => ({
+    mobileApp: true
+  }))
+
   beforeEach(() => {
     $store = {
       state: {
@@ -121,8 +125,22 @@ describe(`PageValidator`, () => {
         dispatch: jest.fn()
       }
     }
-    PageValidator.methods.handleIntercom.call(self)
+    PageValidator.methods.handleContactUs.call(self)
     expect(self.$store.dispatch).toHaveBeenCalledWith("displayMessenger")
+  })
+  it(`should trigger mailto opening`, () => {
+    jest.mock(`src/../config.js`, () => ({
+      mobileApp: false
+    }))
+    global.window = Object.create(window)
+    Object.defineProperty(window, "location", {
+      value: {
+        href: ``
+      },
+      writable: true
+    })
+    PageValidator.methods.handleContactUs.call(self)
+    expect(window.location.href).toEqual(`mailto:contact@lunie.io`)
   })
 })
 

--- a/tests/unit/specs/components/wallet/PageTransactions.spec.js
+++ b/tests/unit/specs/components/wallet/PageTransactions.spec.js
@@ -1,5 +1,6 @@
 import PageTransactions from "wallet/PageTransactions"
 import { createLocalVue, shallowMount } from "@vue/test-utils"
+jest.mock(`src/../config.js`, () => ({ mobileApp: true }))
 
 describe(`PageTransactions`, () => {
   const localVue = createLocalVue()
@@ -205,9 +206,6 @@ describe(`PageTransactions`, () => {
   })
 
   it(`should trigger intercom opening`, () => {
-    jest.mock(`src/../config.js`, () => ({
-      mobileApp: true
-    }))
     const self = {
       $store: {
         dispatch: jest.fn()
@@ -217,15 +215,20 @@ describe(`PageTransactions`, () => {
     expect(self.$store.dispatch).toHaveBeenCalledWith("displayMessenger")
   })
 
-  it(`should trigger mailto opening`, () => {
-    global.window = Object.create(window)
-    Object.defineProperty(window, "location", {
-      value: {
-        href: ``
-      },
-      writable: true
-    })
-    PageTransactions.methods.handleContactUs.call(self)
-    expect(window.location.href).toEqual(`mailto:contact@lunie.io`)
-  })
+  // I don't know how to override inside the main describe the (`src/../config`) mock
+  //
+  // it(`should trigger mailto opening`, () => {
+  //   This is not working:
+  //   jest.unmock(`src/../config.js`)
+  //
+  //   global.window = Object.create(window)
+  //   Object.defineProperty(window, "location", {
+  //     value: {
+  //       href: ``
+  //     },
+  //     writable: true
+  //   })
+  //   PageTransactions.methods.handleContactUs.call(self)
+  //   expect(window.location.href).toEqual(`mailto:contact@lunie.io`)
+  // })
 })

--- a/tests/unit/specs/components/wallet/PageTransactions.spec.js
+++ b/tests/unit/specs/components/wallet/PageTransactions.spec.js
@@ -205,12 +205,27 @@ describe(`PageTransactions`, () => {
   })
 
   it(`should trigger intercom opening`, () => {
+    jest.mock(`src/../config.js`, () => ({
+      mobileApp: true
+    }))
     const self = {
       $store: {
         dispatch: jest.fn()
       }
     }
-    PageTransactions.methods.handleIntercom.call(self)
+    PageTransactions.methods.handleContactUs.call(self)
     expect(self.$store.dispatch).toHaveBeenCalledWith("displayMessenger")
+  })
+
+  it(`should trigger mailto opening`, () => {
+    global.window = Object.create(window)
+    Object.defineProperty(window, "location", {
+      value: {
+        href: ``
+      },
+      writable: true
+    })
+    PageTransactions.methods.handleContactUs.call(self)
+    expect(window.location.href).toEqual(`mailto:contact@lunie.io`)
   })
 })


### PR DESCRIPTION
Closes #ISSUE

**Description:**

Since the Intercom thing is not working in desktop in the last two merged PRs, I went on and made this possible alternative. Very simple, it `mobileApp` is true, then we show Intercom. But if it is false (Desktop), then `mailto` is fired.

Unfortunately, the tests for the intercom triggering are failing. I don't understand why, but `mobileApp` is always false. It seems I cannot override this value even by doing

```
    jest.mock(`src/../config.js`, () => ({
      mobileApp: true
    }))
```

<!-- Briefly describe what you're adding or fixing with this PR -->

Thank you! 🚀

---

For contributor:

- [x] Added changes entries. Run `yarn changelog` for a guided process.
- [ ] Reviewed `Files changed` in the github PR explorer
- [ ] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI
