### PR TITLE
Fabo/fix send success screen

### DIFF
--- a/changes/develop
+++ b/changes/develop
@@ -1,0 +1,1 @@
+[Fixed] Fix success screen showing different denom in multi denom setup @faboweb

--- a/src/ActionModal/components/SendModal.vue
+++ b/src/ActionModal/components/SendModal.vue
@@ -185,7 +185,7 @@ export default {
     max_memo_characters: 256,
     editMemo: false,
     isFirstLoad: true,
-    selectedToken: ``,
+    selectedToken: undefined,
     balances: [],
     denom: ``
   }),
@@ -242,6 +242,9 @@ export default {
       }
     },
     balances: function(balances) {
+      // if there is already a token selected don't reset it
+      if (this.selectedToken) return
+
       // in case the account has no balances we will display the staking denom received from the denom query
       if (balances.length === 0) {
         this.selectedToken = this.denom


### PR DESCRIPTION
the success screen would show a wrong denom

because it would update the selected denom in the back