### PR TITLE
Fix polkadot amount conversion

### DIFF
--- a/changes/mario_3761-polkadot-unit-conversion
+++ b/changes/mario_3761-polkadot-unit-conversion
@@ -1,0 +1,1 @@
+[Fixed] [#3761](https://github.com/cosmos/lunie/issues/3761) Fix polkadot amount conversion @mariopino

--- a/src/ActionModal/utils/networkMessages/polkadot-testnet.js
+++ b/src/ActionModal/utils/networkMessages/polkadot-testnet.js
@@ -11,7 +11,7 @@ export async function MsgSend(
 ) {
   return await getSignMessage(senderAddress, "balances", "transfer", [
     toAddress,
-    amounts[0].amount * 1000000
+    amounts[0].amount * 1000000 // FIXME! Need to clarify why this conversion factor
   ])
 }
 

--- a/src/ActionModal/utils/networkMessages/polkadot-testnet.js
+++ b/src/ActionModal/utils/networkMessages/polkadot-testnet.js
@@ -11,7 +11,7 @@ export async function MsgSend(
 ) {
   return await getSignMessage(senderAddress, "balances", "transfer", [
     toAddress,
-    amounts[0].amount
+    amounts[0].amount * 1000000
   ])
 }
 


### PR DESCRIPTION
Closes #3761 

**Description:**

Fix polkadot amount conversion by applying this conversion factor:

```
amounts[0].amount * 1000000
```

Thank you! 🚀

---

For contributor:

- [ ] Added changes entries. Run `yarn changelog` for a guided process.
- [ ] Reviewed `Files changed` in the github PR explorer
- [ ] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI
