### PR TITLE
Ana/small fix in totalrewards

### DIFF
--- a/changes/ana_small-fix-totalrewards-in-modal-withdraw
+++ b/changes/ana_small-fix-totalrewards-in-modal-withdraw
@@ -1,0 +1,1 @@
+[Fixed] [#3680](https://github.com/cosmos/lunie/pull/3680) Fixes amount of undefined in totalRewards in ModalWithdrawRewards @Bitcoinera

--- a/src/ActionModal/components/ModalWithdrawRewards.vue
+++ b/src/ActionModal/components/ModalWithdrawRewards.vue
@@ -71,7 +71,11 @@ export default {
         .filter(({ denom }) => denom === this.denom)
         .reduce((sum, { amount }) => sum + Number(amount), 0)
         .toFixed(6)
-      return stakingRewards > 0 ? stakingRewards : this.claimedReward.amount
+      return stakingRewards > 0
+        ? stakingRewards
+        : this.claimedReward
+        ? this.claimedReward.amount
+        : null
     },
     notifyMessage() {
       return {
@@ -107,7 +111,9 @@ export default {
         )
         return stakingDenomBalance
           ? stakingDenomBalance.denom
-          : nonZeroBalances.length > 0 ? nonZeroBalances[0].denom : this.denom
+          : nonZeroBalances.length > 0
+          ? nonZeroBalances[0].denom
+          : this.denom
       } else {
         return this.denom
       }


### PR DESCRIPTION
Closes #ISSUE

**Description:**

<!-- Briefly describe what you're adding or fixing with this PR -->
Just a very small fix. ModalWithdrawRewards was throwing an `amount of undefined` error when no more rewards where left.

Thank you! 🚀

---

For contributor:

- [ ] Added changes entries. Run `yarn changelog` for a guided process.
- [ ] Reviewed `Files changed` in the github PR explorer
- [ ] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI
