### PR TITLE
Ana/fix hanging rewards from old session

### DIFF
--- a/changes/ana_3587-livalidator-component-leaves-data
+++ b/changes/ana_3587-livalidator-component-leaves-data
@@ -1,0 +1,1 @@
+[Fixed] [#3606](https://github.com/cosmos/lunie/pull/3606) Fixes having the rewards from the previous session hanging on TableValidators once the user disconnects @Bitcoinera

--- a/src/components/staking/TableValidators.vue
+++ b/src/components/staking/TableValidators.vue
@@ -110,6 +110,13 @@ export default {
     },
     "sort.order": function() {
       this.showing = 15
+    },
+    address: {
+      handler() {
+        if (!this.address) {
+          this.rewards = []
+        }
+      }
     }
   },
   mounted() {

--- a/tests/unit/specs/components/staking/TableValidators.spec.js
+++ b/tests/unit/specs/components/staking/TableValidators.spec.js
@@ -20,7 +20,7 @@ const validators = [
 ]
 
 describe(`TableValidators`, () => {
-  let wrapper, $apollo
+  let wrapper, $apollo, $store
 
   $apollo = {
     queries: {
@@ -33,13 +33,21 @@ describe(`TableValidators`, () => {
   }
 
   beforeEach(() => {
+    $store = {
+      getters: {
+        address: "cosmo1"
+      },
+      state: {}
+    }
+
     wrapper = shallowMount(TableValidators, {
       propsData: { validators },
       directives: {
         infiniteScroll: () => {}
       },
       mocks: {
-        $apollo
+        $apollo,
+        $store
       }
     })
   })


### PR DESCRIPTION
Closes #3587 

**Description:**

<!-- Briefly describe what you're adding or fixing with this PR -->
Fixes having the rewards from the previous session hanging on TableValidators once the user disconnects.

Thank you! 🚀

---

For contributor:

- [ ] Added changes entries. Run `yarn changelog` for a guided process.
- [ ] Reviewed `Files changed` in the github PR explorer
- [ ] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI
