### PR TITLE
Ana/allow use any token to pay fee in Claim Rewards

### DIFF
--- a/changes/ana_claim-rewards-fee-can-be-any-token
+++ b/changes/ana_claim-rewards-fee-can-be-any-token
@@ -1,0 +1,1 @@
+[Changed] [#3664](https://github.com/cosmos/lunie/pull/3664) Now to pay fees in Claim Rewards, if there is no staking denom balance available, fees will be paid in the first token with positive balance @Bitcoinera

--- a/src/ActionModal/components/ModalWithdrawRewards.vue
+++ b/src/ActionModal/components/ModalWithdrawRewards.vue
@@ -4,6 +4,7 @@
     ref="actionModal"
     :transaction-data="transactionData"
     :notify-message="notifyMessage"
+    :selected-denom="feeDenom"
     title="Claim Rewards"
     class="modal-withdraw-rewards"
     submission-error-prefix="Withdrawal failed"
@@ -53,7 +54,8 @@ export default {
     fullDecimals
   },
   data: () => ({
-    rewards: []
+    rewards: [],
+    balances: []
   }),
   computed: {
     ...mapGetters([`address`, `network`]),
@@ -76,6 +78,20 @@ export default {
     },
     validatorsWithRewards() {
       return this.rewards.length > 0
+    },
+    feeDenom() {
+      // since it is cheaper to pay fees with the staking denom (at least in Tendermint), we return this denom
+      // as default if there is any available balance. Otherwise, we return the first balance over 0
+      // TODO: change to be preferrably the same token that is shown as claimed, although not so important
+      if (this.balances && this.balances.length > 0) {
+        return this.balances.filter(({ denom }) => denom === this.denom)[0] &&
+          this.balances.filter(({ denom }) => denom === this.denom)[0].amount >
+            0
+          ? this.denom
+          : this.balances.filter(({ amount }) => amount > 0)[0].denom
+      } else {
+        return this.denom
+      }
     }
   },
   methods: {
@@ -106,6 +122,28 @@ export default {
       /* istanbul ignore next */
       update(data) {
         return data.rewards
+      },
+      /* istanbul ignore next */
+      skip() {
+        return !this.address
+      }
+    },
+    balances: {
+      query: gql`
+        query balances($networkId: String!, $address: String!) {
+          balances(networkId: $networkId, address: $address) {
+            denom
+            amount
+            gasPrice
+          }
+        }
+      `,
+      /* istanbul ignore next */
+      variables() {
+        return {
+          networkId: this.network,
+          address: this.address
+        }
       },
       /* istanbul ignore next */
       skip() {

--- a/src/ActionModal/components/ModalWithdrawRewards.vue
+++ b/src/ActionModal/components/ModalWithdrawRewards.vue
@@ -84,12 +84,13 @@ export default {
       // as default if there is any available balance. Otherwise, we return the first balance over 0
       // TODO: change to be preferrably the same token that is shown as claimed, although not so important
       if (this.balances && this.balances.length > 0) {
-        const stakingDenomBalance = this.balances.filter(
+        const nonZeroBalances = this.balances.filter(({ amount }) => amount > 0)
+        const stakingDenomBalance = nonZeroBalances.find(
           ({ denom }) => denom === this.denom
-        )[0]
-        return stakingDenomBalance && stakingDenomBalance.amount > 0
-          ? this.denom
-          : this.balances.filter(({ amount }) => amount > 0)[0].denom
+        )
+        return stakingDenomBalance
+          ? stakingDenomBalance.denom
+          : nonZeroBalances[0].denom
       } else {
         return this.denom
       }

--- a/src/ActionModal/components/ModalWithdrawRewards.vue
+++ b/src/ActionModal/components/ModalWithdrawRewards.vue
@@ -84,9 +84,10 @@ export default {
       // as default if there is any available balance. Otherwise, we return the first balance over 0
       // TODO: change to be preferrably the same token that is shown as claimed, although not so important
       if (this.balances && this.balances.length > 0) {
-        return this.balances.filter(({ denom }) => denom === this.denom)[0] &&
-          this.balances.filter(({ denom }) => denom === this.denom)[0].amount >
-            0
+        const stakingDenomBalance = this.balances.filter(
+          ({ denom }) => denom === this.denom
+        )[0]
+        return stakingDenomBalance && stakingDenomBalance.amount > 0
           ? this.denom
           : this.balances.filter(({ amount }) => amount > 0)[0].denom
       } else {

--- a/src/ActionModal/components/ModalWithdrawRewards.vue
+++ b/src/ActionModal/components/ModalWithdrawRewards.vue
@@ -90,7 +90,7 @@ export default {
         )
         return stakingDenomBalance
           ? stakingDenomBalance.denom
-          : nonZeroBalances[0].denom
+          : nonZeroBalances.length > 0 ? nonZeroBalances[0].denom : this.denom
       } else {
         return this.denom
       }

--- a/tests/unit/specs/components/ActionModal/components/ModalWithdrawRewards.spec.js
+++ b/tests/unit/specs/components/ActionModal/components/ModalWithdrawRewards.spec.js
@@ -56,6 +56,40 @@ describe(`ModalWithdrawRewards`, () => {
     expect(wrapper.find(`.withdraw-limit`).exists()).toBe(true)
   })
 
+  it(`should return the staking denom if staking denom has any available balance`, () => {
+    const self = {
+      balances: [
+        {
+          denom: "STAKE",
+          amount: 1
+        }
+      ]
+    }
+    const feeDenom = ModalWithdrawRewards.computed.feeDenom.call(self)
+    expect(feeDenom).toEqual(`STAKE`)
+  })
+
+  it(`should return the first balance denom in the balances array with available balance if staking denom has no available balance`, () => {
+    const self = {
+      balances: [
+        {
+          denom: "STAKE",
+          amount: 0
+        },
+        {
+          denom: "TOKEN",
+          amount: 0
+        },
+        {
+          denom: "TOKEN2",
+          amount: 1
+        }
+      ]
+    }
+    const feeDenom = ModalWithdrawRewards.computed.feeDenom.call(self)
+    expect(feeDenom).toEqual(`TOKEN2`)
+  })
+
   describe("Submission Data for Delegating", () => {
     it("should return correct transaction data for delegating", () => {
       expect(wrapper.vm.transactionData).toEqual({


### PR DESCRIPTION
Closes #ISSUE

**Description:**

<!-- Briefly describe what you're adding or fixing with this PR -->
Now if there is no available balance of the staking denom users can still pay fees in Claim Rewards with any other token.

Second and last part of the splitted #3662 

Thank you! 🚀

---

For contributor:

- [ ] Added changes entries. Run `yarn changelog` for a guided process.
- [ ] Reviewed `Files changed` in the github PR explorer
- [ ] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI
