### PR TITLE
[WIP] Network in URL: sign in fixes

### DIFF
--- a/changes/aleksei_sign-in-fixes
+++ b/changes/aleksei_sign-in-fixes
@@ -1,0 +1,1 @@
+[Fixed] [#3616](https://github.com/cosmos/lunie/pull/3616) Fix routing issues when exploring an account @faboweb

--- a/src/components/common/TmSessionExplore.vue
+++ b/src/components/common/TmSessionExplore.vue
@@ -171,7 +171,7 @@ export default {
       })
 
       localStorage.setItem(`prevAddress`, this.address)
-      this.$router.push(`/`)
+      this.$router.push(`/${this.networkOfAddress.slug}/portfolio`)
     },
     bech32Validate(param) {
       try {

--- a/src/routes.js
+++ b/src/routes.js
@@ -12,8 +12,7 @@ export default (apollo, store) => {
     {
       path: `/`,
       beforeEnter: (to, from, next) =>
-        setNetwork({ to, from, next }, apollo, store),
-      component: () => import(`./components/common/NetworkSetter`)
+        setNetwork({ to, from, next }, apollo, store)
     },
     {
       path: `/networks`,

--- a/src/scripts/setNetwork.js
+++ b/src/scripts/setNetwork.js
@@ -1,5 +1,6 @@
 "use strict"
 import gql from "graphql-tag"
+import * as Sentry from "@sentry/browser"
 
 export const setNetwork = async ({ to, next }, apollo, store) => {
   try {
@@ -78,6 +79,7 @@ export const setNetwork = async ({ to, next }, apollo, store) => {
     }
   } catch (error) {
     console.error("Failed to set network from URL", error)
+    Sentry.captureException(error)
   }
 }
 

--- a/src/scripts/setNetwork.js
+++ b/src/scripts/setNetwork.js
@@ -2,78 +2,82 @@
 import gql from "graphql-tag"
 
 export const setNetwork = async ({ to, next }, apollo, store) => {
-  const {
-    data: { networks }
-  } = await apollo.query({
-    query: gql`
-      query Networks {
-        networks {
-          slug
-          id
-          default
+  try {
+    const {
+      data: { networks }
+    } = await apollo.query({
+      query: gql`
+        query Networks {
+          networks {
+            slug
+            id
+            default
+          }
         }
-      }
-    `,
-    fetchPolicy: "cache-first"
-  })
-  let path = to.path
-  if (path === "/") {
-    path = "/portfolio"
-  }
-
-  // if the url is of the form /cosmos-hub/portfolio the path we want to add later is /portfolio and not the whole thing
-  if (to.params.networkId) {
-    const subPathRegexp = /\/.+(\/.+)/ //extracts the subpath
-    const match = subPathRegexp.exec(to.path)
-    if (match && match.length >= 2) {
-      // the path is is of form /cosmos-hub/portfolio
-      path = match[1]
-    } else {
-      // the path is is of form /cosmos-hub so we forward to portfolio
+      `,
+      fetchPolicy: "cache-first"
+    })
+    let path = to.path
+    if (path === "/") {
       path = "/portfolio"
     }
-  }
 
-  // current network slug
-  let network
-  if (
-    to.params.networkId &&
-    store.state.connection.networkSlug === to.params.networkId
-  ) {
-    next() // all as expected
-    return
-  }
-  // desired network is different then current
-  if (
-    to.params.networkId &&
-    store.state.connection.networkSlug !== to.params.networkId
-  ) {
-    // setting new network
-    network = networkChecker(
-      networks.find(network => network.slug === to.params.networkId),
-      networks
-    )
+    // if the url is of the form /cosmos-hub/portfolio the path we want to add later is /portfolio and not the whole thing
+    if (to.params.networkId) {
+      const subPathRegexp = /\/.+(\/.+)/ //extracts the subpath
+      const match = subPathRegexp.exec(to.path)
+      if (match && match.length >= 2) {
+        // the path is is of form /cosmos-hub/portfolio
+        path = match[1]
+      } else {
+        // the path is is of form /cosmos-hub so we forward to portfolio
+        path = "/portfolio"
+      }
+    }
 
-    store.dispatch(`setNetwork`, network)
-    // next(`/${network.slug}${path}`)
-  }
-  // no network is set so we set the default
-  if (!to.params.networkId) {
-    // swithing to current network
-    if (store.state.connection.networkSlug) {
+    // current network slug
+    let network
+    if (
+      to.params.networkId &&
+      store.state.connection.networkSlug === to.params.networkId
+    ) {
+      next() // all as expected
+      return
+    }
+
+    // desired network is different then current
+    if (
+      to.params.networkId &&
+      store.state.connection.networkSlug !== to.params.networkId
+    ) {
+      // setting new network
       network = networkChecker(
-        networks.find(
-          network => network.slug === store.state.connection.networkSlug
-        ),
+        networks.find(network => network.slug === to.params.networkId),
         networks
       )
 
+      next(`/${network.slug}${path}`)
       store.dispatch(`setNetwork`, network)
-      next(`/${network.slug}${path}`)
-    } else {
-      network = networks.find(network => network.default === true)
-      next(`/${network.slug}${path}`)
     }
+    // no network is set so we set the default
+    if (!to.params.networkId || to.params.networkId === "default") {
+      // swithing to current network
+      if (store.state.connection.networkSlug) {
+        network = networkChecker(
+          networks.find(
+            network => network.slug === store.state.connection.networkSlug
+          ),
+          networks
+        )
+      } else {
+        network = networks.find(network => network.default === true)
+      }
+
+      next(`/${network.slug}${path}`)
+      store.dispatch(`setNetwork`, network)
+    }
+  } catch (error) {
+    console.error("Failed to set network from URL", error)
   }
 }
 

--- a/src/scripts/setNetwork.js
+++ b/src/scripts/setNetwork.js
@@ -55,7 +55,7 @@ export const setNetwork = async ({ to, next }, apollo, store) => {
     )
 
     store.dispatch(`setNetwork`, network)
-    next(`/${network.slug}${path}`)
+    // next(`/${network.slug}${path}`)
   }
   // no network is set so we set the default
   if (!to.params.networkId) {

--- a/tests/unit/specs/components/common/TmSessionExplore.spec.js
+++ b/tests/unit/specs/components/common/TmSessionExplore.spec.js
@@ -73,7 +73,8 @@ describe(`TmSessionExplore`, () => {
         {
           id: "cosmos-hub-testnet",
           address_prefix: "cosmos",
-          testnet: false
+          testnet: false,
+          slug: "cosmos-hub"
         }
       ]
     })
@@ -89,7 +90,9 @@ describe(`TmSessionExplore`, () => {
     })
     wrapper.vm.$emit = jest.fn()
     await wrapper.vm.onSubmit()
-    expect(wrapper.vm.$router.push).toHaveBeenCalledWith(`/`)
+    expect(wrapper.vm.$router.push).toHaveBeenCalledWith(
+      `/cosmos-hub/portfolio`
+    )
   })
 
   it(`should signal signedin state on successful login`, async () => {


### PR DESCRIPTION
Closes #ISSUE

**Description:**

<!-- Briefly describe what you're adding or fixing with this PR -->
Sign in routing is still not working great yet.

This PR is to try to fix all of the current bugs.

List of current bugs:

- [] Extension Signin is not working anymore properly (although with the fix here it is, if you click twice in the 'Use account' button 😆 
- [] If you sign in with a Lunie account or in Explore mode, you get an `uncaught Promise` error displayed in the console. 
- [] Persisted accounts automatic signin doesn't seem to be working properly. Connecting to cosmos-hub-3 network I am getting automatically connected to an emoney account. 
- [] `toString()` of undefined after hitting the "Back to Lunie" button


Thank you! 🚀

---

For contributor:

- [ ] Added changes entries. Run `yarn changelog` for a guided process.
- [ ] Reviewed `Files changed` in the github PR explorer
- [ ] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI
