### PR TITLE
Ana/delete gas prices dictionary

### DIFF
--- a/changes/ana_remove-gas-prices-dictionary-logic
+++ b/changes/ana_remove-gas-prices-dictionary-logic
@@ -1,0 +1,1 @@
+[Changed] [#3592](https://github.com/cosmos/lunie/pull/3592) Deletes gas prices dictionary in ActionModal @Bitcoinera

--- a/src/ActionModal/components/ActionModal.vue
+++ b/src/ActionModal/components/ActionModal.vue
@@ -288,7 +288,6 @@ import TmDataMsg from "common/TmDataMsg"
 import TableInvoice from "./TableInvoice"
 import Steps from "./Steps"
 import { mapState, mapGetters } from "vuex"
-import { gasPricesDictionary } from "src/scripts/common"
 import { viewDenom, prettyInt } from "src/scripts/num"
 import { between, requiredIf } from "vuelidate/lib/validators"
 import { track, sendEvent } from "scripts/google-analytics"
@@ -499,8 +498,11 @@ export default {
     selectedBalance() {
       const defaultBalance = {
         amount: 0,
-        // awful network-specific logic. But how to do it otherwise?
-        gasPrice: gasPricesDictionary(this.getDenom)
+        gasPrice:
+          this.balances.length > 1
+            ? this.balances.find(({ denom }) => denom === this.getDenom)
+                .gasPrice
+            : 0
       }
       if (this.balances.length === 0 || !this.network) {
         return defaultBalance

--- a/src/ActionModal/components/ActionModal.vue
+++ b/src/ActionModal/components/ActionModal.vue
@@ -504,8 +504,8 @@ export default {
         return defaultBalance
       }
       // default to the staking denom for fees
-      const stakingDenom = this.selectedDenom || this.network.stakingDenom
-      let balance = this.balances.find(({ denom }) => denom === stakingDenom)
+      const feeDenom = this.selectedDenom || this.network.stakingDenom
+      let balance = this.balances.find(({ denom }) => denom === feeDenom)
       if (!balance) {
         balance = defaultBalance
       }

--- a/src/ActionModal/components/ActionModal.vue
+++ b/src/ActionModal/components/ActionModal.vue
@@ -498,20 +498,14 @@ export default {
     selectedBalance() {
       const defaultBalance = {
         amount: 0,
-        gasPrice:
-          this.balances.length > 1
-            ? this.balances.find(({ denom }) => denom === this.getDenom)
-                .gasPrice
-            : 0
+        gasPrice: 4e-7 // the defaultBalance gas price should be the highest we know of to be sure that no transaction gets out of gas
       }
       if (this.balances.length === 0 || !this.network) {
         return defaultBalance
       }
       // default to the staking denom for fees
-      const denom = this.selectedDenom || this.network.stakingDenom
-      let balance = this.balances.find(
-        ({ denom: balanceDenom }) => balanceDenom === denom
-      )
+      const stakingDenom = this.selectedDenom || this.network.stakingDenom
+      let balance = this.balances.find(({ denom }) => denom === stakingDenom)
       if (!balance) {
         balance = defaultBalance
       }

--- a/src/scripts/common.js
+++ b/src/scripts/common.js
@@ -54,13 +54,3 @@ export function toMicroDenom(denom) {
   }
   return lookup[denom] ? lookup[denom] : denom.toLowerCase()
 }
-
-export function gasPricesDictionary(denom) {
-  const lookup = {
-    ATOM: "6.5e-9",
-    MUON: "6.5e-9",
-    LUNA: "6.5e-9",
-    NGM: "4e-7"
-  }
-  return lookup[denom] || `6.5e-9`
-}

--- a/tests/unit/specs/components/ActionModal/components/ActionModal.spec.js
+++ b/tests/unit/specs/components/ActionModal/components/ActionModal.spec.js
@@ -481,7 +481,7 @@ describe(`ActionModal`, () => {
 
     describe(`fails`, () => {
       it(`when the total invoice amount is more than the balance`, () => {
-        wrapper.setProps({ amount: 1211 })
+        wrapper.setProps({ amount: 1211.01 })
         expect(wrapper.vm.isValidInput(`invoiceTotal`)).toBe(false)
       })
     })


### PR DESCRIPTION
Closes #ISSUE

**Description:**

Following @faboweb's wise advice, I saw that actually the `gasPricesDictionary` is not necessary.

Still, I don't know exactly why I had to slightly change a test, but I think it is fine allowing user have 0 fee transactions (when they transact with their whole balance), since they already get a warning.

I don't know why it changed now though 😅 

<!-- Briefly describe what you're adding or fixing with this PR -->

Thank you! 🚀

---

For contributor:

- [x] Added changes entries. Run `yarn changelog` for a guided process.
- [ ] Reviewed `Files changed` in the github PR explorer
- [ ] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI
