### PR TITLE
Ana/prevent claimrewards opens in extension

### DIFF
--- a/changes/ana_prevent-claimrewards-opening-in-extension
+++ b/changes/ana_prevent-claimrewards-opening-in-extension
@@ -1,0 +1,1 @@
+[Changed] [#3758](https://github.com/cosmos/lunie/pull/3758) Prevents ClaimRewardsTxDetails component from "opening" in the extension @Bitcoinera

--- a/src/components/transactions/message-view/ClaimRewardsTxDetails.vue
+++ b/src/components/transactions/message-view/ClaimRewardsTxDetails.vue
@@ -189,6 +189,7 @@
 </template>
 
 <script>
+import { mapGetters } from "vuex"
 import { prettyLong } from "scripts/num.js"
 import { resolveValidatorName } from "src/filters"
 import TransactionIcon from "../TransactionIcon"
@@ -225,6 +226,7 @@ export default {
     }
   },
   computed: {
+    ...mapGetters([`isExtension`]),
     getValidators() {
       if (this.validators && Object.keys(this.validators).length > 0) {
         return this.transaction.details.from.map(validatorAddress => {
@@ -236,8 +238,9 @@ export default {
     },
     multiClaimShow() {
       // here we prevent any changes for the particular case of one validator and one single denom
-      return this.getValidators.length === 1 &&
-        this.transaction.details.amounts.length === 1
+      return (this.getValidators.length === 1 &&
+        this.transaction.details.amounts.length === 1) ||
+        this.isExtension
         ? false
         : this.show
     }

--- a/tests/unit/specs/components/transactions/message-view/ClaimRewardsTxDetails.spec.js
+++ b/tests/unit/specs/components/transactions/message-view/ClaimRewardsTxDetails.spec.js
@@ -82,6 +82,13 @@ describe(`ClaimRewardsTxDetails`, () => {
         validators: validators,
         show: false
       },
+      mocks: {
+        $store: {
+          getters: {
+            isExtension: false
+          }
+        }
+      },
       stubs: [`router-link`]
     })
     expect(wrapper.element).toMatchSnapshot()


### PR DESCRIPTION
Closes #ISSUE

**Description:**

<!-- Briefly describe what you're adding or fixing with this PR -->
Prevent ClaimRewardsTxDetails component from "opening" in the extension. That is, no validators names and no multi denom are displayed

Thank you! 🚀

---

For contributor:

- [ ] Added changes entries. Run `yarn changelog` for a guided process.
- [ ] Reviewed `Files changed` in the github PR explorer
- [ ] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI
