### PR TITLE
Aleksei/add extension getter to differ pathes

### DIFF
--- a/changes/aleksei_add_extension_getter_to_differ_pathes
+++ b/changes/aleksei_add_extension_getter_to_differ_pathes
@@ -1,0 +1,1 @@
+[Added] added isExtension getter to identify extension use and use other pathes @iambeone

--- a/src/components/common/TmSelectNetwork.vue
+++ b/src/components/common/TmSelectNetwork.vue
@@ -45,10 +45,8 @@ export default {
       }
     }
   },
-  watch: {
-    networks: networks => {
-      this.updateSelectedNetwork(networks)
-    }
+  mounted() {
+    this.updateSelectedNetwork(this.networks)
   },
   methods: {
     async selectNetworkHandler(network) {

--- a/src/components/common/TmSessionImportPassword.vue
+++ b/src/components/common/TmSessionImportPassword.vue
@@ -88,7 +88,7 @@ export default {
   }),
   computed: {
     ...mapState([`recover`]),
-    ...mapGetters([`network`, `networkSlug`]),
+    ...mapGetters([`network`, `networkSlug`, `isExtension`]),
     password: {
       get() {
         return this.$store.state.recover.password
@@ -120,12 +120,16 @@ export default {
           name: this.recover.name,
           network: this.network
         })
-        this.$router.push({
-          name: "portfolio",
-          params: {
-            networkId: this.networkSlug
-          }
-        })
+        if (this.isExtension) {
+          this.$router.push(`/`)
+        } else {
+          this.$router.push({
+            name: "portfolio",
+            params: {
+              networkId: this.networkSlug
+            }
+          })
+        }
       } catch (error) {
         this.error = true
         this.errorMessage = error.message

--- a/src/components/common/TmSessionSignUpSeed.vue
+++ b/src/components/common/TmSessionSignUpSeed.vue
@@ -78,7 +78,7 @@ export default {
   }),
   computed: {
     ...mapState([`session`, `signup`]),
-    ...mapGetters([`network`, `networkSlug`]),
+    ...mapGetters([`network`, `networkSlug`, `isExtension`]),
     fieldSeed: {
       get() {
         return this.$store.state.signup.signUpSeed
@@ -115,12 +115,16 @@ export default {
           name: this.signup.signUpName,
           network: this.network
         })
-        this.$router.push({
-          name: "portfolio",
-          params: {
-            networkId: this.networkSlug
-          }
-        })
+        if (this.isExtension) {
+          this.$router.push(`/`)
+        } else {
+          this.$router.push({
+            name: "portfolio",
+            params: {
+              networkId: this.networkSlug
+            }
+          })
+        }
       } catch (error) {
         this.error = true
         this.errorMessage = error.message

--- a/src/components/transactions/TransactionItem.vue
+++ b/src/components/transactions/TransactionItem.vue
@@ -23,9 +23,9 @@
 </template>
 
 <script>
+import { mapGetters } from "vuex"
 import { messageType } from "./messageTypes.js"
 import TransactionMetadata from "./TransactionMetadata"
-import config from "src/../config"
 
 import {
   SendTxDetails,
@@ -72,10 +72,10 @@ export default {
     }
   },
   data: () => ({
-    show: false,
-    isExtension: config.isExtension
+    show: false
   }),
   computed: {
+    ...mapGetters([`isExtension`]),
     messageTypeComponent: function() {
       switch (this.transaction.type) {
         case messageType.SEND:

--- a/src/vuex/getters.js
+++ b/src/vuex/getters.js
@@ -1,3 +1,4 @@
+import config from "../../config"
 // connection
 export const connected = state => state.connection.connected
 export const nodeUrl = state =>
@@ -7,7 +8,7 @@ export const address = state => state.session.address
 export const network = state => state.connection.network
 export const networkSlug = state => state.connection.networkSlug
 export const addressType = state => state.connection.addressType
-export const isExtension = () => false
+export const isExtension = () => config.isExtension
 export const networks = state => state.connection.networks
 export const stakingDenom = state => {
   let filteredNetwork = state.connection.networks.find(

--- a/src/vuex/getters.js
+++ b/src/vuex/getters.js
@@ -7,6 +7,7 @@ export const address = state => state.session.address
 export const network = state => state.connection.network
 export const networkSlug = state => state.connection.networkSlug
 export const addressType = state => state.connection.addressType
+export const isExtension = () => false
 export const networks = state => state.connection.networks
 export const stakingDenom = state => {
   let filteredNetwork = state.connection.networks.find(

--- a/tests/unit/specs/components/common/TmSessionImportPassword.spec.js
+++ b/tests/unit/specs/components/common/TmSessionImportPassword.spec.js
@@ -15,7 +15,8 @@ describe(`TmSessionImportPassword`, () => {
   beforeEach(() => {
     getters = {
       network: "lunie-net",
-      networkSlug: "lunie"
+      networkSlug: "lunie",
+      isExtension: false
     }
     $store = {
       state: {

--- a/tests/unit/specs/components/common/TmSessionSignUpSeed.spec.js
+++ b/tests/unit/specs/components/common/TmSessionSignUpSeed.spec.js
@@ -13,7 +13,8 @@ describe(`TmSessionSignUpSeed`, () => {
     $store = {
       getters: {
         network: "lunie-net",
-        networkSlug: "lunie"
+        networkSlug: "lunie",
+        isExtension: false
       },
       state: {
         session: { insecureMode: true },

--- a/tests/unit/specs/components/transactions/TransactionItem.spec.js
+++ b/tests/unit/specs/components/transactions/TransactionItem.spec.js
@@ -52,6 +52,13 @@ describe(`TransactionItem`, () => {
           transaction: txs[i],
           validators: {},
           address: "cosmos1"
+        },
+        mocks: {
+          $store: {
+            getters: {
+              isExtension: false
+            }
+          }
         }
       })
       expect(wrapper.element).toMatchSnapshot()


### PR DESCRIPTION
Closes #ISSUE

**Description:**

We are redirecting to the portfolio after creating/restoring accounts. But we don't have such a route in extension. 
Added an isExtension getter to identify the extension and redirecting to different url

Thank you! 🚀

---

For contributor:

- [ ] Added changes entries. Run `yarn changelog` for a guided process.
- [ ] Reviewed `Files changed` in the github PR explorer
- [ ] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI
