### PR TITLE
[Simsala] automatic release created for v1.0.165

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,40 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 <!-- SIMSALA --> <!-- DON'T DELETE, used for automatic changelog updates -->
 
+## [1.0.165] - 2020-02-26
+
+### Added
+
+- adding fingerpring header @iambeone
+- [#3513](https://github.com/cosmos/lunie/issues/3513) sending cancel message to extension on cancel @iambeone
+- [#3565](https://github.com/cosmos/lunie/pull/3565) Now it is possible to pay gas fees in any token (multidenom networks) @Bitcoinera
+- [#3559](https://github.com/cosmos/lunie/pull/3559) Now rewards for multidenom networks are displayed in TmBalance and staking denom is especified in validators' components @Bitcoinera
+
+### Changed
+
+- [#3578](https://github.com/cosmos/lunie/pull/3578) Add new multi denom send denom selection @iambeone
+- Initial activity page load loads only first chunk of all transactions and then after scroll end reached loads more @iambeone
+- [#3553](https://github.com/cosmos/lunie/pull/3553) Adds check in SessionSignIn to verify the signin address belongs to an existing mainnet. Otherwise displays an error message @Bitcoinera
+- [#3583](https://github.com/cosmos/lunie/pull/3583) Adds the isExtension flag for extension @Bitcoinera
+- [#3583](https://github.com/cosmos/lunie/pull/3583) Hides the transaction meta data fold out in the extension @Bitcoinera @faboweb
+
+### Fixed
+
+- [#3580](https://github.com/cosmos/lunie/pull/3580) Fixes the displayed amount in the Claim Rewards modal for multidenom networks @Bitcoinera
+- Fix success screen showing different denom in multi denom setup @faboweb
+- Fix e2e tests failing because it can't find an element for querying for it's text @faboweb
+- [#3455](https://github.com/cosmos/lunie/issues/3455) Improve action modal layout in mobile and extension @mariopino
+- [#3568](https://github.com/cosmos/lunie/issues/3568) Show tutorial buttons only in cosmos main & testnet @mariopino
+
+### Code Improvements
+
+- [#3581](https://github.com/cosmos/lunie/pull/3581) Drops the temporary hack for claim rewards gas prices in e-Money @Bitcoinera
+- remove rpc url from gql @faboweb
+
+### Repository
+
+- updated ios pods @jbibla
+
 ## [1.0.164] - 2020-02-18
 
 ### Added

--- a/changes/aleksei_denom_list_fix
+++ b/changes/aleksei_denom_list_fix
@@ -1,1 +1,0 @@
-[Changed] [#3578](https://github.com/cosmos/lunie/pull/3578) Add new multi denom send denom selection @iambeone

--- a/changes/aleksei_fingerprint_header
+++ b/changes/aleksei_fingerprint_header
@@ -1,1 +1,0 @@
-[Added] adding fingerpring header @iambeone

--- a/changes/aleksei_sending_cancel_message_to_extension
+++ b/changes/aleksei_sending_cancel_message_to_extension
@@ -1,1 +1,0 @@
-[Added] [#3513](https://github.com/cosmos/lunie/issues/3513) sending cancel message to extension on cancel @iambeone

--- a/changes/aleksei_transactions_chunk_loading
+++ b/changes/aleksei_transactions_chunk_loading
@@ -1,1 +1,0 @@
-[Changed] Initial activity page load loads only first chunk of all transactions and then after scroll end reached loads more @iambeone

--- a/changes/ana_add-no-mainnet-for-this-address-found-to-sign-in
+++ b/changes/ana_add-no-mainnet-for-this-address-found-to-sign-in
@@ -1,1 +1,0 @@
-[Changed] [#3553](https://github.com/cosmos/lunie/pull/3553) Adds check in SessionSignIn to verify the signin address belongs to an existing mainnet. Otherwise displays an error message @Bitcoinera

--- a/changes/ana_drop-claim-rewards-gasprice-temporary-hack
+++ b/changes/ana_drop-claim-rewards-gasprice-temporary-hack
@@ -1,1 +1,0 @@
-[Code Improvements] [#3581](https://github.com/cosmos/lunie/pull/3581) Drops the temporary hack for claim rewards gas prices in e-Money @Bitcoinera

--- a/changes/ana_emoney-action-modal
+++ b/changes/ana_emoney-action-modal
@@ -1,1 +1,0 @@
-[Added] [#3565](https://github.com/cosmos/lunie/pull/3565) Now it is possible to pay gas fees in any token (multidenom networks) @Bitcoinera

--- a/changes/ana_emoney-format-rewards
+++ b/changes/ana_emoney-format-rewards
@@ -1,1 +1,0 @@
-[Added] [#3559](https://github.com/cosmos/lunie/pull/3559) Now rewards for multidenom networks are displayed in TmBalance and staking denom is especified in validators' components @Bitcoinera

--- a/changes/ana_fix-emoney-claim-rewards-display-amount
+++ b/changes/ana_fix-emoney-claim-rewards-display-amount
@@ -1,1 +1,0 @@
-[Fixed] [#3580](https://github.com/cosmos/lunie/pull/3580) Fixes the displayed amount in the Claim Rewards modal for multidenom networks @Bitcoinera

--- a/changes/develop
+++ b/changes/develop
@@ -1,1 +1,0 @@
-[Fixed] Fix success screen showing different denom in multi denom setup @faboweb

--- a/changes/fabo_e2e-fix-3
+++ b/changes/fabo_e2e-fix-3
@@ -1,1 +1,0 @@
-[Fixed] Fix e2e tests failing because it can't find an element for querying for it's text @faboweb

--- a/changes/fabo_remove-rpc-url-fromgql
+++ b/changes/fabo_remove-rpc-url-fromgql
@@ -1,1 +1,0 @@
-[Code Improvements] remove rpc url from gql @faboweb

--- a/changes/fix-transaction-item-in-extension
+++ b/changes/fix-transaction-item-in-extension
@@ -1,2 +1,0 @@
-[Changed] [#3583](https://github.com/cosmos/lunie/pull/3583) Adds the isExtension flag for extension @Bitcoinera
-[Changed] [#3583](https://github.com/cosmos/lunie/pull/3583) Hides the transaction meta data fold out in the extension @Bitcoinera @faboweb

--- a/changes/jordan_ios-hot-fix
+++ b/changes/jordan_ios-hot-fix
@@ -1,1 +1,0 @@
-[Repository] updated ios pods @jbibla

--- a/changes/mario_3455-fix-mobile-modal
+++ b/changes/mario_3455-fix-mobile-modal
@@ -1,1 +1,0 @@
-[Fixed] [#3455](https://github.com/cosmos/lunie/issues/3455) Improve action modal layout in mobile and extension @mariopino

--- a/changes/mario_3568-no-tutorial-buttons-when-no-content-available
+++ b/changes/mario_3568-no-tutorial-buttons-when-no-content-available
@@ -1,1 +1,0 @@
-[Fixed] [#3568](https://github.com/cosmos/lunie/issues/3568) Show tutorial buttons only in cosmos main & testnet @mariopino

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lunie",
-  "version": "1.0.164",
+  "version": "1.0.165",
   "description": "Lunie is the staking and governance platform for proof-of-stake blockchains.",
   "author": "Lunie International Software Systems Inc. <hello@lunie.io>",
   "scripts": {


### PR DESCRIPTION
Please manually test before merging this to master

### Added

- adding fingerpring header @iambeone
- [#3513](https://github.com/cosmos/lunie/issues/3513) sending cancel message to extension on cancel @iambeone
- [#3565](https://github.com/cosmos/lunie/pull/3565) Now it is possible to pay gas fees in any token (multidenom networks) @Bitcoinera
- [#3559](https://github.com/cosmos/lunie/pull/3559) Now rewards for multidenom networks are displayed in TmBalance and staking denom is especified in validators' components @Bitcoinera

### Changed

- [#3578](https://github.com/cosmos/lunie/pull/3578) Add new multi denom send denom selection @iambeone
- Initial activity page load loads only first chunk of all transactions and then after scroll end reached loads more @iambeone
- [#3553](https://github.com/cosmos/lunie/pull/3553) Adds check in SessionSignIn to verify the signin address belongs to an existing mainnet. Otherwise displays an error message @Bitcoinera
- [#3583](https://github.com/cosmos/lunie/pull/3583) Adds the isExtension flag for extension @Bitcoinera
- [#3583](https://github.com/cosmos/lunie/pull/3583) Hides the transaction meta data fold out in the extension @Bitcoinera @faboweb

### Fixed

- [#3580](https://github.com/cosmos/lunie/pull/3580) Fixes the displayed amount in the Claim Rewards modal for multidenom networks @Bitcoinera
- Fix success screen showing different denom in multi denom setup @faboweb
- Fix e2e tests failing because it can't find an element for querying for it's text @faboweb
- [#3455](https://github.com/cosmos/lunie/issues/3455) Improve action modal layout in mobile and extension @mariopino
- [#3568](https://github.com/cosmos/lunie/issues/3568) Show tutorial buttons only in cosmos main & testnet @mariopino

### Code Improvements

- [#3581](https://github.com/cosmos/lunie/pull/3581) Drops the temporary hack for claim rewards gas prices in e-Money @Bitcoinera
- remove rpc url from gql @faboweb

### Repository

- updated ios pods @jbibla