### PR TITLE
[Simsala] automatic release created for v1.0.173

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,33 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 <!-- SIMSALA --> <!-- DON'T DELETE, used for automatic changelog updates -->
 
+## [1.0.173] - 2020-03-11
+
+### Changed
+
+- [#3649](https://github.com/cosmos/lunie/pull/3649) Now the memo field is always displayed on SendModal @Bitcoinera
+- [#3664](https://github.com/cosmos/lunie/pull/3664) Now to pay fees in Claim Rewards, if there is no staking denom balance available, fees will be paid in the first token with positive balance @Bitcoinera
+- [#3663](https://github.com/cosmos/lunie/pull/3663) Now it is possible to claim rewards from any token despite not having any staking denom reward @Bitcoinera
+- [#3661](https://github.com/cosmos/lunie/pull/3661) Now amounts are displayed in the TransactionItem component for all ClaimRewards transactions @Bitcoinera
+- [#3658](https://github.com/cosmos/lunie/pull/3658) Filters all "Unknown" transactions in PageBlock @Bitcoinera
+- [#3657](https://github.com/cosmos/lunie/pull/3657) For Terra networks it changes the fee for an action according to the amount of tokens being handled. Fix in ActionModal @Bitcoinera
+
+### Fixed
+
+- [#3650](https://github.com/cosmos/lunie/pull/3650) Fixes the Back to Lunie button @Bitcoinera
+- [#3665](https://github.com/cosmos/lunie/pull/3665) Handles checks in TmBalance when balances are not yet loaded @Bitcoinera
+- [#3653](https://github.com/cosmos/lunie/pull/3653) Fixes the PoweredBy component inside the NetworkItem @Bitcoinera
+- [#3669](https://github.com/cosmos/lunie/pull/3669) Fix concat property of undefined in ClaimRewardsTxDetails as it now wait for getValidators array to be filled @Bitcoinera
+- [#3659](https://github.com/cosmos/lunie/pull/3659) Fix signin routing with Ledger @Bitcoinera
+- [#3656](https://github.com/cosmos/lunie/pull/3656) Fixes Terra microdenoms in the toMicroDenom function @Bitcoinera
+- [#3651](https://github.com/cosmos/lunie/pull/3651) Fixes all the signins and signup routing @Bitcoinera
+- [##3666](https://github.com/cosmos/lunie/issues/#3666) fixed css bug width set to 1023px @jrmoreau
+
+### Repository
+
+- sending sourcemaps to sentry @iambeone
+- netlify config for production build @iambeone
+
 ## [1.0.172] - 2020-03-05
 
 ### Added

--- a/changes/aleksei_sentry_sourcemaps
+++ b/changes/aleksei_sentry_sourcemaps
@@ -1,1 +1,0 @@
-[Repository] sending sourcemaps to sentry @iambeone

--- a/changes/aleksie_netlify_config_created
+++ b/changes/aleksie_netlify_config_created
@@ -1,1 +1,0 @@
-[Repository] netlify config for production build @iambeone

--- a/changes/ana_always-display-memo
+++ b/changes/ana_always-display-memo
@@ -1,1 +1,0 @@
-[Changed] [#3649](https://github.com/cosmos/lunie/pull/3649) Now the memo field is always displayed on SendModal @Bitcoinera

--- a/changes/ana_claim-rewards-fee-can-be-any-token
+++ b/changes/ana_claim-rewards-fee-can-be-any-token
@@ -1,1 +1,0 @@
-[Changed] [#3664](https://github.com/cosmos/lunie/pull/3664) Now to pay fees in Claim Rewards, if there is no staking denom balance available, fees will be paid in the first token with positive balance @Bitcoinera

--- a/changes/ana_claim-rewards-from-any-token
+++ b/changes/ana_claim-rewards-from-any-token
@@ -1,1 +1,0 @@
-[Changed] [#3663](https://github.com/cosmos/lunie/pull/3663) Now it is possible to claim rewards from any token despite not having any staking denom reward @Bitcoinera

--- a/changes/ana_claimrewards-display-amount-in-activity
+++ b/changes/ana_claimrewards-display-amount-in-activity
@@ -1,1 +1,0 @@
-[Changed] [#3661](https://github.com/cosmos/lunie/pull/3661) Now amounts are displayed in the TransactionItem component for all ClaimRewards transactions @Bitcoinera

--- a/changes/ana_filter-out-unknown-transactions-in-block
+++ b/changes/ana_filter-out-unknown-transactions-in-block
@@ -1,1 +1,0 @@
-[Changed] [#3658](https://github.com/cosmos/lunie/pull/3658) Filters all "Unknown" transactions in PageBlock @Bitcoinera

--- a/changes/ana_fix-back-to-lunie-button
+++ b/changes/ana_fix-back-to-lunie-button
@@ -1,1 +1,0 @@
-[Fixed] [#3650](https://github.com/cosmos/lunie/pull/3650) Fixes the Back to Lunie button @Bitcoinera

--- a/changes/ana_fix-broken-terra-portfolio
+++ b/changes/ana_fix-broken-terra-portfolio
@@ -1,1 +1,0 @@
-[Fixed] [#3665](https://github.com/cosmos/lunie/pull/3665) Handles checks in TmBalance when balances are not yet loaded @Bitcoinera

--- a/changes/ana_fix-poweredby-not-being-displayed
+++ b/changes/ana_fix-poweredby-not-being-displayed
@@ -1,1 +1,0 @@
-[Fixed] [#3653](https://github.com/cosmos/lunie/pull/3653) Fixes the PoweredBy component inside the NetworkItem @Bitcoinera

--- a/changes/ana_fix-property-concat-of-undefined
+++ b/changes/ana_fix-property-concat-of-undefined
@@ -1,1 +1,0 @@
-[Fixed] [#3669](https://github.com/cosmos/lunie/pull/3669) Fix concat property of undefined in ClaimRewardsTxDetails as it now wait for getValidators array to be filled @Bitcoinera

--- a/changes/ana_fix-signin-routing-with-ledger
+++ b/changes/ana_fix-signin-routing-with-ledger
@@ -1,1 +1,0 @@
-[Fixed] [#3659](https://github.com/cosmos/lunie/pull/3659) Fix signin routing with Ledger @Bitcoinera

--- a/changes/ana_fix-terra-fee-amount-the-hacky-way
+++ b/changes/ana_fix-terra-fee-amount-the-hacky-way
@@ -1,1 +1,0 @@
-[Changed] [#3657](https://github.com/cosmos/lunie/pull/3657) For Terra networks it changes the fee for an action according to the amount of tokens being handled. Fix in ActionModal @Bitcoinera

--- a/changes/ana_fix-terra-tokens-microdenoms
+++ b/changes/ana_fix-terra-tokens-microdenoms
@@ -1,1 +1,0 @@
-[Fixed] [#3656](https://github.com/cosmos/lunie/pull/3656) Fixes Terra microdenoms in the toMicroDenom function @Bitcoinera

--- a/changes/ana_fix-uncaught-in-promise-after-signins
+++ b/changes/ana_fix-uncaught-in-promise-after-signins
@@ -1,1 +1,0 @@
-[Fixed] [#3651](https://github.com/cosmos/lunie/pull/3651) Fixes all the signins and signup routing @Bitcoinera

--- a/changes/james_change-pixel
+++ b/changes/james_change-pixel
@@ -1,1 +1,0 @@
-[Fixed] [##3666](https://github.com/cosmos/lunie/issues/#3666) fixed css bug width set to 1023px @jrmoreau

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lunie",
-  "version": "1.0.172",
+  "version": "1.0.173",
   "description": "Lunie is the staking and governance platform for proof-of-stake blockchains.",
   "author": "Lunie International Software Systems Inc. <hello@lunie.io>",
   "scripts": {

--- a/src/ActionModal/components/ModalWithdrawRewards.vue
+++ b/src/ActionModal/components/ModalWithdrawRewards.vue
@@ -107,7 +107,9 @@ export default {
         )
         return stakingDenomBalance
           ? stakingDenomBalance.denom
-          : nonZeroBalances.length > 0 ? nonZeroBalances[0].denom : this.denom
+          : nonZeroBalances.length > 0
+          ? nonZeroBalances[0].denom
+          : this.denom
       } else {
         return this.denom
       }


### PR DESCRIPTION
Please manually test before merging this to master

### Changed

- [#3649](https://github.com/cosmos/lunie/pull/3649) Now the memo field is always displayed on SendModal @Bitcoinera
- [#3664](https://github.com/cosmos/lunie/pull/3664) Now to pay fees in Claim Rewards, if there is no staking denom balance available, fees will be paid in the first token with positive balance @Bitcoinera
- [#3663](https://github.com/cosmos/lunie/pull/3663) Now it is possible to claim rewards from any token despite not having any staking denom reward @Bitcoinera
- [#3661](https://github.com/cosmos/lunie/pull/3661) Now amounts are displayed in the TransactionItem component for all ClaimRewards transactions @Bitcoinera
- [#3658](https://github.com/cosmos/lunie/pull/3658) Filters all "Unknown" transactions in PageBlock @Bitcoinera
- [#3657](https://github.com/cosmos/lunie/pull/3657) For Terra networks it changes the fee for an action according to the amount of tokens being handled. Fix in ActionModal @Bitcoinera

### Fixed

- [#3650](https://github.com/cosmos/lunie/pull/3650) Fixes the Back to Lunie button @Bitcoinera
- [#3665](https://github.com/cosmos/lunie/pull/3665) Handles checks in TmBalance when balances are not yet loaded @Bitcoinera
- [#3653](https://github.com/cosmos/lunie/pull/3653) Fixes the PoweredBy component inside the NetworkItem @Bitcoinera
- [#3669](https://github.com/cosmos/lunie/pull/3669) Fix concat property of undefined in ClaimRewardsTxDetails as it now wait for getValidators array to be filled @Bitcoinera
- [#3659](https://github.com/cosmos/lunie/pull/3659) Fix signin routing with Ledger @Bitcoinera
- [#3656](https://github.com/cosmos/lunie/pull/3656) Fixes Terra microdenoms in the toMicroDenom function @Bitcoinera
- [#3651](https://github.com/cosmos/lunie/pull/3651) Fixes all the signins and signup routing @Bitcoinera
- [##3666](https://github.com/cosmos/lunie/issues/#3666) fixed css bug width set to 1023px @jrmoreau

### Repository

- sending sourcemaps to sentry @iambeone
- netlify config for production build @iambeone