### PR TITLE
Jordan/3489 intercom

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,10 +132,10 @@ Dependencies:
 To open Lunie in Xcode: 
 1. Build Lunie
 ```bash
-$ npm run build
+$ yarn build:mobile
 ```
 
-2. This step may take up to 20 minutes to complete if you've never used Cocoapods before.
+2. After a new build, you need to run the following command. This step may take up to 20 minutes to complete if you've never used Cocoapods before.
 ```bash
 $ npx cap sync ios
 ```
@@ -146,14 +146,6 @@ $ npx cap open ios
 ```
 
 Once Xcode is open, just click the Play button to run Lunie on your preferred Simulator or Device.
-
-## Release
-
-Lunie has a automated release process. Every night the CI creates a new release PR. To release manually, run
-
-```bash
-npm run release
-```
 
 ## Testing
 

--- a/changes/jordan_3489-intercom
+++ b/changes/jordan_3489-intercom
@@ -1,0 +1,1 @@
+[Fixed] [#3489](https://github.com/cosmos/lunie/issues/3489) now we register users for the intercom messenger before the messenger is opened to ensure the messenger doesn't fail @jbibla

--- a/src/vuex/modules/intercom.js
+++ b/src/vuex/modules/intercom.js
@@ -17,9 +17,7 @@ export default () => {
       displayMessenger({ state }) {
         if (state.mobileApp) {
           // we have to register users otherwise intercom will not open
-          state.intercom.registerIdentifiedUser({
-            userId: `lunie-app-${Math.floor(Math.random() * 10000 + 1).toString()}`
-          })
+          state.intercom.registerUnidentifiedUser();
           state.intercom.displayMessenger()
         }
       }

--- a/src/vuex/modules/intercom.js
+++ b/src/vuex/modules/intercom.js
@@ -15,7 +15,13 @@ export default () => {
     },
     actions: {
       displayMessenger({ state }) {
-        if (state.mobileApp) state.intercom.displayMessenger()
+        if (state.mobileApp) {
+          // we have to register users otherwise intercom will not open
+          state.intercom.registerIdentifiedUser({
+            userId: `lunie-app-${Math.floor(Math.random() * 10000 + 1).toString()}`
+          })
+          state.intercom.displayMessenger()
+        }
       }
     }
   }

--- a/tests/unit/specs/store/intercom.spec.js
+++ b/tests/unit/specs/store/intercom.spec.js
@@ -5,6 +5,7 @@ describe(`Module: Intercom`, () => {
   let module, state, actions, node
 
   const intercom = {
+    registerUnidentifiedUser: jest.fn(),
     displayMessenger: jest.fn()
   }
 


### PR DESCRIPTION
Closes #3489

**Description:**
- it is necessary to register users with intercom before opening the mobile messenger. i can confirm this works on my local xcode and assume the fix will work on Android and iOS devices
<!-- Briefly describe what you're adding or fixing with this PR -->

Thank you! 🚀

---

For contributor:

- [x] Added changes entries. Run `yarn changelog` for a guided process.
- [x] Reviewed `Files changed` in the github PR explorer
- [ ] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI
