### PR TITLE
[Simsala] automatic release created for v1.0.166

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 <!-- SIMSALA --> <!-- DON'T DELETE, used for automatic changelog updates -->
 
+## [1.0.166] - 2020-02-26
+
+### Changed
+
+- add fingerprint header to fetch @iambeone
+
+### Fixed
+
+- [#3606](https://github.com/cosmos/lunie/pull/3606) Fixes having the rewards from the previous session hanging on TableValidators once the user disconnects @Bitcoinera
+- Fix publish not triggering as the expected commit message was outdated @faboweb
+- Remove service worker as it produced issues with caching @faboweb
+
 ## [1.0.165] - 2020-02-26
 
 ### Added

--- a/changes/aleksei_add_headers_to_fetch
+++ b/changes/aleksei_add_headers_to_fetch
@@ -1,1 +1,0 @@
-[Changed] add fingerprint header to fetch @iambeone

--- a/changes/ana_3587-livalidator-component-leaves-data
+++ b/changes/ana_3587-livalidator-component-leaves-data
@@ -1,1 +1,0 @@
-[Fixed] [#3606](https://github.com/cosmos/lunie/pull/3606) Fixes having the rewards from the previous session hanging on TableValidators once the user disconnects @Bitcoinera

--- a/changes/fabo_fix-publish
+++ b/changes/fabo_fix-publish
@@ -1,1 +1,0 @@
-[Fixed] Fix publish not triggering as the expected commit message was outdated @faboweb

--- a/changes/fabo_no-op-service-worker
+++ b/changes/fabo_no-op-service-worker
@@ -1,1 +1,0 @@
-[Fixed] Remove service worker as it produced issues with caching @faboweb

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lunie",
-  "version": "1.0.165",
+  "version": "1.0.166",
   "description": "Lunie is the staking and governance platform for proof-of-stake blockchains.",
   "author": "Lunie International Software Systems Inc. <hello@lunie.io>",
   "scripts": {


### PR DESCRIPTION
Please manually test before merging this to master

### Changed

- add fingerprint header to fetch @iambeone

### Fixed

- [#3606](https://github.com/cosmos/lunie/pull/3606) Fixes having the rewards from the previous session hanging on TableValidators once the user disconnects @Bitcoinera
- Fix publish not triggering as the expected commit message was outdated @faboweb
- Remove service worker as it produced issues with caching @faboweb