### PR TITLE
Fabo/fix select network responsive

### DIFF
--- a/changes/fabo_fix-select-network-responsive
+++ b/changes/fabo_fix-select-network-responsive
@@ -1,0 +1,1 @@
+[Fixed] Make select network responsive to network updates @faboweb

--- a/src/components/common/TmSelectNetwork.vue
+++ b/src/components/common/TmSelectNetwork.vue
@@ -45,8 +45,13 @@ export default {
       }
     }
   },
-  mounted() {
-    this.updateSelectedNetwork(this.networks)
+  watch: {
+    networks: {
+      immediate: true,
+      handler(networks) {
+        this.updateSelectedNetwork(networks)
+      }
+    }
   },
   methods: {
     async selectNetworkHandler(network) {


### PR DESCRIPTION
As expected making the networks update statically caused issues. In the extension the networks wouldn't load. Now this works.