### PR TITLE
Show tutorial buttons only in cosmos main & testnet

### DIFF
--- a/changes/mario_3568-no-tutorial-buttons-when-no-content-available
+++ b/changes/mario_3568-no-tutorial-buttons-when-no-content-available
@@ -1,0 +1,1 @@
+[Fixed] [#3568](https://github.com/cosmos/lunie/issues/3568) Show tutorial buttons only in cosmos main & testnet @mariopino

--- a/src/components/common/TmBalance.vue
+++ b/src/components/common/TmBalance.vue
@@ -19,7 +19,14 @@
                 {{ overview.totalStake | bigFigureOrShortDecimals | noBlanks }}
               </h2>
             </div>
-            <button class="tutorial-button" @click="openTutorial()">
+            <button
+              v-if="
+                connection.network === 'cosmos-hub-mainnet' ||
+                  connection.network === 'cosmos-hub-testnet'
+              "
+              class="tutorial-button"
+              @click="openTutorial()"
+            >
               <i v-if="false" class="material-icons notranslate">
                 help_outline
               </i>

--- a/src/components/staking/PageValidator.vue
+++ b/src/components/staking/PageValidator.vue
@@ -14,7 +14,14 @@
           <i class="material-icons notranslate arrow">arrow_back</i>
           Back to Validators
         </button>
-        <button class="tutorial-button" @click="openTutorial()">
+        <button
+          v-if="
+            connection.network === 'cosmos-hub-mainnet' ||
+              connection.network === 'cosmos-hub-testnet'
+          "
+          class="tutorial-button"
+          @click="openTutorial()"
+        >
           <i v-if="false" class="material-icons notranslate">help_outline</i>
           <span v-else>Want to learn about staking?</span>
         </button>


### PR DESCRIPTION
Closes #3568 

**Description:**

Show tutorial buttons only in cosmos main & testnet. Just it!

Thank you! 🚀

---

For contributor:

- [ ] Added changes entries. Run `yarn changelog` for a guided process.
- [ ] Reviewed `Files changed` in the github PR explorer
- [ ] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI
