### PR TITLE
Ana/fix validators list link in portfolio

### DIFF
--- a/changes/ana_fix-validators-link-in-porfolio-when-empty
+++ b/changes/ana_fix-validators-link-in-porfolio-when-empty
@@ -1,0 +1,1 @@
+[Fixed] [#3707](https://github.com/cosmos/lunie/pull/3707) Fixes the validators list link on Portfolio when delegations is empty @Bitcoinera

--- a/src/components/staking/DelegationsOverview.vue
+++ b/src/components/staking/DelegationsOverview.vue
@@ -26,8 +26,7 @@
       </div>
       <div slot="subtitle">
         Head over to the
-        <router-link to="/validators"> validator list</router-link>&nbsp;to get
-        staking!
+        <a @click="goToValidators()"> validator list</a>&nbsp;to get staking!
       </div>
     </TmDataMsg>
   </div>
@@ -49,7 +48,18 @@ export default {
     delegations: []
   }),
   computed: {
-    ...mapGetters(["address", `network`])
+    ...mapGetters(["address", `network`, `networks`])
+  },
+  methods: {
+    goToValidators() {
+      this.$router.push({
+        name: "Validators",
+        params: {
+          networkId: this.networks.find(network => network.id === this.network)
+            .slug
+        }
+      })
+    }
   },
   apollo: {
     delegations: {

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -27,6 +27,7 @@ a {
 
 a:hover {
   color: var(--link-hover);
+  cursor: pointer;
 }
 
 #app {

--- a/tests/unit/specs/components/staking/__snapshots__/DelegationsOverview.spec.js.snap
+++ b/tests/unit/specs/components/staking/__snapshots__/DelegationsOverview.spec.js.snap
@@ -15,13 +15,10 @@ exports[`DelegationsOverview shows a sentiment of dissatisfaction when you have 
       
       Head over to the
       
-      <router-link-stub
-        to="/validators"
-      >
+      <a>
          validator list
-      </router-link-stub>
-       to get
-      staking!
+      </a>
+       to get staking!
     
     </div>
   </tmdatamsg-stub>


### PR DESCRIPTION
Closes #ISSUE

**Description:**

<!-- Briefly describe what you're adding or fixing with this PR -->
Fixes the validators list link in Portfolio when there delegations list is empty

![image](https://user-images.githubusercontent.com/40721795/76763786-10a08f00-6794-11ea-8465-b36d9e7e266f.png)

Also adds a general CSS in `app.css` for all `a` elements to have `cursor: pointer` on `hover`

Thank you! 🚀

---

For contributor:

- [ ] Added changes entries. Run `yarn changelog` for a guided process.
- [ ] Reviewed `Files changed` in the github PR explorer
- [ ] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI
