### PR TITLE
Aleksei/extension signin flow fix

### DIFF
--- a/changes/aleksei_extension_signin_flow_fix
+++ b/changes/aleksei_extension_signin_flow_fix
@@ -1,0 +1,1 @@
+[Fixed] fix creating new account record on sign-in with extension @iambeone

--- a/src/vuex/modules/session.js
+++ b/src/vuex/modules/session.js
@@ -85,7 +85,7 @@ export default () => {
       const session = localStorage.getItem(sessionKey(network))
       if (session) {
         const { address, sessionType } = JSON.parse(session)
-        await dispatch(`signIn`, { address, sessionType })
+        await dispatch(`signIn`, { address, sessionType, networkId: network })
       } else {
         commit(`setSignIn`, false)
       }

--- a/tests/unit/specs/store/session.spec.js
+++ b/tests/unit/specs/store/session.spec.js
@@ -463,6 +463,7 @@ describe(`Module: Session`, () => {
         `session_fabo-net`,
         JSON.stringify({
           address: `xxx`,
+          networkId: `fabo-net`,
           sessionType: `local`
         })
       )
@@ -474,6 +475,7 @@ describe(`Module: Session`, () => {
       })
       expect(dispatch).toHaveBeenCalledWith(`signIn`, {
         address: `xxx`,
+        networkId: `fabo-net`,
         sessionType: `local`
       })
 


### PR DESCRIPTION
Closes #ISSUE

**Description:**

Steps to reproduce the issue.
Having accounts in extension select any network (call it networkA) other than the account has. Sign-in with the extension. Head to the networks page. Select the previous network (networkA). The address will remain the same.

This PR fixes this issue. But extension sign-in is still buggy and need to be rewritten

Thank you! 🚀

---

For contributor:

- [ ] Added changes entries. Run `yarn changelog` for a guided process.
- [ ] Reviewed `Files changed` in the github PR explorer
- [ ] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI
