### PR TITLE
Ana/fix powered by in connected network for experimental

### DIFF
--- a/src/components/common/TmConnectedNetwork.vue
+++ b/src/components/common/TmConnectedNetwork.vue
@@ -69,6 +69,7 @@
       </div>
     </div>
     <PoweredBy
+      v-if="currentNetwork"
       :network="currentNetwork"
       powered-by-line
       is-menu

--- a/src/components/common/TmConnectedNetwork.vue
+++ b/src/components/common/TmConnectedNetwork.vue
@@ -69,7 +69,6 @@
       </div>
     </div>
     <PoweredBy
-      v-if="currentNetwork"
       :network="currentNetwork"
       powered-by-line
       is-menu
@@ -99,7 +98,7 @@ export default {
     block: {}
   }),
   computed: {
-    ...mapState([`intercom`, `connection`]),
+    ...mapState([`intercom`, `connection`, `session`]),
     ...mapGetters([`network`]),
     networkSlug() {
       return this.connection.networkSlug
@@ -145,6 +144,11 @@ export default {
     },
     networks: {
       query: Networks,
+      variables() {
+        return {
+          experimental: this.session.experimentalMode
+        }
+      },
       fetchPolicy: "cache-first",
       update: NetworksResult
     },

--- a/src/gql/index.js
+++ b/src/gql/index.js
@@ -76,8 +76,8 @@ export const DelegationsForDelegator = schema => gql`
 `
 
 export const Networks = gql`
-  query Networks {
-    networks {
+  query Networks($experimental: Boolean) {
+    networks(experimental: $experimental) {
       id
       chain_id
       testnet


### PR DESCRIPTION
Closes #ISSUE

**Description:**

<!-- Briefly describe what you're adding or fixing with this PR -->
The experimental parameter was missing in Networks and therefore making PoweredBy error, since networks query was only returning 5 networks (no Kusama among them).

~~Still, I need to refactor to pass experimental from `src/gql`. I think it is cleaner~~
OK, the refactor would be too complex. I think it is OK like this


Thank you! 🚀

---

For contributor:

- [ ] Added changes entries. Run `yarn changelog` for a guided process.
- [ ] Reviewed `Files changed` in the github PR explorer
- [ ] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI
