### PR TITLE
add small check for extension

### DIFF
--- a/changes/ana_add-small-check-for-extension
+++ b/changes/ana_add-small-check-for-extension
@@ -1,0 +1,1 @@
+[Changed] [#3610](https://github.com/cosmos/lunie/pull/3610) Adds a small check in WithdrawRewardsMessageDetails necessary for extension @Bitcoinera

--- a/src/components/transactions/message-view/WithdrawDelegationRewardMessageDetails.vue
+++ b/src/components/transactions/message-view/WithdrawDelegationRewardMessageDetails.vue
@@ -129,7 +129,7 @@ export default {
   },
   computed: {
     getValidators() {
-      if (this.transaction.withdrawValidators) {
+      if (this.transaction.withdrawValidators && this.validators) {
         let validators = []
         JSON.parse(this.transaction.withdrawValidators).forEach(msg => {
           validators.push(this.validators[msg.value.validator_address] || {})


### PR DESCRIPTION
Closes #ISSUE

**Description:**

<!-- Briefly describe what you're adding or fixing with this PR -->
Reviewing Fabo's PR (luniehq/lunie-browser-extension#154) I noticed this simple check was missing in WithdrawRewardsMessageDetails

Thank you! 🚀

---

For contributor:

- [ ] Added changes entries. Run `yarn changelog` for a guided process.
- [ ] Reviewed `Files changed` in the github PR explorer
- [ ] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI
