### PR TITLE
Ana/fix gas estimate for emoney claim rewards

### DIFF
--- a/changes/ana_fix-emoney-claim-rewards-gas-estimate
+++ b/changes/ana_fix-emoney-claim-rewards-gas-estimate
@@ -1,0 +1,1 @@
+[Changed] [#3789](https://github.com/cosmos/lunie/pull/3789) Leaves the default gas estimate, 550000, on e-Money when it is a Claim Rewards action @Bitcoinera

--- a/src/ActionModal/components/ActionModal.vue
+++ b/src/ActionModal/components/ActionModal.vue
@@ -447,8 +447,13 @@ export default {
       )
     },
     estimatedFee() {
-      // another hack
-      this.updateEmoneyGasEstimate()
+      // another hack. e-Money doesn't neet such a high gas estimate for sending
+      if (
+        this.networkId.startsWith(`emoney`) &&
+        this.transactionData.type !== transactionTypes.WITHDRAW
+      ) {
+        this.updateEmoneyGasEstimate()
+      }
       // hack
       // terra uses a tax on all send txs
       if (
@@ -556,9 +561,7 @@ export default {
   },
   methods: {
     updateEmoneyGasEstimate() {
-      if (this.network.id.startsWith(`emoney`)) {
-        this.gasEstimate = 200000
-      }
+      this.gasEstimate = 200000
     },
     confirmModalOpen() {
       let confirmResult = false

--- a/src/ActionModal/components/ActionModal.vue
+++ b/src/ActionModal/components/ActionModal.vue
@@ -300,7 +300,7 @@ import * as Sentry from "@sentry/browser"
 
 import ActionManager from "../utils/ActionManager"
 import BigNumber from "bignumber.js"
-// import transactionTypes from '../utils/transactionTypes'
+import transactionTypes from "../utils/transactionTypes"
 
 const defaultStep = `details`
 const feeStep = `fees`

--- a/src/ActionModal/components/ActionModal.vue
+++ b/src/ActionModal/components/ActionModal.vue
@@ -563,7 +563,7 @@ export default {
   },
   methods: {
     updateTerraGasEstimate() {
-      this.gasEstimate = 200000
+      this.gasEstimate = 300000
     },
     updateEmoneyGasEstimate() {
       this.gasEstimate = 200000

--- a/tests/unit/specs/components/ActionModal/components/ActionModal.spec.js
+++ b/tests/unit/specs/components/ActionModal/components/ActionModal.spec.js
@@ -196,6 +196,21 @@ describe(`ActionModal`, () => {
     expect(maxAmount).toBe(0.00855)
   })
 
+  it(`should not update the gas estimate for emoney when it is a claim rewards transaction`, () => {
+    const self = {
+      gasPrice: "1.5e-8",
+      gasEstimate: 550000,
+      networkId: `emoney-mainnet`,
+      transactionData: {
+        type: `MsgWithdrawDelegationReward`
+      },
+      maxDecimals: ActionModal.methods.maxDecimals,
+      updateEmoneyGasEstimate: ActionModal.methods.updateEmoneyGasEstimate
+    }
+    ActionModal.computed.estimatedFee.call(self)
+    expect(self.gasEstimate).toBe(550000)
+  })
+
   it(`should set the submissionError if the submission is rejected`, async () => {
     const ActionManagerSend = jest
       .fn()

--- a/tests/unit/specs/components/common/Address.spec.js
+++ b/tests/unit/specs/components/common/Address.spec.js
@@ -5,7 +5,7 @@ import { formatAddress } from "src/filters"
 
 const localVue = createLocalVue()
 localVue.directive(`clipboard`, VueClipboard)
-localVue.directive(`tooltip`, () => { })
+localVue.directive(`tooltip`, () => {})
 localVue.filter(`formatAddress`, formatAddress)
 
 describe(`Address Component`, () => {


### PR DESCRIPTION
Closes #ISSUE

**Description:**

<!-- Briefly describe what you're adding or fixing with this PR -->
It leaves the default gas estimate for e-Money when claiming rewards. Otherwise it was resulting in an out of gas error.


Thank you! 🚀

---

For contributor:

- [ ] Added changes entries. Run `yarn changelog` for a guided process.
- [ ] Reviewed `Files changed` in the github PR explorer
- [ ] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI
