### PR TITLE
Ana/claim rewards display amount now for real

### DIFF
--- a/changes/ana_claimrewards-display-amount-in-activity
+++ b/changes/ana_claimrewards-display-amount-in-activity
@@ -1,0 +1,1 @@
+[Changed] [#3661](https://github.com/cosmos/lunie/pull/3661) Now amounts are displayed in the TransactionItem component for all ClaimRewards transactions @Bitcoinera

--- a/src/components/transactions/message-view/ClaimRewardsTxDetails.vue
+++ b/src/components/transactions/message-view/ClaimRewardsTxDetails.vue
@@ -29,7 +29,10 @@
         </div>
       </div>
       <div class="tx__content__right">
-        <p class="amount"></p>
+        <p class="amount">
+          {{ transaction.details.amount.amount | prettyLong }}&nbsp;
+          {{ transaction.details.amount.denom }}
+        </p>
       </div>
     </template>
     <template
@@ -83,7 +86,10 @@
         </div>
       </div>
       <div class="tx__content__right">
-        <p class="amount"></p>
+        <p class="amount">
+          {{ transaction.details.amount.amount | prettyLong }}&nbsp;
+          {{ transaction.details.amount.denom }}
+        </p>
       </div>
     </template>
   </div>

--- a/tests/unit/specs/components/transactions/message-view/__snapshots__/ClaimRewardsTxDetails.spec.js.snap
+++ b/tests/unit/specs/components/transactions/message-view/__snapshots__/ClaimRewardsTxDetails.spec.js.snap
@@ -45,7 +45,12 @@ exports[`ClaimRewardsTxDetails renders a claim rewards transaction message 1`] =
   >
     <p
       class="amount"
-    />
+    >
+      
+        10 
+        ATOM
+      
+    </p>
   </div>
    
   <!---->
@@ -148,7 +153,12 @@ exports[`ClaimRewardsTxDetails renders a multi claim rewards transaction message
   >
     <p
       class="amount"
-    />
+    >
+      
+        3 
+        ATOM
+      
+    </p>
   </div>
 </div>
 `;


### PR DESCRIPTION
Closes #ISSUE

**Description:**

<!-- Briefly describe what you're adding or fixing with this PR -->
Somehow this wasn't in yet. I also don't understand what has happened here. Probably I just forgot, since I believe I'm the last one who worked on this component.

In any case, really easy fix. Now amounts are displayed for real in Activity for ClaimRewards transactions.

![image](https://user-images.githubusercontent.com/40721795/76232031-67531980-6226-11ea-9832-b89ead070618.png)




Thank you! 🚀

---

For contributor:

- [x] Added changes entries. Run `yarn changelog` for a guided process.
- [ ] Reviewed `Files changed` in the github PR explorer
- [ ] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI
