### PR TITLE
Improve action modal layout in mobile and extension

### DIFF
--- a/changes/mario_3455-fix-mobile-modal
+++ b/changes/mario_3455-fix-mobile-modal
@@ -1,0 +1,1 @@
+[Fixed] [#3455](https://github.com/cosmos/lunie/issues/3455) Improve action modal layout in mobile and extension @mariopino

--- a/package.json
+++ b/package.json
@@ -143,4 +143,3 @@
     "url": "git+https://github.com/luniehq/lunie.git"
   }
 }
-

--- a/package.json
+++ b/package.json
@@ -143,3 +143,4 @@
     "url": "git+https://github.com/luniehq/lunie.git"
   }
 }
+

--- a/src/styles/session.css
+++ b/src/styles/session.css
@@ -184,10 +184,11 @@
   .session {
     height: 100vh;
     padding: 3rem 1rem 1rem;
+    max-width: 100%;
   }
 
   .session-frame {
-    max-width: 400px;
+    max-width: 100%;
   }
 
   .bottom-indent {


### PR DESCRIPTION
Closes #3455 

**Description:**

Quick fix to improve modal layout behaviour for widths > 560px and < 667px

Before:

![image](https://user-images.githubusercontent.com/9256178/74733707-2a11f200-524d-11ea-82c8-935f29ca8092.png)

After:

![image](https://user-images.githubusercontent.com/9256178/74733736-3eee8580-524d-11ea-8eb8-09029dac3512.png)


Thank you! 🚀

---

For contributor:

- [ ] Added changes entries. Run `yarn changelog` for a guided process.
- [ ] Reviewed `Files changed` in the github PR explorer
- [ ] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI
