### PR TITLE
Fabo/allow ngm sending

### DIFF
--- a/changes/fabo_allow-ngm-sending
+++ b/changes/fabo_allow-ngm-sending
@@ -1,0 +1,1 @@
+[Changed] Allow sending to and from whitelisted accounts in emoney @faboweb

--- a/src/ActionModal/components/SendModal.vue
+++ b/src/ActionModal/components/SendModal.vue
@@ -226,7 +226,21 @@ export default {
         : []
     },
     sendingNgm() {
-      return this.selectedToken === "NGM" && this.network === "emoney-mainnet"
+      const whitelistedAccount = [
+        "emoney1cs4323dyzu0wxfj4vc62m8q3xsczfavqx9x3zd",
+        "emoney147verqcxwdkgrn663x2qj66zyqc5mu479afw9n",
+        "emoney14r5rva8qk5ee6rvk5sdtmxea40uf74k7uh4yjv",
+        "emoney1s73cel9vxllx700eaeuqr70663w5f0twzcks3l",
+        "emoney1uae5c48qjdc9psfzkwvre0shm9z8wlsfnse2nz"
+      ]
+      return (
+        this.selectedToken === "NGM" &&
+        this.network === "emoney-mainnet" &&
+        !(
+          whitelistedAccount.includes(this.userAddress) ||
+          whitelistedAccount.includes(this.address)
+        )
+      )
     }
   },
   watch: {


### PR DESCRIPTION
Some accounts in emoney are actually whitelisted. So we allow sending for those