### PR TITLE
Ana/fix claim rewards details styles and add all rewards

### DIFF
--- a/changes/ana_fix-claim-rewards-details-styles-and-add-all-rewards
+++ b/changes/ana_fix-claim-rewards-details-styles-and-add-all-rewards
@@ -1,0 +1,1 @@
+[Changed] [#3748](https://github.com/cosmos/lunie/pull/3748) Now ClaimRewardsTxDetails displays all claimed rewards and validators are shown a row below @Bitcoinera

--- a/src/components/network/PageBlock.vue
+++ b/src/components/network/PageBlock.vue
@@ -103,7 +103,7 @@ const transactionV2Fields = `
     }
     ... on ClaimRewardsTx {
       from
-      amount {
+      amounts {
         denom
         amount
       }

--- a/src/components/transactions/message-view/ClaimRewardsTxDetails.vue
+++ b/src/components/transactions/message-view/ClaimRewardsTxDetails.vue
@@ -341,15 +341,6 @@ export default {
 .reponsiveClaimValidator {
   margin: 0 2rem;
 }
-@media screen and (max-width: 822px) {
-  .multiClaimValidatorList {
-    justify-content: space-evenly;
-    width: 100%;
-  }
-  .claimValidator {
-    margin: 0;
-  }
-}
 @media screen and (max-width: 767px) {
   .tx-content-right {
     padding-right: 0;

--- a/src/components/transactions/message-view/ClaimRewardsTxDetails.vue
+++ b/src/components/transactions/message-view/ClaimRewardsTxDetails.vue
@@ -274,6 +274,7 @@ export default {
 .validatorsToggle {
   flex-direction: column;
   display: block;
+  margin-left: 1rem;
 }
 .multi-claim-reward-coin {
   margin: 0.5rem 0;

--- a/src/components/transactions/message-view/ClaimRewardsTxDetails.vue
+++ b/src/components/transactions/message-view/ClaimRewardsTxDetails.vue
@@ -1,102 +1,172 @@
 <template>
-  <div class="tx__content">
-    <TransactionIcon :transaction-type="type" />
-    <div class="tx__content__left">
-      <h3 :class="{ multiClaimRewardH3: show }">{{ caption }}</h3>
-      <div v-if="getValidators" class="validators-images-row">
-        <span v-if="!show && getValidators.length === 1">Rewards from</span>
-        <div
-          :class="{
-            multiClaimRewardRow: getValidators.length > 1 || show,
-            singleValidatorRewardRow: getValidators.length === 1 && !show
-          }"
-        >
+  <div class="claim-rewards-wrapper">
+    <div class="tx__content">
+      <TransactionIcon :transaction-type="type" />
+      <div
+        class="tx__content__left"
+        :class="{
+          responsiveControllerMobileTrue: getValidators.length > 1 && !show
+        }"
+      >
+        <h3 :class="{ multiClaimRewardH3: show }">{{ caption }}</h3>
+        <div v-if="getValidators" class="validators-images-row">
+          <span v-if="!show && getValidators.length === 1">Rewards from</span>
           <div
             :class="{
-              multiClaimValidatorList: getValidators.length > 1 && !show,
-              validatorsToggle: getValidators.length > 1 && show,
-              singleValidatorRewardRow: getValidators.length === 1
+              multiClaimRewardRow: getValidators.length > 1 || show,
+              singleValidatorRewardRow: getValidators.length === 1 && !show,
+              reponsiveControllerDesktop: getValidators.length > 1 && !show
             }"
           >
             <div
-              v-for="(validator, index) in getValidators"
-              :key="validator.name.concat(`-${index}`)"
               :class="{
-                claimValidator: getValidators.length > 1,
+                multiClaimValidatorList: getValidators.length > 1 && !show,
+                validatorsToggle: getValidators.length > 1 && show,
                 singleValidatorRewardRow: getValidators.length === 1
               }"
             >
-              <router-link
-                :to="
-                  show ? `/staking/validators/${validator.operatorAddress}` : ''
-                "
-                class="validator-link"
+              <div
+                v-for="(validator, index) in getValidators"
+                :key="validator.name.concat(`-${index}`)"
+                :class="{
+                  claimValidator: getValidators.length > 1,
+                  singleValidatorRewardRow: getValidators.length === 1
+                }"
               >
-                <div
-                  v-if="!validator.picture || validator.picture === 'null'"
-                  class="row-validator-image"
+                <router-link
+                  :to="
+                    show
+                      ? `/staking/validators/${validator.operatorAddress}`
+                      : ''
+                  "
+                  class="validator-link"
                 >
-                  <Avatar
-                    class="validator-image"
-                    alt="generic validator logo - generated avatar from address"
-                    :address="validator.operatorAddress"
-                  />
-                  <span
-                    v-if="show || getValidators.length === 1"
-                    class="validator-span"
+                  <div
+                    v-if="!validator.picture || validator.picture === 'null'"
+                    class="row-validator-image"
                   >
-                    {{
-                      validator.operatorAddress
-                        | resolveValidatorName(validators)
-                    }}
-                  </span>
-                </div>
-                <div
-                  v-if="validator && validator.picture"
-                  class="row-validator-image"
-                >
-                  <img
-                    :src="validator.picture"
-                    class="validator-image"
-                    :alt="`validator logo for ` + validator.name"
-                  />
-                  <span
-                    v-if="show || getValidators.length === 1"
-                    class="validator-span"
+                    <Avatar
+                      class="validator-image"
+                      alt="generic validator logo - generated avatar from address"
+                      :address="validator.operatorAddress"
+                    />
+                    <span
+                      v-if="show || getValidators.length === 1"
+                      class="validator-span"
+                    >
+                      {{
+                        validator.operatorAddress
+                          | resolveValidatorName(validators)
+                      }}
+                    </span>
+                  </div>
+                  <div
+                    v-if="validator && validator.picture"
+                    class="row-validator-image"
                   >
-                    {{
-                      validator.operatorAddress
-                        | resolveValidatorName(validators)
-                    }}
-                  </span>
-                </div>
-              </router-link>
+                    <img
+                      :src="validator.picture"
+                      class="validator-image"
+                      :alt="`validator logo for ` + validator.name"
+                    />
+                    <span
+                      v-if="show || getValidators.length === 1"
+                      class="validator-span"
+                    >
+                      {{
+                        validator.operatorAddress
+                          | resolveValidatorName(validators)
+                      }}
+                    </span>
+                  </div>
+                </router-link>
+              </div>
             </div>
-          </div>
-          <div v-if="show && transaction.details.amounts.length > 1">
-            <div v-for="coin in transaction.details.amounts" :key="coin.denom">
+            <div v-if="show && transaction.details.amounts.length > 1">
+              <div
+                v-for="coin in transaction.details.amounts"
+                :key="coin.denom"
+              >
+                <p class="multi-claim-reward-coin">
+                  {{ coin.amount | prettyLong }}&nbsp; {{ coin.denom }}
+                </p>
+              </div>
+            </div>
+            <div v-if="show && transaction.details.amounts.length === 1">
               <p class="multi-claim-reward-coin">
-                {{ coin.amount | prettyLong }}&nbsp; {{ coin.denom }}
+                {{ transaction.details.amounts[0].amount | prettyLong }}&nbsp;
+                {{ transaction.details.amounts[0].denom }}
               </p>
             </div>
           </div>
-          <div v-if="show && transaction.details.amounts.length === 1">
-            <p class="multi-claim-reward-coin">
+        </div>
+        <div class="tx-content-right">
+          <div v-if="!show && transaction.details.amounts.length === 1">
+            <p>
               {{ transaction.details.amounts[0].amount | prettyLong }}&nbsp;
               {{ transaction.details.amounts[0].denom }}
             </p>
           </div>
+          <div v-if="!show && transaction.details.amounts.length > 1">
+            <p>Show multiple rewards</p>
+          </div>
         </div>
       </div>
-      <div class="tx-content-right">
-        <div v-if="!show && transaction.details.amounts.length === 1">
-          <p>
-            {{ transaction.details.amounts[0].amount | prettyLong }}&nbsp;
-            {{ transaction.details.amounts[0].denom }}
-          </p>
-        </div>
-        <div v-if="!show && transaction.details.amounts.length > 1">
-          <p>Show multiple rewards</p>
+    </div>
+    <div
+      v-if="!show"
+      class="multiClaimRewardRow"
+      :class="{
+        reponsiveControllerMobile: getValidators.length > 1
+      }"
+    >
+      <div class="multiClaimValidatorList">
+        <div
+          v-for="(validator, index) in getValidators"
+          :key="validator.name.concat(`-${index}`)"
+          class="claimValidator"
+        >
+          <router-link
+            :to="show ? `/staking/validators/${validator.operatorAddress}` : ''"
+            class="validator-link"
+          >
+            <div
+              v-if="!validator.picture || validator.picture === 'null'"
+              class="row-validator-image"
+            >
+              <Avatar
+                class="validator-image"
+                alt="generic validator logo - generated avatar from address"
+                :address="validator.operatorAddress"
+              />
+              <span
+                v-if="show || getValidators.length === 1"
+                class="validator-span"
+              >
+                {{
+                  validator.operatorAddress | resolveValidatorName(validators)
+                }}
+              </span>
+            </div>
+            <div
+              v-if="validator && validator.picture"
+              class="row-validator-image"
+            >
+              <img
+                :src="validator.picture"
+                class="validator-image"
+                :alt="`validator logo for ` + validator.name"
+              />
+              <span
+                v-if="show || getValidators.length === 1"
+                class="validator-span"
+              >
+                {{
+                  validator.operatorAddress | resolveValidatorName(validators)
+                }}
+              </span>
+            </div>
+          </router-link>
         </div>
       </div>
     </div>
@@ -153,6 +223,10 @@ export default {
 }
 </script>
 <style scoped>
+.claim-rewards-wrapper {
+  display: block;
+  width: 100%;
+}
 .tx__icon {
   align-self: flex-start;
 }
@@ -223,6 +297,9 @@ export default {
 .multiClaimValidatorList span {
   padding-right: 0.2rem;
 }
+.reponsiveControllerMobile {
+  display: none;
+}
 @media screen and (max-width: 822px) {
   .multiClaimValidatorList {
     justify-content: space-evenly;
@@ -235,6 +312,18 @@ export default {
 @media screen and (max-width: 767px) {
   .tx-content-right {
     padding-right: 0;
+  }
+}
+@media screen and (max-width: 667px) {
+  .reponsiveControllerDesktop {
+    display: none;
+  }
+  .reponsiveControllerMobile {
+    display: flex;
+    padding-bottom: 1rem;
+  }
+  .responsiveControllerMobileTrue {
+    padding-bottom: 0;
   }
 }
 </style>

--- a/src/components/transactions/message-view/ClaimRewardsTxDetails.vue
+++ b/src/components/transactions/message-view/ClaimRewardsTxDetails.vue
@@ -2,22 +2,9 @@
   <div class="tx__content">
     <TransactionIcon :transaction-type="type" />
     <div class="tx__content__left">
-      <div class="tx__claim__header">
-        <h3 class="multi-claim-reward-h3">{{ caption }}</h3>
-        <div class="tx__content__right">
-          <div v-if="!show && transaction.details.amounts.length === 1">
-            <p>
-              {{ transaction.details.amounts[0].amount | prettyLong }}&nbsp;
-              {{ transaction.details.amounts[0].denom }}
-            </p>
-          </div>
-          <div v-if="!show && transaction.details.amounts.length > 1">
-            <p>Show multiple rewards</p>
-          </div>
-        </div>
-      </div>
-      <template v-if="getValidators" class="validators-images-row">
-        <span v-if="!show">Rewards from</span>
+      <h3 class="multi-claim-reward-h3">{{ caption }}</h3>
+      <div v-if="getValidators" class="validators-images-row">
+        <span v-if="!show && getValidators.length === 1">Rewards from</span>
         <div
           :class="{
             multiClaimRewardRow: getValidators.length > 1 || show,
@@ -100,7 +87,16 @@
             </p>
           </div>
         </div>
-      </template>
+      </div>
+      <div v-if="!show && transaction.details.amounts.length === 1">
+        <p>
+          {{ transaction.details.amounts[0].amount | prettyLong }}&nbsp;
+          {{ transaction.details.amounts[0].denom }}
+        </p>
+      </div>
+      <div v-if="!show && transaction.details.amounts.length > 1">
+        <p>Show multiple rewards</p>
+      </div>
     </div>
   </div>
 </template>
@@ -156,15 +152,15 @@ export default {
 </script>
 <style scoped>
 .tx__content__left {
-  width: 100%;
-}
-.tx__claim__header {
   display: flex;
-  align-items: center;
+  justify-content: space-between;
+  width: 100%;
 }
 .validators-images-row {
   display: flex;
-  flex-direction: row;
+  flex: 3;
+  align-items: center;
+  justify-content: center;
 }
 .singleValidatorRewardRow {
   display: inline;
@@ -173,6 +169,7 @@ export default {
   display: flex;
   justify-content: space-around;
   align-items: center;
+  width: 100%;
 }
 .multiClaimValidatorList {
   display: flex;

--- a/src/components/transactions/message-view/ClaimRewardsTxDetails.vue
+++ b/src/components/transactions/message-view/ClaimRewardsTxDetails.vue
@@ -5,14 +5,19 @@
       <div class="tx__claim__header">
         <h3 class="multi-claim-reward-h3">{{ caption }}</h3>
         <div class="tx__content__right">
-          <p class="amount">
-            {{ transaction.details.amount.amount | prettyLong }}&nbsp;
-            {{ transaction.details.amount.denom }}
-          </p>
+          <div v-if="transaction.details.amounts.length === 1">
+            <p>
+              {{ transaction.details.amounts[0].amount | prettyLong }}&nbsp;
+              {{ transaction.details.amounts[0].denom }}
+            </p>
+          </div>
+          <div v-else-if="!show && transaction.details.amounts.length > 1">
+            <p>Show multiple rewards</p>
+          </div>
         </div>
       </div>
       <template v-if="getValidators && getValidators.length === 1">
-        <div class="multi-claim-reward-row">
+        <div>
           <span>Rewards from</span>
           <router-link
             :to="`/staking/validators/${transaction.details.from[0]}`"
@@ -40,50 +45,68 @@
         v-if="getValidators && getValidators.length > 1"
         class="validators-images-row"
       >
-        <div class="multi-claim-reward-row" :class="{ validatorsToggle: show }">
-          <span v-if="show">Rewards from</span>
+        <div class="multi-claim-reward-row">
           <div
-            v-for="(validator, index) in getValidators"
-            :key="validator.name.concat(`-${index}`)"
-            class="claim-validator"
+            class="multi-claim-validator-list"
+            :class="{ validatorsToggle: show }"
           >
-            <router-link
-              :to="
-                show ? `/staking/validators/${validator.operatorAddress}` : ''
-              "
-              class="validator-link"
+            <span v-if="show">Rewards from</span>
+            <div
+              v-for="(validator, index) in getValidators"
+              :key="validator.name.concat(`-${index}`)"
+              class="claim-validator"
             >
-              <div
-                v-if="!validator.picture || validator.picture === 'null'"
-                class="row-validator-image"
+              <router-link
+                :to="
+                  show ? `/staking/validators/${validator.operatorAddress}` : ''
+                "
+                class="validator-link"
               >
-                <Avatar
-                  class="validator-image"
-                  alt="generic validator logo - generated avatar from address"
-                  :address="validator.operatorAddress"
-                />
-                <span v-if="show" class="validator-span">
-                  {{
-                    validator.operatorAddress | resolveValidatorName(validators)
-                  }}
-                </span>
-              </div>
-              <div
-                v-if="validator && validator.picture"
-                class="row-validator-image"
-              >
-                <img
-                  :src="validator.picture"
-                  class="validator-image"
-                  :alt="`validator logo for ` + validator.name"
-                />
-                <span v-if="show" class="validator-span">
-                  {{
-                    validator.operatorAddress | resolveValidatorName(validators)
-                  }}
-                </span>
-              </div>
-            </router-link>
+                <div
+                  v-if="!validator.picture || validator.picture === 'null'"
+                  class="row-validator-image"
+                >
+                  <Avatar
+                    class="validator-image"
+                    alt="generic validator logo - generated avatar from address"
+                    :address="validator.operatorAddress"
+                  />
+                  <span v-if="show" class="validator-span">
+                    {{
+                      validator.operatorAddress
+                        | resolveValidatorName(validators)
+                    }}
+                  </span>
+                </div>
+                <div
+                  v-if="validator && validator.picture"
+                  class="row-validator-image"
+                >
+                  <img
+                    :src="validator.picture"
+                    class="validator-image"
+                    :alt="`validator logo for ` + validator.name"
+                  />
+                  <span v-if="show" class="validator-span">
+                    {{
+                      validator.operatorAddress
+                        | resolveValidatorName(validators)
+                    }}
+                  </span>
+                </div>
+              </router-link>
+            </div>
+          </div>
+          <div v-if="show && transaction.details.amounts.length > 1">
+            <div
+              v-for="coin in transaction.details.amounts"
+              :key="coin.denom"
+              class="amount"
+            >
+              <p class="multi-claim-reward-coin">
+                {{ coin.amount | prettyLong }}&nbsp; {{ coin.denom }}
+              </p>
+            </div>
           </div>
         </div>
       </template>
@@ -154,14 +177,21 @@ export default {
 }
 .multi-claim-reward-row {
   display: flex;
+  justify-content: space-around;
+}
+.multi-claim-validator-list {
+  display: flex;
   align-items: center;
   justify-content: center;
 }
-.multi-claim-reward-row.validatorsToggle {
+.multi-claim-validator-list.validatorsToggle {
   flex-direction: column;
 }
 .multi-claim-reward-h3 {
   margin-right: 20px;
+}
+.multi-claim-reward-coin {
+  margin: 1rem 0;
 }
 .claim-validator {
   margin: 0 2rem;
@@ -189,11 +219,11 @@ export default {
 .tx a {
   margin-left: 0.1rem;
 }
-.multi-claim-reward-row span {
+.multi-claim-validator-list span {
   padding-right: 0.2rem;
 }
 @media screen and (max-width: 767px) {
-  .multi-claim-reward-row {
+  .multi-claim-validator-list {
     justify-content: space-evenly;
   }
   .claim-validator {

--- a/src/components/transactions/message-view/ClaimRewardsTxDetails.vue
+++ b/src/components/transactions/message-view/ClaimRewardsTxDetails.vue
@@ -2,7 +2,7 @@
   <div class="tx__content">
     <TransactionIcon :transaction-type="type" />
     <div class="tx__content__left">
-      <h3 class="multi-claim-reward-h3">{{ caption }}</h3>
+      <h3 :class="{ multiClaimRewardH3: show }">{{ caption }}</h3>
       <div v-if="getValidators" class="validators-images-row">
         <span v-if="!show && getValidators.length === 1">Rewards from</span>
         <div
@@ -153,6 +153,9 @@ export default {
 }
 </script>
 <style scoped>
+.tx__icon {
+  align-self: flex-start;
+}
 .tx__content__left {
   display: flex;
   justify-content: space-between;
@@ -160,6 +163,9 @@ export default {
 }
 .tx-content-right {
   padding-right: 1rem;
+}
+.multiClaimRewardH3 {
+  margin-top: 0.25rem;
 }
 .validators-images-row {
   display: flex;
@@ -184,9 +190,6 @@ export default {
 .multiClaimValidatorList.validatorsToggle {
   flex-direction: column;
   display: block;
-}
-.multi-claim-reward-h3 {
-  margin-right: 20px;
 }
 .multi-claim-reward-coin {
   margin: 0.5rem 0;

--- a/src/components/transactions/message-view/ClaimRewardsTxDetails.vue
+++ b/src/components/transactions/message-view/ClaimRewardsTxDetails.vue
@@ -41,10 +41,11 @@
         class="validators-images-row"
       >
         <div class="multi-claim-reward-row" :class="{ validatorsToggle: show }">
+          <span v-if="show">Rewards from</span>
           <div
             v-for="(validator, index) in getValidators"
             :key="validator.name.concat(`-${index}`)"
-            class="claim__validator"
+            class="claim-validator"
           >
             <router-link
               :to="
@@ -156,10 +157,13 @@ export default {
   align-items: center;
   justify-content: center;
 }
+.multi-claim-reward-row.validatorsToggle {
+  flex-direction: column;
+}
 .multi-claim-reward-h3 {
   margin-right: 20px;
 }
-.claim__validator {
+.claim-validator {
   margin: 0 2rem;
 }
 .row-validator-image {
@@ -182,10 +186,6 @@ export default {
 .multi-claim-reward-show:hover {
   color: var(--link-hover);
 }
-.multi-claim-reward-row.validatorsToggle {
-  display: block;
-  margin-left: 10vh;
-}
 .tx a {
   margin-left: 0.1rem;
 }
@@ -196,7 +196,7 @@ export default {
   .multi-claim-reward-row {
     justify-content: space-evenly;
   }
-  .claim__validator {
+  .claim-validator {
     margin: 0;
   }
 }

--- a/src/components/transactions/message-view/ClaimRewardsTxDetails.vue
+++ b/src/components/transactions/message-view/ClaimRewardsTxDetails.vue
@@ -2,7 +2,7 @@
   <div class="tx__content">
     <TransactionIcon :transaction-type="type" />
     <div class="tx__content__left">
-      <div class="tx__claim__header" :class="{ txClaimHeaderOpen: show }">
+      <div class="tx__claim__header">
         <h3 class="multi-claim-reward-h3">{{ caption }}</h3>
         <div class="tx__content__right">
           <div v-if="!show && transaction.details.amounts.length === 1">
@@ -26,7 +26,7 @@
         >
           <div
             :class="{
-              multiClaimValidatorList: getValidators.length > 1,
+              multiClaimValidatorList: getValidators.length > 1 && !show,
               validatorsToggle: getValidators.length > 1 && show,
               singleValidatorRewardRow: getValidators.length === 1
             }"
@@ -162,10 +162,6 @@ export default {
   display: flex;
   align-items: center;
 }
-.txClaimHeaderOpen {
-  display: inline;
-  float: left;
-}
 .validators-images-row {
   display: flex;
   flex-direction: row;
@@ -225,6 +221,7 @@ export default {
 @media screen and (max-width: 767px) {
   .multiClaimValidatorList {
     justify-content: space-evenly;
+    width: 100%;
   }
   .claimValidator {
     margin: 0;

--- a/src/components/transactions/message-view/ClaimRewardsTxDetails.vue
+++ b/src/components/transactions/message-view/ClaimRewardsTxDetails.vue
@@ -2,7 +2,7 @@
   <div class="tx__content">
     <TransactionIcon :transaction-type="type" />
     <div class="tx__content__left">
-      <div class="tx__claim__header">
+      <div class="tx__claim__header" :class="{ txClaimHeaderOpen: show }">
         <h3 class="multi-claim-reward-h3">{{ caption }}</h3>
         <div class="tx__content__right">
           <div v-if="transaction.details.amounts.length === 1">
@@ -155,6 +155,10 @@ export default {
 .tx__claim__header {
   display: flex;
   align-items: center;
+}
+.txClaimHeaderOpen {
+  display: inline;
+  float: left;
 }
 .validators-images-row {
   display: flex;

--- a/src/components/transactions/message-view/ClaimRewardsTxDetails.vue
+++ b/src/components/transactions/message-view/ClaimRewardsTxDetails.vue
@@ -114,17 +114,14 @@
       </div>
     </div>
     <div
-      v-if="!show"
-      class="multiClaimRewardRow"
-      :class="{
-        reponsiveControllerMobile: getValidators.length > 1
-      }"
+      v-if="!show && getValidators.length > 1"
+      class="multiClaimRewardRow reponsiveControllerMobile"
     >
-      <div class="multiClaimValidatorList">
+      <div class="responsiveMultiClaimValidatorList">
         <div
           v-for="(validator, index) in getValidators"
           :key="validator.name.concat(`-${index}`)"
-          class="claimValidator"
+          class="reponsiveClaimValidator"
         >
           <router-link
             :to="show ? `/staking/validators/${validator.operatorAddress}` : ''"
@@ -300,6 +297,14 @@ export default {
 .reponsiveControllerMobile {
   display: none;
 }
+.responsiveMultiClaimValidatorList {
+  display: flex;
+  width: 100%;
+  justify-content: center;
+}
+.reponsiveClaimValidator {
+  margin: 0 2rem;
+}
 @media screen and (max-width: 822px) {
   .multiClaimValidatorList {
     justify-content: space-evenly;
@@ -313,8 +318,6 @@ export default {
   .tx-content-right {
     padding-right: 0;
   }
-}
-@media screen and (max-width: 667px) {
   .reponsiveControllerDesktop {
     display: none;
   }
@@ -323,7 +326,15 @@ export default {
     padding-bottom: 1rem;
   }
   .responsiveControllerMobileTrue {
-    padding-bottom: 0;
+    padding-bottom: 0.5rem;
+  }
+}
+@media screen and (max-width: 576px) {
+  .responsiveMultiClaimValidatorList {
+    justify-content: space-evenly;
+  }
+  .reponsiveClaimValidator {
+    margin: 0;
   }
 }
 </style>

--- a/src/components/transactions/message-view/ClaimRewardsTxDetails.vue
+++ b/src/components/transactions/message-view/ClaimRewardsTxDetails.vue
@@ -17,24 +17,23 @@
           >
           <div
             :class="{
-              multiClaimRewardRow: getValidators.length > 1 || show,
-              singleValidatorRewardRow: getValidators.length === 1 && !show,
+              multiClaimRewardRow: getValidators.length > 1,
+              multiClaimRewardRowOpen: show,
               reponsiveControllerDesktop: getValidators.length > 1 && !show
             }"
           >
             <div
               :class="{
                 multiClaimValidatorList: getValidators.length > 1 && !show,
-                validatorsToggle: getValidators.length > 1 && show,
-                singleValidatorRewardRow: getValidators.length === 1
+                validatorsToggle: show
               }"
             >
               <div
                 v-for="(validator, index) in getValidators"
                 :key="validator.name.concat(`-${index}`)"
+                class="claimValidator"
                 :class="{
-                  claimValidator: getValidators.length > 1,
-                  singleValidatorRewardRow: getValidators.length === 1
+                  singleValidatorRewardRow: getValidators.length === 1 && !show
                 }"
               >
                 <router-link
@@ -96,7 +95,10 @@
                 </p>
               </div>
             </div>
-            <div v-if="show && transaction.details.amounts.length === 1">
+            <div
+              v-if="show && transaction.details.amounts.length === 1"
+              class="single-reward-coin"
+            >
               <p class="multi-claim-reward-coin">
                 {{ transaction.details.amounts[0].amount | prettyLong }}&nbsp;
                 {{ transaction.details.amounts[0].denom }}
@@ -242,6 +244,7 @@ export default {
 }
 .multiClaimRewardH3 {
   margin-top: 0.25rem;
+  align-self: flex-start;
 }
 .validators-images-row {
   display: flex;
@@ -250,7 +253,7 @@ export default {
   justify-content: center;
 }
 .singleValidatorRewardRow {
-  display: inline;
+  margin: 0 !important;
 }
 .multiClaimRewardRow {
   display: flex;
@@ -258,17 +261,25 @@ export default {
   align-items: center;
   width: 100%;
 }
+.multiClaimRewardRowOpen {
+  display: flex;
+  justify-content: space-between;
+  width: 100%;
+}
 .multiClaimValidatorList {
   display: flex;
   align-items: center;
   justify-content: center;
 }
-.multiClaimValidatorList.validatorsToggle {
+.validatorsToggle {
   flex-direction: column;
   display: block;
 }
 .multi-claim-reward-coin {
   margin: 0.5rem 0;
+}
+.single-reward-coin {
+  align-self: flex-start;
 }
 .claimValidator {
   margin: 0 2rem;

--- a/src/components/transactions/message-view/ClaimRewardsTxDetails.vue
+++ b/src/components/transactions/message-view/ClaimRewardsTxDetails.vue
@@ -16,45 +16,28 @@
           </div>
         </div>
       </div>
-      <template v-if="getValidators && getValidators.length === 1">
-        <div>
-          <span>Rewards from</span>
-          <router-link
-            :to="`/staking/validators/${transaction.details.from[0]}`"
-            class="validator-link"
-          >
-            <Avatar
-              v-if="
-                !getValidators[0].picture || getValidators[0].picture === 'null'
-              "
-              class="validator-image"
-              alt="generic validator logo - generated avatar from address"
-              :address="getValidators[0].operatorAddress"
-            />
-            <img
-              v-if="getValidators[0].picture"
-              :src="getValidators[0].picture"
-              class="validator-image"
-              :alt="`validator logo for ` + getValidators[0].name"
-            />
-            {{ transaction.details.from[0] | resolveValidatorName(validators) }}
-          </router-link>
-        </div>
-      </template>
-      <template
-        v-if="getValidators && getValidators.length > 1"
-        class="validators-images-row"
-      >
-        <div class="multi-claim-reward-row">
+      <template v-if="getValidators" class="validators-images-row">
+        <span v-if="!show">Rewards from</span>
+        <div
+          :class="{
+            multiClaimRewardRow: getValidators.length > 1 || show,
+            singleValidatorRewardRow: getValidators.length === 1 && !show
+          }"
+        >
           <div
-            class="multi-claim-validator-list"
-            :class="{ validatorsToggle: show }"
+            :class="{
+              multiClaimValidatorList: getValidators.length > 1,
+              validatorsToggle: getValidators.length > 1 && show,
+              singleValidatorRewardRow: getValidators.length === 1
+            }"
           >
-            <span v-if="show">Rewards from</span>
             <div
               v-for="(validator, index) in getValidators"
               :key="validator.name.concat(`-${index}`)"
-              class="claim-validator"
+              :class="{
+                claimValidator: getValidators.length > 1,
+                singleValidatorRewardRow: getValidators.length === 1
+              }"
             >
               <router-link
                 :to="
@@ -71,7 +54,10 @@
                     alt="generic validator logo - generated avatar from address"
                     :address="validator.operatorAddress"
                   />
-                  <span v-if="show" class="validator-span">
+                  <span
+                    v-if="show || getValidators.length === 1"
+                    class="validator-span"
+                  >
                     {{
                       validator.operatorAddress
                         | resolveValidatorName(validators)
@@ -87,7 +73,10 @@
                     class="validator-image"
                     :alt="`validator logo for ` + validator.name"
                   />
-                  <span v-if="show" class="validator-span">
+                  <span
+                    v-if="show || getValidators.length === 1"
+                    class="validator-span"
+                  >
                     {{
                       validator.operatorAddress
                         | resolveValidatorName(validators)
@@ -175,16 +164,19 @@ export default {
   display: flex;
   flex-direction: row;
 }
-.multi-claim-reward-row {
+.singleValidatorRewardRow {
+  display: inline;
+}
+.multiClaimRewardRow {
   display: flex;
   justify-content: space-around;
 }
-.multi-claim-validator-list {
+.multiClaimValidatorList {
   display: flex;
   align-items: center;
   justify-content: center;
 }
-.multi-claim-validator-list.validatorsToggle {
+.multiClaimValidatorList.validatorsToggle {
   flex-direction: column;
 }
 .multi-claim-reward-h3 {
@@ -193,7 +185,7 @@ export default {
 .multi-claim-reward-coin {
   margin: 1rem 0;
 }
-.claim-validator {
+.claimValidator {
   margin: 0 2rem;
 }
 .row-validator-image {
@@ -219,14 +211,14 @@ export default {
 .tx a {
   margin-left: 0.1rem;
 }
-.multi-claim-validator-list span {
+.multiClaimValidatorList span {
   padding-right: 0.2rem;
 }
 @media screen and (max-width: 767px) {
-  .multi-claim-validator-list {
+  .multiClaimValidatorList {
     justify-content: space-evenly;
   }
-  .claim-validator {
+  .claimValidator {
     margin: 0;
   }
 }

--- a/src/components/transactions/message-view/ClaimRewardsTxDetails.vue
+++ b/src/components/transactions/message-view/ClaimRewardsTxDetails.vue
@@ -170,6 +170,7 @@ export default {
 .multiClaimRewardRow {
   display: flex;
   justify-content: space-around;
+  align-items: center;
 }
 .multiClaimValidatorList {
   display: flex;
@@ -178,12 +179,13 @@ export default {
 }
 .multiClaimValidatorList.validatorsToggle {
   flex-direction: column;
+  display: block;
 }
 .multi-claim-reward-h3 {
   margin-right: 20px;
 }
 .multi-claim-reward-coin {
-  margin: 1rem 0;
+  margin: 0.5rem 0;
 }
 .claimValidator {
   margin: 0 2rem;

--- a/src/components/transactions/message-view/ClaimRewardsTxDetails.vue
+++ b/src/components/transactions/message-view/ClaimRewardsTxDetails.vue
@@ -5,27 +5,30 @@
       <div
         class="tx__content__left"
         :class="{
-          responsiveControllerMobileTrue: getValidators.length > 1 && !show
+          responsiveControllerMobileTrue:
+            getValidators.length > 1 && !multiClaimShow
         }"
       >
-        <h3 :class="{ multiClaimRewardH3: show }">{{ caption }}</h3>
+        <h3 :class="{ multiClaimRewardH3: multiClaimShow }">{{ caption }}</h3>
         <div v-if="getValidators" class="validators-images-row">
           <span
-            v-if="!show && getValidators.length === 1"
+            v-if="!multiClaimShow && getValidators.length === 1"
             class="rewards-from-span"
             >Rewards from</span
           >
           <div
             :class="{
               multiClaimRewardRow: getValidators.length > 1,
-              multiClaimRewardRowOpen: show,
-              reponsiveControllerDesktop: getValidators.length > 1 && !show
+              multiClaimRewardRowOpen: multiClaimShow,
+              reponsiveControllerDesktop:
+                getValidators.length > 1 && !multiClaimShow
             }"
           >
             <div
               :class="{
-                multiClaimValidatorList: getValidators.length > 1 && !show,
-                validatorsToggle: show
+                multiClaimValidatorList:
+                  getValidators.length > 1 && !multiClaimShow,
+                validatorsToggle: multiClaimShow
               }"
             >
               <div
@@ -33,12 +36,13 @@
                 :key="validator.name.concat(`-${index}`)"
                 class="claimValidator"
                 :class="{
-                  singleValidatorRewardRow: getValidators.length === 1 && !show
+                  singleValidatorRewardRow:
+                    getValidators.length === 1 && !multiClaimShow
                 }"
               >
                 <router-link
                   :to="
-                    show
+                    multiClaimShow
                       ? `/staking/validators/${validator.operatorAddress}`
                       : ''
                   "
@@ -54,7 +58,7 @@
                       :address="validator.operatorAddress"
                     />
                     <span
-                      v-if="show || getValidators.length === 1"
+                      v-if="multiClaimShow || getValidators.length === 1"
                       class="validator-span"
                     >
                       {{
@@ -73,7 +77,7 @@
                       :alt="`validator logo for ` + validator.name"
                     />
                     <span
-                      v-if="show || getValidators.length === 1"
+                      v-if="multiClaimShow || getValidators.length === 1"
                       class="validator-span"
                     >
                       {{
@@ -85,7 +89,9 @@
                 </router-link>
               </div>
             </div>
-            <div v-if="show && transaction.details.amounts.length > 1">
+            <div
+              v-if="multiClaimShow && transaction.details.amounts.length > 1"
+            >
               <div
                 v-for="coin in transaction.details.amounts"
                 :key="coin.denom"
@@ -96,7 +102,7 @@
               </div>
             </div>
             <div
-              v-if="show && transaction.details.amounts.length === 1"
+              v-if="multiClaimShow && transaction.details.amounts.length === 1"
               class="single-reward-coin"
             >
               <p class="multi-claim-reward-coin">
@@ -107,20 +113,22 @@
           </div>
         </div>
         <div class="tx-content-right">
-          <div v-if="!show && transaction.details.amounts.length === 1">
+          <div
+            v-if="!multiClaimShow && transaction.details.amounts.length === 1"
+          >
             <p>
               {{ transaction.details.amounts[0].amount | prettyLong }}&nbsp;
               {{ transaction.details.amounts[0].denom }}
             </p>
           </div>
-          <div v-if="!show && transaction.details.amounts.length > 1">
+          <div v-if="!multiClaimShow && transaction.details.amounts.length > 1">
             <p>Show multiple rewards</p>
           </div>
         </div>
       </div>
     </div>
     <div
-      v-if="!show && getValidators.length > 1"
+      v-if="!multiClaimShow && getValidators.length > 1"
       class="multiClaimRewardRow reponsiveControllerMobile"
     >
       <div class="responsiveMultiClaimValidatorList">
@@ -130,7 +138,11 @@
           class="reponsiveClaimValidator"
         >
           <router-link
-            :to="show ? `/staking/validators/${validator.operatorAddress}` : ''"
+            :to="
+              multiClaimShow
+                ? `/staking/validators/${validator.operatorAddress}`
+                : ''
+            "
             class="validator-link"
           >
             <div
@@ -143,7 +155,7 @@
                 :address="validator.operatorAddress"
               />
               <span
-                v-if="show || getValidators.length === 1"
+                v-if="multiClaimShow || getValidators.length === 1"
                 class="validator-span"
               >
                 {{
@@ -161,7 +173,7 @@
                 :alt="`validator logo for ` + validator.name"
               />
               <span
-                v-if="show || getValidators.length === 1"
+                v-if="multiClaimShow || getValidators.length === 1"
                 class="validator-span"
               >
                 {{
@@ -221,6 +233,13 @@ export default {
       } else {
         return []
       }
+    },
+    multiClaimShow() {
+      // here we prevent any changes for the particular case of one validator and one single denom
+      return this.getValidators.length === 1 &&
+        this.transaction.details.amounts.length === 1
+        ? false
+        : this.show
     }
   }
 }
@@ -298,11 +317,11 @@ export default {
   float: left;
   margin-left: 5px;
 }
-.multi-claim-reward-show {
+.multi-claim-reward-multiClaimShow {
   margin-left: 40px;
   color: var(--link);
 }
-.multi-claim-reward-show:hover {
+.multi-claim-reward-multiClaimShow:hover {
   color: var(--link-hover);
 }
 .tx a {

--- a/src/components/transactions/message-view/ClaimRewardsTxDetails.vue
+++ b/src/components/transactions/message-view/ClaimRewardsTxDetails.vue
@@ -88,14 +88,16 @@
           </div>
         </div>
       </div>
-      <div v-if="!show && transaction.details.amounts.length === 1">
-        <p>
-          {{ transaction.details.amounts[0].amount | prettyLong }}&nbsp;
-          {{ transaction.details.amounts[0].denom }}
-        </p>
-      </div>
-      <div v-if="!show && transaction.details.amounts.length > 1">
-        <p>Show multiple rewards</p>
+      <div class="tx-content-right">
+        <div v-if="!show && transaction.details.amounts.length === 1">
+          <p>
+            {{ transaction.details.amounts[0].amount | prettyLong }}&nbsp;
+            {{ transaction.details.amounts[0].denom }}
+          </p>
+        </div>
+        <div v-if="!show && transaction.details.amounts.length > 1">
+          <p>Show multiple rewards</p>
+        </div>
       </div>
     </div>
   </div>
@@ -156,6 +158,9 @@ export default {
   justify-content: space-between;
   width: 100%;
 }
+.tx-content-right {
+  padding-right: 1rem;
+}
 .validators-images-row {
   display: flex;
   flex: 3;
@@ -215,13 +220,18 @@ export default {
 .multiClaimValidatorList span {
   padding-right: 0.2rem;
 }
-@media screen and (max-width: 767px) {
+@media screen and (max-width: 822px) {
   .multiClaimValidatorList {
     justify-content: space-evenly;
     width: 100%;
   }
   .claimValidator {
     margin: 0;
+  }
+}
+@media screen and (max-width: 767px) {
+  .tx-content-right {
+    padding-right: 0;
   }
 }
 </style>

--- a/src/components/transactions/message-view/ClaimRewardsTxDetails.vue
+++ b/src/components/transactions/message-view/ClaimRewardsTxDetails.vue
@@ -322,7 +322,7 @@ export default {
 .reponsiveClaimValidator {
   margin: 0 2rem;
 }
-@media screen and (max-width: 822px) {
+@media screen and (max-width: 1035px) {
   .multiClaimValidatorList {
     justify-content: space-evenly;
     width: 100%;

--- a/src/components/transactions/message-view/ClaimRewardsTxDetails.vue
+++ b/src/components/transactions/message-view/ClaimRewardsTxDetails.vue
@@ -302,7 +302,7 @@ export default {
   align-self: flex-start;
 }
 .claimValidator {
-  margin: 0 2rem;
+  margin: 0 1rem;
 }
 .row-validator-image {
   padding: 5px;
@@ -341,7 +341,7 @@ export default {
 .reponsiveClaimValidator {
   margin: 0 2rem;
 }
-@media screen and (max-width: 1035px) {
+@media screen and (max-width: 822px) {
   .multiClaimValidatorList {
     justify-content: space-evenly;
     width: 100%;

--- a/src/components/transactions/message-view/ClaimRewardsTxDetails.vue
+++ b/src/components/transactions/message-view/ClaimRewardsTxDetails.vue
@@ -10,7 +10,11 @@
       >
         <h3 :class="{ multiClaimRewardH3: show }">{{ caption }}</h3>
         <div v-if="getValidators" class="validators-images-row">
-          <span v-if="!show && getValidators.length === 1">Rewards from</span>
+          <span
+            v-if="!show && getValidators.length === 1"
+            class="rewards-from-span"
+            >Rewards from</span
+          >
           <div
             :class="{
               multiClaimRewardRow: getValidators.length > 1 || show,
@@ -230,6 +234,7 @@ export default {
 .tx__content__left {
   display: flex;
   justify-content: space-between;
+  align-items: center;
   width: 100%;
 }
 .tx-content-right {
@@ -335,6 +340,9 @@ export default {
   }
   .reponsiveClaimValidator {
     margin: 0;
+  }
+  .rewards-from-span {
+    display: none;
   }
 }
 </style>

--- a/src/components/transactions/message-view/ClaimRewardsTxDetails.vue
+++ b/src/components/transactions/message-view/ClaimRewardsTxDetails.vue
@@ -87,11 +87,7 @@
             </div>
           </div>
           <div v-if="show && transaction.details.amounts.length > 1">
-            <div
-              v-for="coin in transaction.details.amounts"
-              :key="coin.denom"
-              class="amount"
-            >
+            <div v-for="coin in transaction.details.amounts" :key="coin.denom">
               <p class="multi-claim-reward-coin">
                 {{ coin.amount | prettyLong }}&nbsp; {{ coin.denom }}
               </p>

--- a/src/components/transactions/message-view/ClaimRewardsTxDetails.vue
+++ b/src/components/transactions/message-view/ClaimRewardsTxDetails.vue
@@ -1,9 +1,17 @@
 <template>
   <div class="tx__content">
     <TransactionIcon :transaction-type="type" />
-    <h3 class="multi-claim-reward-h3">{{ caption }}</h3>
-    <template v-if="getValidators && getValidators.length === 1">
-      <div class="tx__content__left">
+    <div class="tx__content__left">
+      <div class="tx__claim__header">
+        <h3 class="multi-claim-reward-h3">{{ caption }}</h3>
+        <div class="tx__content__right">
+          <p class="amount">
+            {{ transaction.details.amount.amount | prettyLong }}&nbsp;
+            {{ transaction.details.amount.denom }}
+          </p>
+        </div>
+      </div>
+      <template v-if="getValidators && getValidators.length === 1">
         <div class="multi-claim-reward-row">
           <span>Rewards from</span>
           <router-link
@@ -27,26 +35,21 @@
             {{ transaction.details.from[0] | resolveValidatorName(validators) }}
           </router-link>
         </div>
-      </div>
-      <div class="tx__content__right">
-        <p class="amount">
-          {{ transaction.details.amount.amount | prettyLong }}&nbsp;
-          {{ transaction.details.amount.denom }}
-        </p>
-      </div>
-    </template>
-    <template
-      v-if="getValidators && getValidators.length > 1"
-      class="validators-images-row"
-    >
-      <div class="tx__content__left multi-claim-reward-row">
+      </template>
+      <template
+        v-if="getValidators && getValidators.length > 1"
+        class="validators-images-row"
+      >
         <div class="multi-claim-reward-row" :class="{ validatorsToggle: show }">
           <div
             v-for="(validator, index) in getValidators"
             :key="validator.name.concat(`-${index}`)"
+            class="claim__validator"
           >
             <router-link
-              :to="`/staking/validators/${validator.operatorAddress}`"
+              :to="
+                show ? `/staking/validators/${validator.operatorAddress}` : ''
+              "
               class="validator-link"
             >
               <div
@@ -81,16 +84,9 @@
               </div>
             </router-link>
           </div>
-          <span v-if="!show" class="multi-claim-reward-show">Show</span>
         </div>
-      </div>
-      <div class="tx__content__right">
-        <p class="amount">
-          {{ transaction.details.amount.amount | prettyLong }}&nbsp;
-          {{ transaction.details.amount.denom }}
-        </p>
-      </div>
-    </template>
+      </template>
+    </div>
   </div>
 </template>
 
@@ -144,6 +140,13 @@ export default {
 }
 </script>
 <style scoped>
+.tx__content__left {
+  width: 100%;
+}
+.tx__claim__header {
+  display: flex;
+  align-items: center;
+}
 .validators-images-row {
   display: flex;
   flex-direction: row;
@@ -151,9 +154,13 @@ export default {
 .multi-claim-reward-row {
   display: flex;
   align-items: center;
+  justify-content: center;
 }
 .multi-claim-reward-h3 {
   margin-right: 20px;
+}
+.claim__validator {
+  margin: 0 2rem;
 }
 .row-validator-image {
   padding: 5px;
@@ -177,11 +184,20 @@ export default {
 }
 .multi-claim-reward-row.validatorsToggle {
   display: block;
+  margin-left: 10vh;
 }
 .tx a {
   margin-left: 0.1rem;
 }
 .multi-claim-reward-row span {
   padding-right: 0.2rem;
+}
+@media screen and (max-width: 767px) {
+  .multi-claim-reward-row {
+    justify-content: space-evenly;
+  }
+  .claim__validator {
+    margin: 0;
+  }
 }
 </style>

--- a/src/components/transactions/message-view/ClaimRewardsTxDetails.vue
+++ b/src/components/transactions/message-view/ClaimRewardsTxDetails.vue
@@ -5,13 +5,13 @@
       <div class="tx__claim__header" :class="{ txClaimHeaderOpen: show }">
         <h3 class="multi-claim-reward-h3">{{ caption }}</h3>
         <div class="tx__content__right">
-          <div v-if="transaction.details.amounts.length === 1">
+          <div v-if="!show && transaction.details.amounts.length === 1">
             <p>
               {{ transaction.details.amounts[0].amount | prettyLong }}&nbsp;
               {{ transaction.details.amounts[0].denom }}
             </p>
           </div>
-          <div v-else-if="!show && transaction.details.amounts.length > 1">
+          <div v-if="!show && transaction.details.amounts.length > 1">
             <p>Show multiple rewards</p>
           </div>
         </div>
@@ -92,6 +92,12 @@
                 {{ coin.amount | prettyLong }}&nbsp; {{ coin.denom }}
               </p>
             </div>
+          </div>
+          <div v-if="show && transaction.details.amounts.length === 1">
+            <p class="multi-claim-reward-coin">
+              {{ transaction.details.amounts[0].amount | prettyLong }}&nbsp;
+              {{ transaction.details.amounts[0].denom }}
+            </p>
           </div>
         </div>
       </template>

--- a/src/components/wallet/PageTransactions.vue
+++ b/src/components/wallet/PageTransactions.vue
@@ -88,7 +88,7 @@ const txFields = `
     }
     ... on ClaimRewardsTx {
       from
-      amount {
+      amounts {
         denom
         amount
       }

--- a/tests/unit/specs/components/transactions/message-view/ClaimRewardsTxDetails.spec.js
+++ b/tests/unit/specs/components/transactions/message-view/ClaimRewardsTxDetails.spec.js
@@ -14,10 +14,12 @@ describe(`ClaimRewardsTxDetails`, () => {
     fees: [],
     details: {
       from: ["cosmosvaloper123"],
-      amount: {
-        denom: "ATOM",
-        amount: "10"
-      }
+      amounts: [
+        {
+          denom: "ATOM",
+          amount: "10"
+        }
+      ]
     }
   }
 
@@ -73,7 +75,7 @@ describe(`ClaimRewardsTxDetails`, () => {
     expect(wrapper.element).toMatchSnapshot()
   })
 
-  it.only(`renders a multi claim rewards transaction message`, () => {
+  it(`renders a multi claim rewards transaction message`, () => {
     wrapper = shallowMount(ClaimRewardsTxDetails, {
       propsData: {
         transaction: multiTx,

--- a/tests/unit/specs/components/transactions/message-view/ClaimRewardsTxDetails.spec.js
+++ b/tests/unit/specs/components/transactions/message-view/ClaimRewardsTxDetails.spec.js
@@ -31,10 +31,12 @@ describe(`ClaimRewardsTxDetails`, () => {
     fees: [],
     details: {
       from: ["cosmosvaloper123", "cosmosvaloper456", "cosmosvaloper789"],
-      amount: {
-        denom: "ATOM",
-        amount: "3"
-      }
+      amounts: [
+        {
+          denom: "ATOM",
+          amount: "3"
+        }
+      ]
     }
   }
 
@@ -71,7 +73,7 @@ describe(`ClaimRewardsTxDetails`, () => {
     expect(wrapper.element).toMatchSnapshot()
   })
 
-  it(`renders a multi claim rewards transaction message`, () => {
+  it.only(`renders a multi claim rewards transaction message`, () => {
     wrapper = shallowMount(ClaimRewardsTxDetails, {
       propsData: {
         transaction: multiTx,

--- a/tests/unit/specs/components/transactions/message-view/ClaimRewardsTxDetails.spec.js
+++ b/tests/unit/specs/components/transactions/message-view/ClaimRewardsTxDetails.spec.js
@@ -96,4 +96,43 @@ describe(`ClaimRewardsTxDetails`, () => {
     )
     expect(getValidatorsResponse).toEqual([])
   })
+
+  it(`returns false if the claim was from one validator and just one denom`, () => {
+    const self = {
+      getValidators: [{ name: "Pepito" }],
+      transaction: {
+        details: {
+          amounts: [
+            {
+              amount: 1
+            }
+          ]
+        }
+      }
+    }
+    const multiClaimShow = ClaimRewardsTxDetails.computed.multiClaimShow.call(
+      self
+    )
+    expect(multiClaimShow).toBe(false)
+  })
+
+  it(`returns the show prop if the claim was not from one validator and just one denom`, () => {
+    const self = {
+      show: true,
+      getValidators: [{ name: "Pepito" }, { name: "Maria Magdalena" }],
+      transaction: {
+        details: {
+          amounts: [
+            {
+              amount: 1
+            }
+          ]
+        }
+      }
+    }
+    const multiClaimShow = ClaimRewardsTxDetails.computed.multiClaimShow.call(
+      self
+    )
+    expect(multiClaimShow).toBe(true)
+  })
 })

--- a/tests/unit/specs/components/transactions/message-view/__snapshots__/ClaimRewardsTxDetails.spec.js.snap
+++ b/tests/unit/specs/components/transactions/message-view/__snapshots__/ClaimRewardsTxDetails.spec.js.snap
@@ -67,100 +67,112 @@ exports[`ClaimRewardsTxDetails renders a multi claim rewards transaction message
     transactiontype="Claimed"
   />
    
-  <h3
-    class="multi-claim-reward-h3"
-  >
-    Claimed
-  </h3>
-   
-  <!---->
-   
   <div
-    class="tx__content__left multi-claim-reward-row"
+    class="tx__content__left"
   >
     <div
-      class="multi-claim-reward-row"
+      class="tx__claim__header"
     >
-      <div>
-        <router-link-stub
-          class="validator-link"
-          to="/staking/validators/cosmosvaloper123"
-        >
-          <div
-            class="row-validator-image"
-          >
-            <avatar-stub
-              address="cosmosvaloper123"
-              alt="generic validator logo - generated avatar from address"
-              class="validator-image"
-            />
-             
-            <!---->
-          </div>
-           
-          <!---->
-        </router-link-stub>
+      <h3
+        class="multi-claim-reward-h3"
+      >
+        Claimed
+      </h3>
+       
+      <div
+        class="tx__content__right"
+      >
+        <div>
+          <p>
+            
+            3 
+            ATOM
+          
+          </p>
+        </div>
       </div>
-      <div>
-        <router-link-stub
-          class="validator-link"
-          to="/staking/validators/cosmosvaloper456"
+    </div>
+     
+    <span>
+      Rewards from
+    </span>
+     
+    <div
+      class="multiClaimRewardRow"
+    >
+      <div
+        class="multiClaimValidatorList"
+      >
+        <div
+          class="claimValidator"
         >
-          <div
-            class="row-validator-image"
+          <router-link-stub
+            class="validator-link"
+            to=""
           >
-            <avatar-stub
-              address="cosmosvaloper456"
-              alt="generic validator logo - generated avatar from address"
-              class="validator-image"
-            />
+            <div
+              class="row-validator-image"
+            >
+              <avatar-stub
+                address="cosmosvaloper123"
+                alt="generic validator logo - generated avatar from address"
+                class="validator-image"
+              />
+               
+              <!---->
+            </div>
              
             <!---->
-          </div>
-           
-          <!---->
-        </router-link-stub>
-      </div>
-      <div>
-        <router-link-stub
-          class="validator-link"
-          to="/staking/validators/cosmosvaloper789"
+          </router-link-stub>
+        </div>
+        <div
+          class="claimValidator"
         >
-          <div
-            class="row-validator-image"
+          <router-link-stub
+            class="validator-link"
+            to=""
           >
-            <avatar-stub
-              address="cosmosvaloper789"
-              alt="generic validator logo - generated avatar from address"
-              class="validator-image"
-            />
+            <div
+              class="row-validator-image"
+            >
+              <avatar-stub
+                address="cosmosvaloper456"
+                alt="generic validator logo - generated avatar from address"
+                class="validator-image"
+              />
+               
+              <!---->
+            </div>
              
             <!---->
-          </div>
-           
-          <!---->
-        </router-link-stub>
+          </router-link-stub>
+        </div>
+        <div
+          class="claimValidator"
+        >
+          <router-link-stub
+            class="validator-link"
+            to=""
+          >
+            <div
+              class="row-validator-image"
+            >
+              <avatar-stub
+                address="cosmosvaloper789"
+                alt="generic validator logo - generated avatar from address"
+                class="validator-image"
+              />
+               
+              <!---->
+            </div>
+             
+            <!---->
+          </router-link-stub>
+        </div>
       </div>
        
-      <span
-        class="multi-claim-reward-show"
-      >
-        Show
-      </span>
+      <!---->
     </div>
-  </div>
-   
-  <div
-    class="tx__content__right"
-  >
-    <p
-      class="amount"
-    >
-      
-        3 
-        ATOM
-      
-    </p>
   </div>
 </div>
 `;

--- a/tests/unit/specs/components/transactions/message-view/__snapshots__/ClaimRewardsTxDetails.spec.js.snap
+++ b/tests/unit/specs/components/transactions/message-view/__snapshots__/ClaimRewardsTxDetails.spec.js.snap
@@ -2,196 +2,324 @@
 
 exports[`ClaimRewardsTxDetails renders a claim rewards transaction message 1`] = `
 <div
-  class="tx__content"
+  class="claim-rewards-wrapper"
 >
-  <transactionicon-stub
-    transactiontype="Claimed"
-  />
-   
   <div
-    class="tx__content__left"
+    class="tx__content"
   >
-    <h3
-      class="multi-claim-reward-h3"
-    >
-      Claimed
-    </h3>
+    <transactionicon-stub
+      transactiontype="Claimed"
+    />
      
     <div
-      class="validators-images-row"
+      class="tx__content__left"
     >
-      <span>
-        Rewards from
-      </span>
+      <h3
+        class=""
+      >
+        Claimed
+      </h3>
        
       <div
-        class="singleValidatorRewardRow"
+        class="validators-images-row"
       >
+        <span>
+          Rewards from
+        </span>
+         
         <div
           class="singleValidatorRewardRow"
         >
           <div
             class="singleValidatorRewardRow"
           >
-            <router-link-stub
-              class="validator-link"
-              to=""
+            <div
+              class="singleValidatorRewardRow"
             >
-              <div
-                class="row-validator-image"
+              <router-link-stub
+                class="validator-link"
+                to=""
               >
-                <avatar-stub
-                  address="cosmosvaloper123"
-                  alt="generic validator logo - generated avatar from address"
-                  class="validator-image"
-                />
-                 
-                <span
-                  class="validator-span"
+                <div
+                  class="row-validator-image"
                 >
-                  
+                  <avatar-stub
+                    address="cosmosvaloper123"
+                    alt="generic validator logo - generated avatar from address"
+                    class="validator-image"
+                  />
+                   
+                  <span
+                    class="validator-span"
+                  >
+                    
                   SuperValidator
                 
-                </span>
-              </div>
-               
-              <!---->
-            </router-link-stub>
+                  </span>
+                </div>
+                 
+                <!---->
+              </router-link-stub>
+            </div>
           </div>
+           
+          <!---->
+           
+          <!---->
         </div>
-         
-        <!---->
+      </div>
+       
+      <div
+        class="tx-content-right"
+      >
+        <div>
+          <p>
+            
+          10 
+          ATOM
+        
+          </p>
+        </div>
          
         <!---->
       </div>
     </div>
-     
-    <div>
-      <p>
-        
-        10 
-        ATOM
-      
-      </p>
+  </div>
+   
+  <div
+    class="multiClaimRewardRow"
+  >
+    <div
+      class="multiClaimValidatorList"
+    >
+      <div
+        class="claimValidator"
+      >
+        <router-link-stub
+          class="validator-link"
+          to=""
+        >
+          <div
+            class="row-validator-image"
+          >
+            <avatar-stub
+              address="cosmosvaloper123"
+              alt="generic validator logo - generated avatar from address"
+              class="validator-image"
+            />
+             
+            <span
+              class="validator-span"
+            >
+              
+              SuperValidator
+            
+            </span>
+          </div>
+           
+          <!---->
+        </router-link-stub>
+      </div>
     </div>
-     
-    <!---->
   </div>
 </div>
 `;
 
 exports[`ClaimRewardsTxDetails renders a multi claim rewards transaction message 1`] = `
 <div
-  class="tx__content"
+  class="claim-rewards-wrapper"
 >
-  <transactionicon-stub
-    transactiontype="Claimed"
-  />
-   
   <div
-    class="tx__content__left"
+    class="tx__content"
   >
-    <h3
-      class="multi-claim-reward-h3"
-    >
-      Claimed
-    </h3>
+    <transactionicon-stub
+      transactiontype="Claimed"
+    />
      
     <div
-      class="validators-images-row"
+      class="tx__content__left responsiveControllerMobileTrue"
     >
-      <!---->
+      <h3
+        class=""
+      >
+        Claimed
+      </h3>
        
       <div
-        class="multiClaimRewardRow"
+        class="validators-images-row"
       >
+        <!---->
+         
         <div
-          class="multiClaimValidatorList"
+          class="multiClaimRewardRow reponsiveControllerDesktop"
         >
           <div
-            class="claimValidator"
+            class="multiClaimValidatorList"
           >
-            <router-link-stub
-              class="validator-link"
-              to=""
+            <div
+              class="claimValidator"
             >
-              <div
-                class="row-validator-image"
+              <router-link-stub
+                class="validator-link"
+                to=""
               >
-                <avatar-stub
-                  address="cosmosvaloper123"
-                  alt="generic validator logo - generated avatar from address"
-                  class="validator-image"
-                />
+                <div
+                  class="row-validator-image"
+                >
+                  <avatar-stub
+                    address="cosmosvaloper123"
+                    alt="generic validator logo - generated avatar from address"
+                    class="validator-image"
+                  />
+                   
+                  <!---->
+                </div>
                  
                 <!---->
-              </div>
-               
-              <!---->
-            </router-link-stub>
-          </div>
-          <div
-            class="claimValidator"
-          >
-            <router-link-stub
-              class="validator-link"
-              to=""
+              </router-link-stub>
+            </div>
+            <div
+              class="claimValidator"
             >
-              <div
-                class="row-validator-image"
+              <router-link-stub
+                class="validator-link"
+                to=""
               >
-                <avatar-stub
-                  address="cosmosvaloper456"
-                  alt="generic validator logo - generated avatar from address"
-                  class="validator-image"
-                />
+                <div
+                  class="row-validator-image"
+                >
+                  <avatar-stub
+                    address="cosmosvaloper456"
+                    alt="generic validator logo - generated avatar from address"
+                    class="validator-image"
+                  />
+                   
+                  <!---->
+                </div>
                  
                 <!---->
-              </div>
-               
-              <!---->
-            </router-link-stub>
-          </div>
-          <div
-            class="claimValidator"
-          >
-            <router-link-stub
-              class="validator-link"
-              to=""
+              </router-link-stub>
+            </div>
+            <div
+              class="claimValidator"
             >
-              <div
-                class="row-validator-image"
+              <router-link-stub
+                class="validator-link"
+                to=""
               >
-                <avatar-stub
-                  address="cosmosvaloper789"
-                  alt="generic validator logo - generated avatar from address"
-                  class="validator-image"
-                />
+                <div
+                  class="row-validator-image"
+                >
+                  <avatar-stub
+                    address="cosmosvaloper789"
+                    alt="generic validator logo - generated avatar from address"
+                    class="validator-image"
+                  />
+                   
+                  <!---->
+                </div>
                  
                 <!---->
-              </div>
-               
-              <!---->
-            </router-link-stub>
+              </router-link-stub>
+            </div>
           </div>
+           
+          <!---->
+           
+          <!---->
         </div>
-         
-        <!---->
+      </div>
+       
+      <div
+        class="tx-content-right"
+      >
+        <div>
+          <p>
+            
+          3 
+          ATOM
+        
+          </p>
+        </div>
          
         <!---->
       </div>
     </div>
-     
-    <div>
-      <p>
-        
-        3 
-        ATOM
-      
-      </p>
+  </div>
+   
+  <div
+    class="multiClaimRewardRow reponsiveControllerMobile"
+  >
+    <div
+      class="multiClaimValidatorList"
+    >
+      <div
+        class="claimValidator"
+      >
+        <router-link-stub
+          class="validator-link"
+          to=""
+        >
+          <div
+            class="row-validator-image"
+          >
+            <avatar-stub
+              address="cosmosvaloper123"
+              alt="generic validator logo - generated avatar from address"
+              class="validator-image"
+            />
+             
+            <!---->
+          </div>
+           
+          <!---->
+        </router-link-stub>
+      </div>
+      <div
+        class="claimValidator"
+      >
+        <router-link-stub
+          class="validator-link"
+          to=""
+        >
+          <div
+            class="row-validator-image"
+          >
+            <avatar-stub
+              address="cosmosvaloper456"
+              alt="generic validator logo - generated avatar from address"
+              class="validator-image"
+            />
+             
+            <!---->
+          </div>
+           
+          <!---->
+        </router-link-stub>
+      </div>
+      <div
+        class="claimValidator"
+      >
+        <router-link-stub
+          class="validator-link"
+          to=""
+        >
+          <div
+            class="row-validator-image"
+          >
+            <avatar-stub
+              address="cosmosvaloper789"
+              alt="generic validator logo - generated avatar from address"
+              class="validator-image"
+            />
+             
+            <!---->
+          </div>
+           
+          <!---->
+        </router-link-stub>
+      </div>
     </div>
-     
-    <!---->
   </div>
 </div>
 `;

--- a/tests/unit/specs/components/transactions/message-view/__snapshots__/ClaimRewardsTxDetails.spec.js.snap
+++ b/tests/unit/specs/components/transactions/message-view/__snapshots__/ClaimRewardsTxDetails.spec.js.snap
@@ -23,7 +23,9 @@ exports[`ClaimRewardsTxDetails renders a claim rewards transaction message 1`] =
       <div
         class="validators-images-row"
       >
-        <span>
+        <span
+          class="rewards-from-span"
+        >
           Rewards from
         </span>
          

--- a/tests/unit/specs/components/transactions/message-view/__snapshots__/ClaimRewardsTxDetails.spec.js.snap
+++ b/tests/unit/specs/components/transactions/message-view/__snapshots__/ClaimRewardsTxDetails.spec.js.snap
@@ -90,6 +90,8 @@ exports[`ClaimRewardsTxDetails renders a multi claim rewards transaction message
           
           </p>
         </div>
+         
+        <!---->
       </div>
     </div>
      
@@ -170,6 +172,8 @@ exports[`ClaimRewardsTxDetails renders a multi claim rewards transaction message
           </router-link-stub>
         </div>
       </div>
+       
+      <!---->
        
       <!---->
     </div>

--- a/tests/unit/specs/components/transactions/message-view/__snapshots__/ClaimRewardsTxDetails.spec.js.snap
+++ b/tests/unit/specs/components/transactions/message-view/__snapshots__/ClaimRewardsTxDetails.spec.js.snap
@@ -8,54 +8,75 @@ exports[`ClaimRewardsTxDetails renders a claim rewards transaction message 1`] =
     transactiontype="Claimed"
   />
    
-  <h3
-    class="multi-claim-reward-h3"
-  >
-    Claimed
-  </h3>
-   
   <div
     class="tx__content__left"
   >
+    <h3
+      class="multi-claim-reward-h3"
+    >
+      Claimed
+    </h3>
+     
     <div
-      class="multi-claim-reward-row"
+      class="validators-images-row"
     >
       <span>
         Rewards from
       </span>
        
-      <router-link-stub
-        class="validator-link"
-        to="/staking/validators/cosmosvaloper123"
+      <div
+        class="singleValidatorRewardRow"
       >
-        <avatar-stub
-          address="cosmosvaloper123"
-          alt="generic validator logo - generated avatar from address"
-          class="validator-image"
-        />
+        <div
+          class="singleValidatorRewardRow"
+        >
+          <div
+            class="singleValidatorRewardRow"
+          >
+            <router-link-stub
+              class="validator-link"
+              to=""
+            >
+              <div
+                class="row-validator-image"
+              >
+                <avatar-stub
+                  address="cosmosvaloper123"
+                  alt="generic validator logo - generated avatar from address"
+                  class="validator-image"
+                />
+                 
+                <span
+                  class="validator-span"
+                >
+                  
+                  SuperValidator
+                
+                </span>
+              </div>
+               
+              <!---->
+            </router-link-stub>
+          </div>
+        </div>
          
         <!---->
-        
-          SuperValidator
-        
-      </router-link-stub>
+         
+        <!---->
+      </div>
     </div>
-  </div>
-   
-  <div
-    class="tx__content__right"
-  >
-    <p
-      class="amount"
-    >
-      
+     
+    <div>
+      <p>
+        
         10 
         ATOM
       
-    </p>
+      </p>
+    </div>
+     
+    <!---->
   </div>
-   
-  <!---->
 </div>
 `;
 
@@ -70,113 +91,107 @@ exports[`ClaimRewardsTxDetails renders a multi claim rewards transaction message
   <div
     class="tx__content__left"
   >
-    <div
-      class="tx__claim__header"
+    <h3
+      class="multi-claim-reward-h3"
     >
-      <h3
-        class="multi-claim-reward-h3"
-      >
-        Claimed
-      </h3>
+      Claimed
+    </h3>
+     
+    <div
+      class="validators-images-row"
+    >
+      <!---->
        
       <div
-        class="tx__content__right"
+        class="multiClaimRewardRow"
       >
-        <div>
-          <p>
-            
-            3 
-            ATOM
-          
-          </p>
+        <div
+          class="multiClaimValidatorList"
+        >
+          <div
+            class="claimValidator"
+          >
+            <router-link-stub
+              class="validator-link"
+              to=""
+            >
+              <div
+                class="row-validator-image"
+              >
+                <avatar-stub
+                  address="cosmosvaloper123"
+                  alt="generic validator logo - generated avatar from address"
+                  class="validator-image"
+                />
+                 
+                <!---->
+              </div>
+               
+              <!---->
+            </router-link-stub>
+          </div>
+          <div
+            class="claimValidator"
+          >
+            <router-link-stub
+              class="validator-link"
+              to=""
+            >
+              <div
+                class="row-validator-image"
+              >
+                <avatar-stub
+                  address="cosmosvaloper456"
+                  alt="generic validator logo - generated avatar from address"
+                  class="validator-image"
+                />
+                 
+                <!---->
+              </div>
+               
+              <!---->
+            </router-link-stub>
+          </div>
+          <div
+            class="claimValidator"
+          >
+            <router-link-stub
+              class="validator-link"
+              to=""
+            >
+              <div
+                class="row-validator-image"
+              >
+                <avatar-stub
+                  address="cosmosvaloper789"
+                  alt="generic validator logo - generated avatar from address"
+                  class="validator-image"
+                />
+                 
+                <!---->
+              </div>
+               
+              <!---->
+            </router-link-stub>
+          </div>
         </div>
+         
+        <!---->
          
         <!---->
       </div>
     </div>
      
-    <span>
-      Rewards from
-    </span>
-     
-    <div
-      class="multiClaimRewardRow"
-    >
-      <div
-        class="multiClaimValidatorList"
-      >
-        <div
-          class="claimValidator"
-        >
-          <router-link-stub
-            class="validator-link"
-            to=""
-          >
-            <div
-              class="row-validator-image"
-            >
-              <avatar-stub
-                address="cosmosvaloper123"
-                alt="generic validator logo - generated avatar from address"
-                class="validator-image"
-              />
-               
-              <!---->
-            </div>
-             
-            <!---->
-          </router-link-stub>
-        </div>
-        <div
-          class="claimValidator"
-        >
-          <router-link-stub
-            class="validator-link"
-            to=""
-          >
-            <div
-              class="row-validator-image"
-            >
-              <avatar-stub
-                address="cosmosvaloper456"
-                alt="generic validator logo - generated avatar from address"
-                class="validator-image"
-              />
-               
-              <!---->
-            </div>
-             
-            <!---->
-          </router-link-stub>
-        </div>
-        <div
-          class="claimValidator"
-        >
-          <router-link-stub
-            class="validator-link"
-            to=""
-          >
-            <div
-              class="row-validator-image"
-            >
-              <avatar-stub
-                address="cosmosvaloper789"
-                alt="generic validator logo - generated avatar from address"
-                class="validator-image"
-              />
-               
-              <!---->
-            </div>
-             
-            <!---->
-          </router-link-stub>
-        </div>
-      </div>
-       
-      <!---->
-       
-      <!---->
+    <div>
+      <p>
+        
+        3 
+        ATOM
+      
+      </p>
     </div>
+     
+    <!---->
   </div>
 </div>
 `;

--- a/tests/unit/specs/components/transactions/message-view/__snapshots__/ClaimRewardsTxDetails.spec.js.snap
+++ b/tests/unit/specs/components/transactions/message-view/__snapshots__/ClaimRewardsTxDetails.spec.js.snap
@@ -53,8 +53,8 @@ exports[`ClaimRewardsTxDetails renders a claim rewards transaction message 1`] =
                     class="validator-span"
                   >
                     
-                  SuperValidator
-                
+                    SuperValidator
+                  
                   </span>
                 </div>
                  
@@ -75,9 +75,9 @@ exports[`ClaimRewardsTxDetails renders a claim rewards transaction message 1`] =
         <div>
           <p>
             
-          10 
-          ATOM
-        
+            10 
+            ATOM
+          
           </p>
         </div>
          
@@ -86,42 +86,7 @@ exports[`ClaimRewardsTxDetails renders a claim rewards transaction message 1`] =
     </div>
   </div>
    
-  <div
-    class="multiClaimRewardRow"
-  >
-    <div
-      class="multiClaimValidatorList"
-    >
-      <div
-        class="claimValidator"
-      >
-        <router-link-stub
-          class="validator-link"
-          to=""
-        >
-          <div
-            class="row-validator-image"
-          >
-            <avatar-stub
-              address="cosmosvaloper123"
-              alt="generic validator logo - generated avatar from address"
-              class="validator-image"
-            />
-             
-            <span
-              class="validator-span"
-            >
-              
-              SuperValidator
-            
-            </span>
-          </div>
-           
-          <!---->
-        </router-link-stub>
-      </div>
-    </div>
-  </div>
+  <!---->
 </div>
 `;
 
@@ -236,9 +201,9 @@ exports[`ClaimRewardsTxDetails renders a multi claim rewards transaction message
         <div>
           <p>
             
-          3 
-          ATOM
-        
+            3 
+            ATOM
+          
           </p>
         </div>
          
@@ -251,10 +216,10 @@ exports[`ClaimRewardsTxDetails renders a multi claim rewards transaction message
     class="multiClaimRewardRow reponsiveControllerMobile"
   >
     <div
-      class="multiClaimValidatorList"
+      class="responsiveMultiClaimValidatorList"
     >
       <div
-        class="claimValidator"
+        class="reponsiveClaimValidator"
       >
         <router-link-stub
           class="validator-link"
@@ -276,7 +241,7 @@ exports[`ClaimRewardsTxDetails renders a multi claim rewards transaction message
         </router-link-stub>
       </div>
       <div
-        class="claimValidator"
+        class="reponsiveClaimValidator"
       >
         <router-link-stub
           class="validator-link"
@@ -298,7 +263,7 @@ exports[`ClaimRewardsTxDetails renders a multi claim rewards transaction message
         </router-link-stub>
       </div>
       <div
-        class="claimValidator"
+        class="reponsiveClaimValidator"
       >
         <router-link-stub
           class="validator-link"

--- a/tests/unit/specs/components/transactions/message-view/__snapshots__/ClaimRewardsTxDetails.spec.js.snap
+++ b/tests/unit/specs/components/transactions/message-view/__snapshots__/ClaimRewardsTxDetails.spec.js.snap
@@ -30,13 +30,13 @@ exports[`ClaimRewardsTxDetails renders a claim rewards transaction message 1`] =
         </span>
          
         <div
-          class="singleValidatorRewardRow"
+          class=""
         >
           <div
-            class="singleValidatorRewardRow"
+            class=""
           >
             <div
-              class="singleValidatorRewardRow"
+              class="claimValidator singleValidatorRewardRow"
             >
               <router-link-stub
                 class="validator-link"


### PR DESCRIPTION
Only works together with luniehq/lunie-api#493

**Description:**

<!-- Briefly describe what you're adding or fixing with this PR -->

Making the ClaimRewardsTxDetails great again!

Inspired but not strictly following Charlie's design (since some things don't fit how currently the details components are displayed).

This is how it looks now:

- For multiple validators:

![image](https://user-images.githubusercontent.com/40721795/77234471-ecd3b380-6bae-11ea-9d3b-7b72e41756a0.png)

![image](https://user-images.githubusercontent.com/40721795/77234462-d9c0e380-6bae-11ea-909f-45128271cc55.png)

- For a single validator:

![image](https://user-images.githubusercontent.com/40721795/77234490-17257100-6baf-11ea-9522-bcfa93f75873.png)

(Single validator open: this is the case I am most doubtful about)

![image](https://user-images.githubusercontent.com/40721795/77234494-29071400-6baf-11ea-9b90-5f7a788f8234.png)

Please, do share all your suggestions & design wisdom & awesome CSS skills 🙏 

Thank you! 🚀

---

For contributor:

- [ ] Added changes entries. Run `yarn changelog` for a guided process.
- [ ] Reviewed `Files changed` in the github PR explorer
- [ ] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI
