### PR TITLE
Prevent Google Translate to translate material icons

### DIFF
--- a/changes/mario_3563-google-dont-translate-material-icons
+++ b/changes/mario_3563-google-dont-translate-material-icons
@@ -1,0 +1,1 @@
+[Added] [#3563](https://github.com/cosmos/lunie/issues/3563) Prevent Google Translate to translate material icons @mariopino

--- a/package.json
+++ b/package.json
@@ -143,3 +143,4 @@
     "url": "git+https://github.com/luniehq/lunie.git"
   }
 }
+

--- a/src/ActionModal/components/ActionModal.vue
+++ b/src/ActionModal/components/ActionModal.vue
@@ -7,14 +7,14 @@
         class="action-modal-icon action-modal-prev"
         @click="previousStep"
       >
-        <i class="material-icons">arrow_back</i>
+        <i class="material-icons notranslate">arrow_back</i>
       </div>
       <div
         id="closeBtn"
         class="action-modal-icon action-modal-close"
         @click="close"
       >
-        <i class="material-icons">close</i>
+        <i class="material-icons notranslate">close</i>
       </div>
       <div class="action-modal-header">
         <span class="action-modal-title">{{

--- a/src/components/common/AppHeader.vue
+++ b/src/components/common/AppHeader.vue
@@ -19,10 +19,12 @@
         </router-link>
         <template v-if="!desktop">
           <div v-if="open" class="close-menu" @click="close()">
-            <i class="material-icons mobile-menu-action">close</i>
+            <i class="material-icons notranslate mobile-menu-action">close</i>
           </div>
           <div v-if="!open" class="open-menu" @click="show()">
-            <i class="material-icons mobile-menu-action">more_vert</i>
+            <i class="material-icons notranslate mobile-menu-action">
+              more_vert
+            </i>
           </div>
         </template>
       </div>

--- a/src/components/common/AppMenu.vue
+++ b/src/components/common/AppMenu.vue
@@ -94,7 +94,7 @@
         <h2 class="app-menu-title">
           Networks
         </h2>
-        <i class="material-icons hide-xs">chevron_right</i>
+        <i class="material-icons notranslate hide-xs">chevron_right</i>
       </router-link>
 
       <router-link

--- a/src/components/common/AppMenu.vue
+++ b/src/components/common/AppMenu.vue
@@ -7,7 +7,9 @@
           <Bech32 :address="address || ''" />
         </div>
         <a v-if="session.signedIn" id="sign-out" @click="signOut()">
-          <i v-tooltip.top="'Sign Out'" class="material-icons">exit_to_app</i>
+          <i v-tooltip.top="'Sign Out'" class="material-icons notranslate">
+            exit_to_app
+          </i>
         </a>
       </div>
       <a
@@ -43,7 +45,7 @@
         <h2 class="app-menu-title">
           Portfolio
         </h2>
-        <i class="material-icons">chevron_right</i>
+        <i class="material-icons notranslate">chevron_right</i>
       </router-link>
       <router-link
         class="app-menu-item hide-xs"
@@ -54,7 +56,7 @@
         <h2 class="app-menu-title">
           Validators
         </h2>
-        <i class="material-icons">chevron_right</i>
+        <i class="material-icons notranslate">chevron_right</i>
       </router-link>
 
       <router-link
@@ -66,7 +68,7 @@
         <h2 class="app-menu-title">
           Proposals
         </h2>
-        <i class="material-icons">chevron_right</i>
+        <i class="material-icons notranslate">chevron_right</i>
       </router-link>
 
       <router-link
@@ -79,7 +81,7 @@
         <h2 class="app-menu-title">
           Activity
         </h2>
-        <i class="material-icons">chevron_right</i>
+        <i class="material-icons notranslate">chevron_right</i>
       </router-link>
 
       <router-link

--- a/src/components/common/Bar.vue
+++ b/src/components/common/Bar.vue
@@ -3,7 +3,7 @@
     <p>
       <slot />
     </p>
-    <i class="material-icons close-icon" @click="close()">close</i>
+    <i class="material-icons notranslate close-icon" @click="close()">close</i>
   </div>
 </template>
 

--- a/src/components/common/Bech32.vue
+++ b/src/components/common/Bech32.vue
@@ -9,7 +9,7 @@
       {{ address | formatBech32(longForm) }}
     </div>
     <div :class="{ active: copySuccess }" class="copied">
-      <i class="material-icons">check</i>
+      <i class="material-icons notranslate">check</i>
     </div>
   </div>
 </template>

--- a/src/components/common/MobileMenu.vue
+++ b/src/components/common/MobileMenu.vue
@@ -6,19 +6,19 @@
       exact="exact"
       title="Portfolio"
     >
-      <i class="material-icons">star</i>
+      <i class="material-icons notranslate">star</i>
       <h2 class="app-menu-title">
         Portfolio
       </h2>
     </router-link>
     <router-link class="mobile-menu-item" to="/validators" title="Validators">
-      <i class="material-icons">sort</i>
+      <i class="material-icons notranslate">sort</i>
       <h2 class="app-menu-title">
         Validators
       </h2>
     </router-link>
     <router-link class="mobile-menu-item" to="/proposals" title="Proposals">
-      <i class="material-icons">add_circle_outline</i>
+      <i class="material-icons notranslate">add_circle_outline</i>
       <h2 class="app-menu-title">
         Proposals
       </h2>
@@ -29,7 +29,7 @@
       exact="exact"
       title="Transactions"
     >
-      <i class="material-icons">show_chart</i>
+      <i class="material-icons notranslate">show_chart</i>
       <h2 class="app-menu-title">
         Activity
       </h2>
@@ -40,7 +40,7 @@
       exact="exact"
       title="Networks"
     >
-      <i class="material-icons">public</i>
+      <i class="material-icons notranslate">public</i>
       <h2 class="app-menu-title">
         Networks
       </h2>

--- a/src/components/common/ModalTutorial.vue
+++ b/src/components/common/ModalTutorial.vue
@@ -5,14 +5,14 @@
         <div class="modal-tutorial-button-container">
           <div>
             <a href="#" @click.prevent="prevLink">
-              <i class="material-icons chevron_left"></i>
+              <i class="material-icons notranslate chevron_left"></i>
             </a>
             <a href="#" @click.prevent="nextLink">
-              <i class="material-icons chevron_right"></i>
+              <i class="material-icons notranslate chevron_right"></i>
             </a>
           </div>
           <a href="#" @click.prevent="close">
-            <i class="material-icons close"></i>
+            <i class="material-icons notranslate close"></i>
           </a>
         </div>
         <div class="top-bg" :class="background"></div>
@@ -48,7 +48,7 @@
             >
               {{ finalStep ? `Read the full guide` : `Next step` }}
               <i
-                class="material-icons arrow_forward"
+                class="material-icons notranslate arrow_forward"
                 :class="finalStep ? `final-step` : ``"
               ></i>
             </button>

--- a/src/components/common/SessionFrame.vue
+++ b/src/components/common/SessionFrame.vue
@@ -7,7 +7,7 @@
       <div class="session-outer-container">
         <div class="session">
           <a v-if="!hideBack" @click="goBack">
-            <i class="material-icons circle back">arrow_back</i>
+            <i class="material-icons notranslate circle back">arrow_back</i>
           </a>
           <slot></slot>
         </div>

--- a/src/components/common/SessionFrame.vue
+++ b/src/components/common/SessionFrame.vue
@@ -20,7 +20,7 @@
           @click.native="$router.push(`/`)"
         />
         <a class="user-box" @click="$router.push(`/`)">
-          <i class="material-icons">close</i>
+          <i class="material-icons notranslate">close</i>
         </a>
       </div>
     </div>

--- a/src/components/common/TmBalance.vue
+++ b/src/components/common/TmBalance.vue
@@ -20,7 +20,9 @@
               </h2>
             </div>
             <button class="tutorial-button" @click="openTutorial()">
-              <i v-if="false" class="material-icons">help_outline</i>
+              <i v-if="false" class="material-icons notranslate">
+                help_outline
+              </i>
               <span v-else>Need some tokens?</span>
             </button>
           </div>

--- a/src/components/common/TmDataMsg.vue
+++ b/src/components/common/TmDataMsg.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="tm-data-msg">
     <div class="tm-data-msg__icon" :class="{ success: success }">
-      <i :class="spinnerClass" class="material-icons">{{ icon }}</i>
+      <i :class="spinnerClass" class="material-icons notranslate">{{ icon }}</i>
     </div>
     <div class="tm-data-msg__text">
       <h2 class="tm-data-msg__title">

--- a/src/components/common/TmField.vue
+++ b/src/components/common/TmField.vue
@@ -23,7 +23,7 @@
       </template>
     </select>
     <div class="tm-field-select-addon">
-      <i class="material-icons">arrow_drop_down</i>
+      <i class="material-icons notranslate">arrow_drop_down</i>
     </div>
   </div>
 

--- a/src/components/common/TmLiSession.vue
+++ b/src/components/common/TmLiSession.vue
@@ -9,7 +9,7 @@
       </div>
     </div>
     <div class="tm-li-session-icon">
-      <i class="material-icons">arrow_forward</i>
+      <i class="material-icons notranslate">arrow_forward</i>
     </div>
   </router-link>
 </template>

--- a/src/components/common/TmLiSession.vue
+++ b/src/components/common/TmLiSession.vue
@@ -1,7 +1,7 @@
 <template>
   <router-link :to="route" class="tm-li-session">
     <div class="tm-li-session-icon">
-      <i class="material-icons circle">{{ icon }}</i>
+      <i class="material-icons notranslate circle">{{ icon }}</i>
     </div>
     <div class="tm-li-session-text">
       <div class="tm-li-session-title">

--- a/src/components/common/TmModalError.vue
+++ b/src/components/common/TmModalError.vue
@@ -2,7 +2,7 @@
   <div class="tm-modal-error__wrapper">
     <div class="tm-modal-error">
       <div class="tm-modal-error__icon">
-        <i class="material-icons">{{ icon }}</i>
+        <i class="material-icons notranslate">{{ icon }}</i>
       </div>
       <div class="tm-modal-error__title">
         {{ title }}

--- a/src/components/common/TmNotification.vue
+++ b/src/components/common/TmNotification.vue
@@ -2,7 +2,7 @@
   <div v-if="active" :class="cssClass" @click="deactivate()">
     <header>
       <div v-if="icon" class="icon">
-        <i class="material-icons">{{ icon }}</i>
+        <i class="material-icons notranslate">{{ icon }}</i>
       </div>
       <div v-if="title" class="title">
         {{ title }}

--- a/src/components/common/TmSeed.vue
+++ b/src/components/common/TmSeed.vue
@@ -12,7 +12,10 @@
       class="copy-seed"
     >
       Copy to clipboard
-      <i class="material-icons copied" :class="{ active: copySuccess }">
+      <i
+        class="material-icons notranslate copied"
+        :class="{ active: copySuccess }"
+      >
         check
       </i>
     </div>

--- a/src/components/common/TmSessionExplore.vue
+++ b/src/components/common/TmSessionExplore.vue
@@ -27,7 +27,7 @@
               </div>
             </div>
             <div class="tm-li-session-icon">
-              <i class="material-icons">arrow_forward</i>
+              <i class="material-icons notranslate">arrow_forward</i>
             </div>
           </div>
         </div>

--- a/src/components/common/TmSessionExplore.vue
+++ b/src/components/common/TmSessionExplore.vue
@@ -14,7 +14,7 @@
         >
           <div class="tm-li-session">
             <div class="tm-li-session-icon">
-              <i class="material-icons circle">
+              <i class="material-icons notranslate circle">
                 {{ getAddressIcon(account.type) }}
               </i>
             </div>

--- a/src/components/common/TmSessionHardware.vue
+++ b/src/components/common/TmSessionHardware.vue
@@ -24,7 +24,7 @@
               >
                 {{ hidFeatureLink }}
                 <i
-                  class="material-icons copied"
+                  class="material-icons notranslate copied"
                   :class="{ active: copySuccess }"
                 >
                   check
@@ -46,7 +46,10 @@
               class="copy-feature-link"
             >
               {{ linuxLedgerConnectionLink }}
-              <i class="material-icons copied" :class="{ active: copySuccess }">
+              <i
+                class="material-icons notranslate copied"
+                :class="{ active: copySuccess }"
+              >
                 check
               </i>
             </div>

--- a/src/components/common/TmSessionWelcome.vue
+++ b/src/components/common/TmSessionWelcome.vue
@@ -9,7 +9,7 @@
         />
       </router-link>
       <router-link to="/" class="session-close-mobile user-box">
-        <i class="material-icons">close</i>
+        <i class="material-icons notranslate">close</i>
       </router-link>
 
       <h2 class="session-title welcome">

--- a/src/components/governance/PageProposal.vue
+++ b/src/components/governance/PageProposal.vue
@@ -15,7 +15,7 @@
               :style="{ visibility: getPrevProposalId ? 'visible' : 'hidden' }"
               class="read-more-link"
             >
-              <i class="material-icons">chevron_left</i>
+              <i class="material-icons notranslate">chevron_left</i>
             </router-link>
             <h2 class="proposal-title">{{ proposal.title }}</h2>
             <router-link
@@ -23,7 +23,7 @@
               :style="{ visibility: getNextProposalId ? 'visible' : 'hidden' }"
               class="read-more-link"
             >
-              <i class="material-icons">chevron_right</i>
+              <i class="material-icons notranslate">chevron_right</i>
             </router-link>
           </div>
           <p class="proposer">

--- a/src/components/network/NetworkItem.vue
+++ b/src/components/network/NetworkItem.vue
@@ -25,7 +25,7 @@
         v-else-if="connected && network === networkitem.id"
         class="network-selected"
       >
-        <i class="material-icons">check</i>
+        <i class="material-icons notranslate">check</i>
       </div>
     </div>
   </div>

--- a/src/components/staking/PageValidator.vue
+++ b/src/components/staking/PageValidator.vue
@@ -11,7 +11,7 @@
     <template v-if="validator.operatorAddress" slot="managed-body">
       <div class="button-container">
         <button class="back-button" @click="$router.push(`/validators`)">
-          <i class="material-icons arrow">arrow_back</i>
+          <i class="material-icons notranslate arrow">arrow_back</i>
           Back to Validators
         </button>
         <button class="tutorial-button" @click="openTutorial()">

--- a/src/components/staking/PageValidator.vue
+++ b/src/components/staking/PageValidator.vue
@@ -15,7 +15,7 @@
           Back to Validators
         </button>
         <button class="tutorial-button" @click="openTutorial()">
-          <i v-if="false" class="material-icons">help_outline</i>
+          <i v-if="false" class="material-icons notranslate">help_outline</i>
           <span v-else>Want to learn about staking?</span>
         </button>
       </div>

--- a/src/components/staking/PanelSort.vue
+++ b/src/components/staking/PanelSort.vue
@@ -17,7 +17,7 @@
         @click="orderBy(property.value)"
       >
         {{ property.title }}
-        <i class="material-icons">arrow_drop_up</i>
+        <i class="material-icons notranslate">arrow_drop_up</i>
       </a>
       <span v-else>{{ property.title }}</span>
     </th>

--- a/src/components/transactions/TransactionItem.vue
+++ b/src/components/transactions/TransactionItem.vue
@@ -9,7 +9,9 @@
         :show="show"
       />
       <div class="toggle" :class="{ up: show }">
-        <i class="material-icons toggle-icon">keyboard_arrow_down</i>
+        <i class="material-icons notranslate toggle-icon">
+          keyboard_arrow_down
+        </i>
       </div>
     </div>
     <transition name="slide-out">

--- a/src/components/transactions/TransactionMetadata.vue
+++ b/src/components/transactions/TransactionMetadata.vue
@@ -9,14 +9,17 @@
         #{{ transaction.height | prettyInt }}</router-link
       >
       <span v-else>#{{ transaction.height | prettyInt }}</span>
-      &nbsp;<i class="material-icons">access_time</i>&nbsp;{{ date }}
+      &nbsp;<i class="material-icons notranslate">access_time</i>&nbsp;{{
+        date
+      }}
     </p>
     <p v-if="transaction.undelegationEndTime">
       Liquid date:
       {{ getUndelegationEndTime() }}
     </p>
     <p v-if="transaction.memo">
-      <i class="material-icons">message</i> Memo: {{ transaction.memo }}
+      <i class="material-icons notranslate">message</i> Memo:&nbsp;
+      {{ transaction.memo }}
     </p>
     <p>
       Fee:

--- a/src/components/transactions/message-view/BeginRedelegateMessageDetails.vue
+++ b/src/components/transactions/message-view/BeginRedelegateMessageDetails.vue
@@ -20,7 +20,7 @@
           transaction.value.validator_src_address
             | resolveValidatorName(validators)
         }} </router-link
-      ><i class="material-icons arrow">arrow_right_alt</i>
+      ><i class="material-icons notranslate arrow">arrow_right_alt</i>
       <router-link
         :to="`staking/validators/${transaction.value.validator_dst_address}`"
       >

--- a/src/components/transactions/message-view/SendMessageDetails.vue
+++ b/src/components/transactions/message-view/SendMessageDetails.vue
@@ -21,7 +21,7 @@
       <template v-else>
         <span>From&nbsp;</span>
         <Bech32 :address="transaction.value.from_address" />
-        <i class="material-icons arrow">arrow_right_alt</i>
+        <i class="material-icons notranslate arrow">arrow_right_alt</i>
         <Bech32 :address="transaction.value.to_address" />
       </template>
     </div>

--- a/tests/unit/specs/components/ActionModal/components/__snapshots__/ActionModal.spec.js.snap
+++ b/tests/unit/specs/components/ActionModal/components/__snapshots__/ActionModal.spec.js.snap
@@ -11,7 +11,7 @@ exports[`ActionModal back button renders and functions 1`] = `
     id="prevBtn"
   >
     <i
-      class="material-icons"
+      class="material-icons notranslate"
     >
       arrow_back
     </i>
@@ -22,7 +22,7 @@ exports[`ActionModal back button renders and functions 1`] = `
     id="closeBtn"
   >
     <i
-      class="material-icons"
+      class="material-icons notranslate"
     >
       close
     </i>
@@ -101,7 +101,7 @@ exports[`ActionModal runs validation and changes step on sign step should dispal
     id="prevBtn"
   >
     <i
-      class="material-icons"
+      class="material-icons notranslate"
     >
       arrow_back
     </i>
@@ -112,7 +112,7 @@ exports[`ActionModal runs validation and changes step on sign step should dispal
     id="closeBtn"
   >
     <i
-      class="material-icons"
+      class="material-icons notranslate"
     >
       close
     </i>
@@ -199,7 +199,7 @@ exports[`ActionModal should show the action modal on success 1`] = `
     id="closeBtn"
   >
     <i
-      class="material-icons"
+      class="material-icons notranslate"
     >
       close
     </i>
@@ -271,7 +271,7 @@ exports[`ActionModal should show the action modal waiting on inclusion 1`] = `
     id="closeBtn"
   >
     <i
-      class="material-icons"
+      class="material-icons notranslate"
     >
       close
     </i>
@@ -314,7 +314,7 @@ exports[`ActionModal should show the action modal when user has logged in with e
     id="prevBtn"
   >
     <i
-      class="material-icons"
+      class="material-icons notranslate"
     >
       arrow_back
     </i>
@@ -325,7 +325,7 @@ exports[`ActionModal should show the action modal when user has logged in with e
     id="closeBtn"
   >
     <i
-      class="material-icons"
+      class="material-icons notranslate"
     >
       close
     </i>
@@ -395,7 +395,7 @@ exports[`ActionModal should show the action modal when user has logged in with e
     id="prevBtn"
   >
     <i
-      class="material-icons"
+      class="material-icons notranslate"
     >
       arrow_back
     </i>
@@ -406,7 +406,7 @@ exports[`ActionModal should show the action modal when user has logged in with e
     id="closeBtn"
   >
     <i
-      class="material-icons"
+      class="material-icons notranslate"
     >
       close
     </i>
@@ -478,7 +478,7 @@ exports[`ActionModal should show the action modal when user has logged in with e
     id="closeBtn"
   >
     <i
-      class="material-icons"
+      class="material-icons notranslate"
     >
       close
     </i>
@@ -548,7 +548,7 @@ exports[`ActionModal should show the action modal when user has logged in with e
     id="prevBtn"
   >
     <i
-      class="material-icons"
+      class="material-icons notranslate"
     >
       arrow_back
     </i>
@@ -559,7 +559,7 @@ exports[`ActionModal should show the action modal when user has logged in with e
     id="closeBtn"
   >
     <i
-      class="material-icons"
+      class="material-icons notranslate"
     >
       close
     </i>
@@ -630,7 +630,7 @@ exports[`ActionModal should show the action modal when user has logged in with e
     id="prevBtn"
   >
     <i
-      class="material-icons"
+      class="material-icons notranslate"
     >
       arrow_back
     </i>
@@ -641,7 +641,7 @@ exports[`ActionModal should show the action modal when user has logged in with e
     id="closeBtn"
   >
     <i
-      class="material-icons"
+      class="material-icons notranslate"
     >
       close
     </i>
@@ -728,7 +728,7 @@ exports[`ActionModal should show the action modal when user has logged in with e
     id="closeBtn"
   >
     <i
-      class="material-icons"
+      class="material-icons notranslate"
     >
       close
     </i>
@@ -815,7 +815,7 @@ exports[`ActionModal should show the action modal when user has logged in with l
     id="prevBtn"
   >
     <i
-      class="material-icons"
+      class="material-icons notranslate"
     >
       arrow_back
     </i>
@@ -826,7 +826,7 @@ exports[`ActionModal should show the action modal when user has logged in with l
     id="closeBtn"
   >
     <i
-      class="material-icons"
+      class="material-icons notranslate"
     >
       close
     </i>
@@ -897,7 +897,7 @@ exports[`ActionModal should show the action modal when user has logged in with l
     id="prevBtn"
   >
     <i
-      class="material-icons"
+      class="material-icons notranslate"
     >
       arrow_back
     </i>
@@ -908,7 +908,7 @@ exports[`ActionModal should show the action modal when user has logged in with l
     id="closeBtn"
   >
     <i
-      class="material-icons"
+      class="material-icons notranslate"
     >
       close
     </i>
@@ -984,7 +984,7 @@ exports[`ActionModal should show the action modal when user has logged in with l
     id="closeBtn"
   >
     <i
-      class="material-icons"
+      class="material-icons notranslate"
     >
       close
     </i>
@@ -1060,7 +1060,7 @@ exports[`ActionModal should show the action modal when user has logged in with l
     id="prevBtn"
   >
     <i
-      class="material-icons"
+      class="material-icons notranslate"
     >
       arrow_back
     </i>
@@ -1071,7 +1071,7 @@ exports[`ActionModal should show the action modal when user has logged in with l
     id="closeBtn"
   >
     <i
-      class="material-icons"
+      class="material-icons notranslate"
     >
       close
     </i>
@@ -1142,7 +1142,7 @@ exports[`ActionModal should show the action modal when user has logged in with l
     id="prevBtn"
   >
     <i
-      class="material-icons"
+      class="material-icons notranslate"
     >
       arrow_back
     </i>
@@ -1153,7 +1153,7 @@ exports[`ActionModal should show the action modal when user has logged in with l
     id="closeBtn"
   >
     <i
-      class="material-icons"
+      class="material-icons notranslate"
     >
       close
     </i>
@@ -1234,7 +1234,7 @@ exports[`ActionModal should show the action modal when user has logged in with l
     id="closeBtn"
   >
     <i
-      class="material-icons"
+      class="material-icons notranslate"
     >
       close
     </i>
@@ -1316,7 +1316,7 @@ exports[`ActionModal should show the action modal when user hasn't logged in 1`]
     id="closeBtn"
   >
     <i
-      class="material-icons"
+      class="material-icons notranslate"
     >
       close
     </i>
@@ -1388,7 +1388,7 @@ exports[`ActionModal shows a feature unavailable message 1`] = `
     id="closeBtn"
   >
     <i
-      class="material-icons"
+      class="material-icons notranslate"
     >
       close
     </i>
@@ -1451,7 +1451,7 @@ exports[`ActionModal shows loading when there is still data to be loaded 1`] = `
     id="closeBtn"
   >
     <i
-      class="material-icons"
+      class="material-icons notranslate"
     >
       close
     </i>

--- a/tests/unit/specs/components/common/__snapshots__/AppHeader.spec.js.snap
+++ b/tests/unit/specs/components/common/__snapshots__/AppHeader.spec.js.snap
@@ -58,7 +58,7 @@ exports[`AppHeader should show the sidebar as a menu on mobile 1`] = `
         class="close-menu"
       >
         <i
-          class="material-icons mobile-menu-action"
+          class="material-icons notranslate mobile-menu-action"
         >
           close
         </i>

--- a/tests/unit/specs/components/common/__snapshots__/Bar.spec.js.snap
+++ b/tests/unit/specs/components/common/__snapshots__/Bar.spec.js.snap
@@ -7,7 +7,7 @@ exports[`Bar shows a primary bar 1`] = `
   <p />
    
   <i
-    class="material-icons close-icon"
+    class="material-icons notranslate close-icon"
   >
     close
   </i>

--- a/tests/unit/specs/components/common/__snapshots__/Bech32.spec.js.snap
+++ b/tests/unit/specs/components/common/__snapshots__/Bech32.spec.js.snap
@@ -16,7 +16,7 @@ exports[`Bech32 should show a long address 1`] = `
     class="copied"
   >
     <i
-      class="material-icons"
+      class="material-icons notranslate"
     >
       check
     </i>
@@ -40,7 +40,7 @@ exports[`Bech32 should show a short address 1`] = `
     class="copied"
   >
     <i
-      class="material-icons"
+      class="material-icons notranslate"
     >
       check
     </i>

--- a/tests/unit/specs/components/common/__snapshots__/FeatureNotAvailable.spec.js.snap
+++ b/tests/unit/specs/components/common/__snapshots__/FeatureNotAvailable.spec.js.snap
@@ -8,7 +8,7 @@ exports[`FeatureNotAvailable shows a warning about a feature not being available
     class="tm-data-msg__icon"
   >
     <i
-      class="material-icons"
+      class="material-icons notranslate"
     >
       timeline
     </i>

--- a/tests/unit/specs/components/common/__snapshots__/ModalTutorial.spec.js.snap
+++ b/tests/unit/specs/components/common/__snapshots__/ModalTutorial.spec.js.snap
@@ -19,7 +19,7 @@ exports[`TmModal has the expected html structure 1`] = `
             href="#"
           >
             <i
-              class="material-icons chevron_left"
+              class="material-icons notranslate chevron_left"
             />
           </a>
            
@@ -27,7 +27,7 @@ exports[`TmModal has the expected html structure 1`] = `
             href="#"
           >
             <i
-              class="material-icons chevron_right"
+              class="material-icons notranslate chevron_right"
             />
           </a>
         </div>
@@ -36,7 +36,7 @@ exports[`TmModal has the expected html structure 1`] = `
           href="#"
         >
           <i
-            class="material-icons close"
+            class="material-icons notranslate close"
           />
         </a>
       </div>
@@ -111,7 +111,7 @@ exports[`TmModal has the expected html structure 1`] = `
             Next step
             
         <i
-          class="material-icons arrow_forward"
+          class="material-icons notranslate arrow_forward"
         />
       </button>
       <!---->

--- a/tests/unit/specs/components/common/__snapshots__/PageFeatureNotAvailable.spec.js.snap
+++ b/tests/unit/specs/components/common/__snapshots__/PageFeatureNotAvailable.spec.js.snap
@@ -19,7 +19,7 @@ exports[`PageFeatureNotAvailable shows a warning about a feature not being avail
         class="tm-data-msg__icon"
       >
         <i
-          class="material-icons"
+          class="material-icons notranslate"
         >
           timeline
         </i>

--- a/tests/unit/specs/components/common/__snapshots__/SessionFrame.spec.js.snap
+++ b/tests/unit/specs/components/common/__snapshots__/SessionFrame.spec.js.snap
@@ -23,7 +23,7 @@ exports[`SessionFrame shows an overview of all wallets to sign in with from the 
     >
       <a>
         <i
-          class="material-icons circle back"
+          class="material-icons notranslate circle back"
         >
           arrow_back
         </i>

--- a/tests/unit/specs/components/common/__snapshots__/SessionFrame.spec.js.snap
+++ b/tests/unit/specs/components/common/__snapshots__/SessionFrame.spec.js.snap
@@ -45,7 +45,7 @@ exports[`SessionFrame shows an overview of all wallets to sign in with from the 
       class="user-box"
     >
       <i
-        class="material-icons"
+        class="material-icons notranslate"
       >
         close
       </i>

--- a/tests/unit/specs/components/common/__snapshots__/TmDataEmpty.spec.js.snap
+++ b/tests/unit/specs/components/common/__snapshots__/TmDataEmpty.spec.js.snap
@@ -8,7 +8,7 @@ exports[`TmDataEmpty has the expected html structure 1`] = `
     class="tm-data-msg__icon"
   >
     <i
-      class="material-icons"
+      class="material-icons notranslate"
     >
       info_outline
     </i>

--- a/tests/unit/specs/components/common/__snapshots__/TmDataEmptyTx.spec.js.snap
+++ b/tests/unit/specs/components/common/__snapshots__/TmDataEmptyTx.spec.js.snap
@@ -8,7 +8,7 @@ exports[`TmDataEmptyTx has the expected html structure 1`] = `
     class="tm-data-msg__icon"
   >
     <i
-      class="material-icons"
+      class="material-icons notranslate"
     >
       receipt
     </i>

--- a/tests/unit/specs/components/common/__snapshots__/TmDataError.spec.js.snap
+++ b/tests/unit/specs/components/common/__snapshots__/TmDataError.spec.js.snap
@@ -8,7 +8,7 @@ exports[`TmDataError has the expected html structure 1`] = `
     class="tm-data-msg__icon"
   >
     <i
-      class="material-icons"
+      class="material-icons notranslate"
     >
       sentiment_very_dissatisfied
     </i>

--- a/tests/unit/specs/components/common/__snapshots__/TmDataMsg.spec.js.snap
+++ b/tests/unit/specs/components/common/__snapshots__/TmDataMsg.spec.js.snap
@@ -8,7 +8,7 @@ exports[`TmDataMsg has the expected html structure 1`] = `
     class="tm-data-msg__icon"
   >
     <i
-      class="material-icons"
+      class="material-icons notranslate"
     >
       help
     </i>

--- a/tests/unit/specs/components/common/__snapshots__/TmField.spec.js.snap
+++ b/tests/unit/specs/components/common/__snapshots__/TmField.spec.js.snap
@@ -251,7 +251,7 @@ exports[`TmField displays as a select 1`] = `
     class="tm-field-select-addon"
   >
     <i
-      class="material-icons"
+      class="material-icons notranslate"
     >
       arrow_drop_down
     </i>
@@ -297,7 +297,7 @@ exports[`TmField displays as a select 2`] = `
     class="tm-field-select-addon"
   >
     <i
-      class="material-icons"
+      class="material-icons notranslate"
     >
       arrow_drop_down
     </i>
@@ -343,7 +343,7 @@ exports[`TmField displays as a select 3`] = `
     class="tm-field-select-addon"
   >
     <i
-      class="material-icons"
+      class="material-icons notranslate"
     >
       arrow_drop_down
     </i>

--- a/tests/unit/specs/components/common/__snapshots__/TmLiSession.spec.js.snap
+++ b/tests/unit/specs/components/common/__snapshots__/TmLiSession.spec.js.snap
@@ -9,7 +9,7 @@ exports[`TmLiSession has the expected html structure 1`] = `
     class="tm-li-session-icon"
   >
     <i
-      class="material-icons circle"
+      class="material-icons notranslate circle"
     >
       mood
     </i>

--- a/tests/unit/specs/components/common/__snapshots__/TmLiSession.spec.js.snap
+++ b/tests/unit/specs/components/common/__snapshots__/TmLiSession.spec.js.snap
@@ -31,7 +31,7 @@ exports[`TmLiSession has the expected html structure 1`] = `
     class="tm-li-session-icon"
   >
     <i
-      class="material-icons"
+      class="material-icons notranslate"
     >
       arrow_forward
     </i>

--- a/tests/unit/specs/components/common/__snapshots__/TmModalError.spec.js.snap
+++ b/tests/unit/specs/components/common/__snapshots__/TmModalError.spec.js.snap
@@ -11,7 +11,7 @@ exports[`TmModalError has the expected html structure 1`] = `
       class="tm-modal-error__icon"
     >
       <i
-        class="material-icons"
+        class="material-icons notranslate"
       >
         error_outline
       </i>

--- a/tests/unit/specs/components/common/__snapshots__/TmNotification.spec.js.snap
+++ b/tests/unit/specs/components/common/__snapshots__/TmNotification.spec.js.snap
@@ -87,7 +87,7 @@ exports[`TmNotification.vue has the expected html structure 3`] = `
       class="icon"
     >
       <i
-        class="material-icons"
+        class="material-icons notranslate"
       >
         search
       </i>

--- a/tests/unit/specs/components/common/__snapshots__/TmSeed.spec.js.snap
+++ b/tests/unit/specs/components/common/__snapshots__/TmSeed.spec.js.snap
@@ -22,7 +22,7 @@ exports[`TmSeed should render the seed in a table component 1`] = `
     Copy to clipboard
     
     <i
-      class="material-icons copied"
+      class="material-icons notranslate copied"
     >
       
       check

--- a/tests/unit/specs/components/common/__snapshots__/TmSessionExplore.spec.js.snap
+++ b/tests/unit/specs/components/common/__snapshots__/TmSessionExplore.spec.js.snap
@@ -27,7 +27,7 @@ exports[`TmSessionExplore shows a form to sign in with an address 1`] = `
             class="tm-li-session-icon"
           >
             <i
-              class="material-icons circle"
+              class="material-icons notranslate circle"
             >
               
               vpn_key
@@ -76,7 +76,7 @@ exports[`TmSessionExplore shows a form to sign in with an address 1`] = `
             class="tm-li-session-icon"
           >
             <i
-              class="material-icons circle"
+              class="material-icons notranslate circle"
             >
               
               laptop
@@ -125,7 +125,7 @@ exports[`TmSessionExplore shows a form to sign in with an address 1`] = `
             class="tm-li-session-icon"
           >
             <i
-              class="material-icons circle"
+              class="material-icons notranslate circle"
             >
               
               phone_iphone

--- a/tests/unit/specs/components/common/__snapshots__/TmSessionExplore.spec.js.snap
+++ b/tests/unit/specs/components/common/__snapshots__/TmSessionExplore.spec.js.snap
@@ -59,7 +59,7 @@ exports[`TmSessionExplore shows a form to sign in with an address 1`] = `
             class="tm-li-session-icon"
           >
             <i
-              class="material-icons"
+              class="material-icons notranslate"
             >
               arrow_forward
             </i>
@@ -108,7 +108,7 @@ exports[`TmSessionExplore shows a form to sign in with an address 1`] = `
             class="tm-li-session-icon"
           >
             <i
-              class="material-icons"
+              class="material-icons notranslate"
             >
               arrow_forward
             </i>
@@ -157,7 +157,7 @@ exports[`TmSessionExplore shows a form to sign in with an address 1`] = `
             class="tm-li-session-icon"
           >
             <i
-              class="material-icons"
+              class="material-icons notranslate"
             >
               arrow_forward
             </i>

--- a/tests/unit/specs/components/common/__snapshots__/TmSessionHardware.spec.js.snap
+++ b/tests/unit/specs/components/common/__snapshots__/TmSessionHardware.spec.js.snap
@@ -4,7 +4,7 @@ exports[`TmSessionHardware should show a state indicator for different states of
 <div class="session-frame" name="component-fade" mode="out-in">
   <router-link-stub to="/"><img src="~assets/images/lunie-logo-white.svg" class="session-logo"></router-link-stub>
   <div class="session-outer-container">
-    <div class="session"><a><i class="material-icons circle back">arrow_back</i></a>
+    <div class="session"><a><i class="material-icons notranslate circle back">arrow_back</i></a>
       <h2 class="session-title">
         Use my Ledger Nano
       </h2>
@@ -36,7 +36,7 @@ exports[`TmSessionHardware should show a state indicator for different states of
 <div class="session-frame" name="component-fade" mode="out-in">
   <router-link-stub to="/"><img src="~assets/images/lunie-logo-white.svg" class="session-logo"></router-link-stub>
   <div class="session-outer-container">
-    <div class="session"><a><i class="material-icons circle back">arrow_back</i></a>
+    <div class="session"><a><i class="material-icons notranslate circle back">arrow_back</i></a>
       <h2 class="session-title">
         Use my Ledger Nano
       </h2>
@@ -67,7 +67,7 @@ exports[`TmSessionHardware should show a state indicator for different states of
 <div class="session-frame" name="component-fade" mode="out-in">
   <router-link-stub to="/"><img src="~assets/images/lunie-logo-white.svg" class="session-logo"></router-link-stub>
   <div class="session-outer-container">
-    <div class="session"><a><i class="material-icons circle back">arrow_back</i></a>
+    <div class="session"><a><i class="material-icons notranslate circle back">arrow_back</i></a>
       <h2 class="session-title">
         Use my Ledger Nano
       </h2>
@@ -113,7 +113,7 @@ exports[`TmSessionHardware shows the ledger conection view when there're errors 
     >
       <a>
         <i
-          class="material-icons circle back"
+          class="material-icons notranslate circle back"
         >
           arrow_back
         </i>
@@ -218,7 +218,7 @@ exports[`TmSessionHardware shows the ledger conection view with no errors 1`] = 
     >
       <a>
         <i
-          class="material-icons circle back"
+          class="material-icons notranslate circle back"
         >
           arrow_back
         </i>
@@ -298,7 +298,7 @@ exports[`TmSessionHardware sign in does show the instructions to enable HID on W
 <div class="session-frame" name="component-fade" mode="out-in">
   <router-link-stub to="/"><img src="~assets/images/lunie-logo-white.svg" class="session-logo"></router-link-stub>
   <div class="session-outer-container">
-    <div class="session"><a><i class="material-icons circle back">arrow_back</i></a>
+    <div class="session"><a><i class="material-icons notranslate circle back">arrow_back</i></a>
       <h2 class="session-title">
         Use my Ledger Nano
       </h2>
@@ -328,7 +328,7 @@ exports[`TmSessionHardware sign in does show the instructions to fix connection 
 <div class="session-frame" name="component-fade" mode="out-in">
   <router-link-stub to="/"><img src="~assets/images/lunie-logo-white.svg" class="session-logo"></router-link-stub>
   <div class="session-outer-container">
-    <div class="session"><a><i class="material-icons circle back">arrow_back</i></a>
+    <div class="session"><a><i class="material-icons notranslate circle back">arrow_back</i></a>
       <h2 class="session-title">
         Use my Ledger Nano
       </h2>
@@ -343,7 +343,7 @@ exports[`TmSessionHardware sign in does show the instructions to fix connection 
               Please visit the following site to learn more about how to fix them:
               <div class="copy-feature-link">
                 https://support.ledger.com/hc/en-us/articles/360019301813-Fix-USB-issues
-                <i class="material-icons copied">
+                <i class="material-icons notranslate copied">
                   check
                 </i></div> <br> <br>
               <!----> <button class="button">

--- a/tests/unit/specs/components/common/__snapshots__/TmSessionHardware.spec.js.snap
+++ b/tests/unit/specs/components/common/__snapshots__/TmSessionHardware.spec.js.snap
@@ -28,7 +28,7 @@ exports[`TmSessionHardware should show a state indicator for different states of
   </div>
   <div class="session-close"><button class="button session-close-button" color="secondary">
       Back to Lunie
-    </button> <a class="user-box"><i class="material-icons">close</i></a></div>
+    </button> <a class="user-box"><i class="material-icons notranslate">close</i></a></div>
 </div>
 `;
 
@@ -59,7 +59,7 @@ exports[`TmSessionHardware should show a state indicator for different states of
   </div>
   <div class="session-close"><button class="button session-close-button" color="secondary">
       Back to Lunie
-    </button> <a class="user-box"><i class="material-icons">close</i></a></div>
+    </button> <a class="user-box"><i class="material-icons notranslate">close</i></a></div>
 </div>
 `;
 
@@ -86,7 +86,7 @@ exports[`TmSessionHardware should show a state indicator for different states of
   </div>
   <div class="session-close"><button class="button session-close-button" color="secondary">
       Back to Lunie
-    </button> <a class="user-box"><i class="material-icons">close</i></a></div>
+    </button> <a class="user-box"><i class="material-icons notranslate">close</i></a></div>
 </div>
 `;
 
@@ -186,7 +186,7 @@ exports[`TmSessionHardware shows the ledger conection view when there're errors 
       class="user-box"
     >
       <i
-        class="material-icons"
+        class="material-icons notranslate"
       >
         close
       </i>
@@ -285,7 +285,7 @@ exports[`TmSessionHardware shows the ledger conection view with no errors 1`] = 
       class="user-box"
     >
       <i
-        class="material-icons"
+        class="material-icons notranslate"
       >
         close
       </i>
@@ -320,7 +320,7 @@ exports[`TmSessionHardware sign in does show the instructions to enable HID on W
   </div>
   <div class="session-close"><button class="button session-close-button" color="secondary">
       Back to Lunie
-    </button> <a class="user-box"><i class="material-icons">close</i></a></div>
+    </button> <a class="user-box"><i class="material-icons notranslate">close</i></a></div>
 </div>
 `;
 
@@ -356,6 +356,6 @@ exports[`TmSessionHardware sign in does show the instructions to fix connection 
   </div>
   <div class="session-close"><button class="button session-close-button" color="secondary">
       Back to Lunie
-    </button> <a class="user-box"><i class="material-icons">close</i></a></div>
+    </button> <a class="user-box"><i class="material-icons notranslate">close</i></a></div>
 </div>
 `;

--- a/tests/unit/specs/components/common/__snapshots__/TmSessionWelcome.spec.js.snap
+++ b/tests/unit/specs/components/common/__snapshots__/TmSessionWelcome.spec.js.snap
@@ -22,7 +22,7 @@ exports[`TmSessionWelcome has the expected html structure 1`] = `
       to="/"
     >
       <i
-        class="material-icons"
+        class="material-icons notranslate"
       >
         close
       </i>
@@ -117,7 +117,7 @@ exports[`TmSessionWelcome has the expected html structure when on mobile 1`] = `
       to="/"
     >
       <i
-        class="material-icons"
+        class="material-icons notranslate"
       >
         close
       </i>

--- a/tests/unit/specs/components/governance/__snapshots__/PageProposal.spec.js.snap
+++ b/tests/unit/specs/components/governance/__snapshots__/PageProposal.spec.js.snap
@@ -7,9 +7,9 @@ exports[`PageProposal Modal onVote enables voting if the proposal is on the 'Vot
           Voting Period
         </span>
       <div class="proposal-title__row">
-        <router-link-stub to="/proposals/undefined" class="read-more-link" style="visibility: hidden;"><i class="material-icons">chevron_left</i></router-link-stub>
+        <router-link-stub to="/proposals/undefined" class="read-more-link" style="visibility: hidden;"><i class="material-icons notranslate">chevron_left</i></router-link-stub>
         <h2 class="proposal-title">test</h2>
-        <router-link-stub to="/proposals/undefined" class="read-more-link" style="visibility: hidden;"><i class="material-icons">chevron_right</i></router-link-stub>
+        <router-link-stub to="/proposals/undefined" class="read-more-link" style="visibility: hidden;"><i class="material-icons notranslate">chevron_right</i></router-link-stub>
       </div>
       <p class="proposer">
         Proposed by Big Daddy Validator:
@@ -88,9 +88,9 @@ exports[`PageProposal Modal onVote shows the last valid vote 1`] = `
           Rejected
         </span>
       <div class="proposal-title__row">
-        <router-link-stub to="/proposals/undefined" class="read-more-link" style="visibility: hidden;"><i class="material-icons">chevron_left</i></router-link-stub>
+        <router-link-stub to="/proposals/undefined" class="read-more-link" style="visibility: hidden;"><i class="material-icons notranslate">chevron_left</i></router-link-stub>
         <h2 class="proposal-title">test</h2>
-        <router-link-stub to="/proposals/undefined" class="read-more-link" style="visibility: hidden;"><i class="material-icons">chevron_right</i></router-link-stub>
+        <router-link-stub to="/proposals/undefined" class="read-more-link" style="visibility: hidden;"><i class="material-icons notranslate">chevron_right</i></router-link-stub>
       </div>
       <p class="proposer">
         Proposed by Big Daddy Validator:
@@ -182,7 +182,7 @@ exports[`PageProposal should show a loader if the necessary data hasen't been lo
           to="/proposals/undefined"
         >
           <i
-            class="material-icons"
+            class="material-icons notranslate"
           >
             chevron_left
           </i>
@@ -200,7 +200,7 @@ exports[`PageProposal should show a loader if the necessary data hasen't been lo
           to="/proposals/undefined"
         >
           <i
-            class="material-icons"
+            class="material-icons notranslate"
           >
             chevron_right
           </i>

--- a/tests/unit/specs/components/staking/__snapshots__/PanelSort.spec.js.snap
+++ b/tests/unit/specs/components/staking/__snapshots__/PanelSort.spec.js.snap
@@ -18,7 +18,7 @@ exports[`PanelSort has the expected html structure 1`] = `
       ID
       
       <i
-        class="material-icons"
+        class="material-icons notranslate"
       >
         arrow_drop_up
       </i>
@@ -34,7 +34,7 @@ exports[`PanelSort has the expected html structure 1`] = `
       AMOUNT
       
       <i
-        class="material-icons"
+        class="material-icons notranslate"
       >
         arrow_drop_up
       </i>

--- a/tests/unit/specs/components/transactions/__snapshots__/TransactionItem.spec.js.snap
+++ b/tests/unit/specs/components/transactions/__snapshots__/TransactionItem.spec.js.snap
@@ -13,9 +13,11 @@ exports[`TransactionItem renders a MsgBeginRedelegate transaction item 1`] = `
       class="toggle"
     >
       <i
-        class="material-icons toggle-icon"
+        class="material-icons notranslate toggle-icon"
       >
+        
         keyboard_arrow_down
+      
       </i>
     </div>
   </div>
@@ -37,9 +39,11 @@ exports[`TransactionItem renders a MsgDelegate transaction item 1`] = `
       class="toggle"
     >
       <i
-        class="material-icons toggle-icon"
+        class="material-icons notranslate toggle-icon"
       >
+        
         keyboard_arrow_down
+      
       </i>
     </div>
   </div>
@@ -61,9 +65,11 @@ exports[`TransactionItem renders a MsgDeposit transaction item 1`] = `
       class="toggle"
     >
       <i
-        class="material-icons toggle-icon"
+        class="material-icons notranslate toggle-icon"
       >
+        
         keyboard_arrow_down
+      
       </i>
     </div>
   </div>
@@ -85,9 +91,11 @@ exports[`TransactionItem renders a MsgMultiSend transaction item 1`] = `
       class="toggle"
     >
       <i
-        class="material-icons toggle-icon"
+        class="material-icons notranslate toggle-icon"
       >
+        
         keyboard_arrow_down
+      
       </i>
     </div>
   </div>
@@ -109,9 +117,11 @@ exports[`TransactionItem renders a MsgSend transaction item 1`] = `
       class="toggle"
     >
       <i
-        class="material-icons toggle-icon"
+        class="material-icons notranslate toggle-icon"
       >
+        
         keyboard_arrow_down
+      
       </i>
     </div>
   </div>
@@ -133,9 +143,11 @@ exports[`TransactionItem renders a MsgSubmitProposal transaction item 1`] = `
       class="toggle"
     >
       <i
-        class="material-icons toggle-icon"
+        class="material-icons notranslate toggle-icon"
       >
+        
         keyboard_arrow_down
+      
       </i>
     </div>
   </div>
@@ -157,9 +169,11 @@ exports[`TransactionItem renders a MsgUndelegate transaction item 1`] = `
       class="toggle"
     >
       <i
-        class="material-icons toggle-icon"
+        class="material-icons notranslate toggle-icon"
       >
+        
         keyboard_arrow_down
+      
       </i>
     </div>
   </div>
@@ -181,9 +195,11 @@ exports[`TransactionItem renders a MsgVote transaction item 1`] = `
       class="toggle"
     >
       <i
-        class="material-icons toggle-icon"
+        class="material-icons notranslate toggle-icon"
       >
+        
         keyboard_arrow_down
+      
       </i>
     </div>
   </div>
@@ -205,9 +221,11 @@ exports[`TransactionItem renders a MsgWithdrawDelegationReward transaction item 
       class="toggle"
     >
       <i
-        class="material-icons toggle-icon"
+        class="material-icons notranslate toggle-icon"
       >
+        
         keyboard_arrow_down
+      
       </i>
     </div>
   </div>

--- a/tests/unit/specs/components/transactions/__snapshots__/TransactionMetadata.spec.js.snap
+++ b/tests/unit/specs/components/transactions/__snapshots__/TransactionMetadata.spec.js.snap
@@ -14,7 +14,7 @@ exports[`TransactionMetadata renders correct transaction metadata 1`] = `
     
      
     <i
-      class="material-icons"
+      class="material-icons notranslate"
     >
       access_time
     </i>

--- a/tests/unit/specs/components/transactions/message-view/__snapshots__/BeginRedelegateMessageDetails.spec.js.snap
+++ b/tests/unit/specs/components/transactions/message-view/__snapshots__/BeginRedelegateMessageDetails.spec.js.snap
@@ -28,7 +28,7 @@ exports[`BeginRedelegateMessageDetails renders a redelegate transaction message 
       cosmos…mos1 
     </router-link-stub>
     <i
-      class="material-icons arrow"
+      class="material-icons notranslate arrow"
     >
       arrow_right_alt
     </i>


### PR DESCRIPTION
Closes #3563 

**Description:**

Adding notranslate class to material icons solve the problem as @Bitcoinera suggested!

Thank you! 🚀

---

For contributor:

- [ ] Added changes entries. Run `yarn changelog` for a guided process.
- [ ] Reviewed `Files changed` in the github PR explorer
- [ ] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI
