### PR TITLE
Ana/claim any token rewards

### DIFF
--- a/changes/ana_claim-any-token-rewards
+++ b/changes/ana_claim-any-token-rewards
@@ -1,0 +1,1 @@
+[Changed] [#3662](https://github.com/cosmos/lunie/pull/3662) Now it is possible to claim rewards from any token despite not having any staking denom reward @Bitcoinera

--- a/changes/ana_claim-any-token-rewards
+++ b/changes/ana_claim-any-token-rewards
@@ -1,1 +1,2 @@
 [Changed] [#3662](https://github.com/cosmos/lunie/pull/3662) Now it is possible to claim rewards from any token despite not having any staking denom reward @Bitcoinera
+[Changed] [#3662](https://github.com/cosmos/lunie/pull/3662) Now to pay fees in Claim Rewards, if there is no staking denom balance available fees will be paid in the token we are claiming rewards from @Bitcoinera

--- a/src/ActionModal/components/ActionModal.vue
+++ b/src/ActionModal/components/ActionModal.vue
@@ -737,7 +737,9 @@ export default {
         "Action",
         "Modal",
         this.featureFlag,
-        this.featureFlag == "claim_rewards"
+        this.featureFlag == "claim_rewards" &&
+          this.rewards &&
+          this.rewards.length > 0
           ? this.rewards[0].amount
           : this.amount
       )

--- a/src/ActionModal/components/ModalWithdrawRewards.vue
+++ b/src/ActionModal/components/ModalWithdrawRewards.vue
@@ -20,7 +20,7 @@
       field-id="amount"
       field-label="Amount"
     >
-      <span class="input-suffix">{{ denom }}</span>
+      <span class="input-suffix">{{ claimedReward.denom }}</span>
       <TmField
         id="amount"
         v-model="totalRewards"
@@ -63,10 +63,11 @@ export default {
       }
     },
     totalRewards() {
-      return this.rewards
+      const stakingRewards = this.rewards
         .filter(({ denom }) => denom === this.denom)
         .reduce((sum, { amount }) => sum + Number(amount), 0)
         .toFixed(6)
+      return stakingRewards > 0 ? stakingRewards : this.claimedReward.amount
     },
     notifyMessage() {
       return {
@@ -76,6 +77,17 @@ export default {
     },
     validatorsWithRewards() {
       return this.rewards.length > 0
+    },
+    claimedReward() {
+      if (this.denom && this.rewards && this.rewards.length > 0) {
+        return (
+          this.rewards.filter(
+            reward => reward.denom === this.denom && reward.amount > 0
+          )[0] || this.rewards.filter(reward => reward.amount > 0)[0]
+        )
+      } else {
+        return ""
+      }
     }
   },
   methods: {

--- a/src/components/common/TmBalance.vue
+++ b/src/components/common/TmBalance.vue
@@ -299,7 +299,7 @@ export default {
     // only be ready to withdraw of the validator rewards are loaded and the user has rewards to withdraw
     // the validator rewards are needed to filter the top 5 validators to withdraw from
     readyToWithdraw() {
-      return this.overview.totalRewards > 0
+      return this.balances.find(balance => balance.amount > 0)
     },
     stakingBalance() {
       return this.balances.find(({ denom }) => denom === this.stakingDenom)

--- a/src/components/common/TmBalance.vue
+++ b/src/components/common/TmBalance.vue
@@ -20,7 +20,11 @@
               </h2>
             </div>
             <div
-              v-if="isMultiDenomNetwork && stakingBalance.fiatValue"
+              v-if="
+                isMultiDenomNetwork &&
+                  stakingBalance &&
+                  stakingBalance.fiatValue
+              "
               class="currency-selector"
             >
               <img
@@ -112,6 +116,7 @@
                     <span
                       v-if="
                         isMultiDenomNetwork &&
+                          stakingBalance &&
                           stakingBalance.fiatValue &&
                           stakingBalance.fiatValue.amount > 0 &&
                           preferredCurrency
@@ -171,7 +176,8 @@
                   </div>
                   <div
                     v-if="
-                      balance.fiatValue &&
+                      balance &&
+                        balance.fiatValue &&
                         balance.fiatValue.amount > 0 &&
                         preferredCurrency
                     "

--- a/src/components/common/TmBalance.vue
+++ b/src/components/common/TmBalance.vue
@@ -305,7 +305,9 @@ export default {
     // only be ready to withdraw of the validator rewards are loaded and the user has rewards to withdraw
     // the validator rewards are needed to filter the top 5 validators to withdraw from
     readyToWithdraw() {
-      return this.overview.rewards ? this.overview.rewards(reward => reward.amount > 0) : null
+      return this.overview.rewards
+        ? this.overview.rewards.find(reward => reward.amount > 0.001)
+        : null
     },
     stakingBalance() {
       return this.balances.find(({ denom }) => denom === this.stakingDenom)

--- a/src/components/common/TmBalance.vue
+++ b/src/components/common/TmBalance.vue
@@ -305,9 +305,16 @@ export default {
     // only be ready to withdraw of the validator rewards are loaded and the user has rewards to withdraw
     // the validator rewards are needed to filter the top 5 validators to withdraw from
     readyToWithdraw() {
-      return this.overview.rewards
-        ? this.overview.rewards.find(reward => reward.amount > 0) // from the UX perspective this should be greater than 0.001, since we only display rewards from that value on
-        : null
+      if (this.overview.rewards && this.overview.rewards.length > 0) {
+        const allTotalRewards = this.overview.rewards.map(reward =>
+          this.calculateTotalRewardsDenom(reward.denom)
+        )
+        return allTotalRewards.length > 0
+          ? allTotalRewards.find(reward => parseFloat(reward) > 0.001)
+          : null
+      } else {
+        return null
+      }
     },
     stakingBalance() {
       return this.balances.find(({ denom }) => denom === this.stakingDenom)

--- a/src/components/common/TmBalance.vue
+++ b/src/components/common/TmBalance.vue
@@ -305,7 +305,7 @@ export default {
     // only be ready to withdraw of the validator rewards are loaded and the user has rewards to withdraw
     // the validator rewards are needed to filter the top 5 validators to withdraw from
     readyToWithdraw() {
-      return this.balances.find(balance => balance.amount > 0)
+      return this.overview.rewards ? this.overview.rewards(reward => reward.amount > 0) : null
     },
     stakingBalance() {
       return this.balances.find(({ denom }) => denom === this.stakingDenom)

--- a/src/components/common/TmBalance.vue
+++ b/src/components/common/TmBalance.vue
@@ -306,7 +306,7 @@ export default {
     // the validator rewards are needed to filter the top 5 validators to withdraw from
     readyToWithdraw() {
       return this.overview.rewards
-        ? this.overview.rewards.find(reward => reward.amount > 0.001)
+        ? this.overview.rewards.find(reward => reward.amount > 0) // from the UX perspective this should be greater than 0.001, since we only display rewards from that value on
         : null
     },
     stakingBalance() {

--- a/tests/unit/specs/components/ActionModal/components/__snapshots__/ModalWithdrawRewards.spec.js.snap
+++ b/tests/unit/specs/components/ActionModal/components/__snapshots__/ModalWithdrawRewards.spec.js.snap
@@ -29,18 +29,13 @@ exports[`ModalWithdrawRewards should show the withdraw rewards modal 1`] = `
     fieldid="amount"
     fieldlabel="Amount"
   >
-    <span
-      class="input-suffix"
-    >
-      
-    </span>
+    <!---->
      
     <tmfield-stub
       class="tm-field-addon"
       disabled="disabled"
       id="amount"
       type="number"
-      value="0.000000"
     />
   </tmformgroup-stub>
 </actionmodal-stub>

--- a/tests/unit/specs/components/common/TmBalance.spec.js
+++ b/tests/unit/specs/components/common/TmBalance.spec.js
@@ -102,7 +102,8 @@ describe(`TmBalance`, () => {
   it(`disables claim rewards button when no rewards`, () => {
     wrapper.setData({
       overview: {
-        totalRewards: 0
+        totalRewards: 0,
+        rewards: []
       }
     })
     const $refs = { ModalWithdrawRewards: { open: jest.fn() } }

--- a/tests/unit/specs/components/common/__snapshots__/TmBalance.spec.js.snap
+++ b/tests/unit/specs/components/common/__snapshots__/TmBalance.spec.js.snap
@@ -70,7 +70,6 @@ exports[`TmBalance do not show available atoms when the user has none in the fir
        
       <tmbtn-stub
         class="withdraw-rewards"
-        disabled="true"
         id="withdraw-btn"
         value="Claim Rewards"
       />


### PR DESCRIPTION
Closes #ISSUE

**Description:**

<!-- Briefly describe what you're adding or fixing with this PR -->
Enable claiming rewards from any token, even when there is not staking denom reward.

Also adds a logic where by default we pay fees with the staking denom for claim rewards (like it was before) but, in case there is no available balance for the staking denom, then we will pay fees with the token we are claiming rewards from.

Of course, changes readyToWithdraw too in TmBalance.

I can split this PR if it is more convenient.

Thank you! 🚀

---

For contributor:

- [ ] Added changes entries. Run `yarn changelog` for a guided process.
- [ ] Reviewed `Files changed` in the github PR explorer
- [ ] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI
