### PR TITLE
Fabo/remove rpc url from gql

### DIFF
--- a/changes/fabo_remove-rpc-url-fromgql
+++ b/changes/fabo_remove-rpc-url-fromgql
@@ -1,0 +1,1 @@
+[Code Improvements] remove rpc url from gql @faboweb

--- a/src/gql/index.js
+++ b/src/gql/index.js
@@ -82,7 +82,6 @@ export const Networks = gql`
       chain_id
       testnet
       title
-      rpc_url
       icon
     }
   }

--- a/tests/unit/specs/components/ActionModal/components/ActionModal.spec.js
+++ b/tests/unit/specs/components/ActionModal/components/ActionModal.spec.js
@@ -51,7 +51,6 @@ describe(`ActionModal`, () => {
     id: "cosmos-hub-testnet",
     stakingDenom: "STAKE",
     chain_id: "gaia-13006",
-    rpc_url: "wss://gaia-13006.lunie.io:26657/websocket",
     api_url: "https://gaia-13006.lunie.io",
     action_send: true // to enable the feature send, needs to match the title of the ActionModal
   }

--- a/tests/unit/specs/store/connection.spec.js
+++ b/tests/unit/specs/store/connection.spec.js
@@ -89,8 +89,7 @@ describe(`Module: Connection`, () => {
     await actions.setNetwork(
       { commit, dispatch },
       {
-        id: "awesomenet",
-        rpc_url: "https://localhost:1337"
+        id: "awesomenet"
       }
     )
     expect(commit).toHaveBeenCalledWith("setNetworkId", "awesomenet")


### PR DESCRIPTION
This is anyway not used clientside