### PR TITLE
Ana/apply network capabilities as enums (retro-compatible)

### DIFF
--- a/changes/ana_apply-network-capabilities-as-enums
+++ b/changes/ana_apply-network-capabilities-as-enums
@@ -1,0 +1,1 @@
+[Changed] [#3794](https://github.com/cosmos/lunie/pull/3794) Now network capabilities can be handled both as String and as Boolean @Bitcoinera

--- a/src/ActionModal/components/ActionModal.vue
+++ b/src/ActionModal/components/ActionModal.vue
@@ -337,9 +337,9 @@ const sessionType = {
 }
 
 const networkCapabilityDictionary = {
-  ENABLED: true,
-  DISABLED: false,
-  MISSING: null
+  true: "ENABLED",
+  false: "DISABLED",
+  null: "MISSING"
 }
 
 export default {
@@ -442,7 +442,7 @@ export default {
     checkFeatureAvailable() {
       const action = `action_` + this.featureFlag
       return typeof this.network[action] === `string`
-        ? networkCapabilityDictionary[this.network[action]]
+        ? networkCapabilityDictionary[this.network[action]] === "ENABLED"
         : this.network[action]
     },
     network() {

--- a/src/ActionModal/components/ActionModal.vue
+++ b/src/ActionModal/components/ActionModal.vue
@@ -336,6 +336,12 @@ const sessionType = {
   EXTENSION: SIGN_METHODS.EXTENSION
 }
 
+const networkCapabilityDictionary = {
+  ENABLED: true,
+  DISABLED: false,
+  MISSING: null
+}
+
 export default {
   name: `action-modal`,
   components: {
@@ -435,7 +441,9 @@ export default {
     ...mapGetters({ networkId: `network` }),
     checkFeatureAvailable() {
       const action = `action_` + this.featureFlag
-      return this.network[action] === true
+      return typeof this.network[action] === `string`
+        ? networkCapabilityDictionary[this.network[action]]
+        : this.network[action] === true
     },
     network() {
       return this.networks.find(({ id }) => id == this.networkId)

--- a/src/ActionModal/components/ActionModal.vue
+++ b/src/ActionModal/components/ActionModal.vue
@@ -443,7 +443,7 @@ export default {
       const action = `action_` + this.featureFlag
       return typeof this.network[action] === `string`
         ? networkCapabilityDictionary[this.network[action]]
-        : this.network[action] === true
+        : this.network[action]
     },
     network() {
       return this.networks.find(({ id }) => id == this.networkId)

--- a/src/ActionModal/components/ActionModal.vue
+++ b/src/ActionModal/components/ActionModal.vue
@@ -441,9 +441,11 @@ export default {
     ...mapGetters({ networkId: `network` }),
     checkFeatureAvailable() {
       const action = `action_` + this.featureFlag
-      return typeof this.network[action] === `string`
+      // DEPRECATE to support the upgrade of the old Boolean value to the new ENUM capability model, we support here temporarily the upgrade from the Boolean model to the ENUM model
+      return typeof this.network[action] === `boolean` ||
+        this.network[action] === null
         ? networkCapabilityDictionary[this.network[action]] === "ENABLED"
-        : this.network[action]
+        : this.network[action] === "ENABLED"
     },
     network() {
       return this.networks.find(({ id }) => id == this.networkId)

--- a/src/gql/index.js
+++ b/src/gql/index.js
@@ -134,31 +134,6 @@ export const NetworksAll = gql`
   }
 `
 
-// capability is 'feature_portfolio' / 'action_send'
-export const NetworkCapability = networkId => gql`
-query Networks {
-  network(id: "${networkId}") {
-    id
-    feature_session
-    feature_portfolio
-    feature_validators
-    feature_proposals
-    feature_activity
-    feature_explorer
-    action_send
-    action_claim_rewards
-    action_delegate
-    action_redelegate
-    action_undelegate
-    action_deposit
-    action_vote
-    action_proposal
-    stakingDenom
-  }
-}
-`
-
-export const NetworkCapabilityResult = action => data => data.network[action]
 export const NetworksResult = data => data.networks
 
 const ProposalFragment = `

--- a/src/router.js
+++ b/src/router.js
@@ -7,9 +7,9 @@ import Vue from "vue"
 Vue.use(router)
 
 const networkCapabilityDictionary = {
-  ENABLED: true,
-  DISABLED: false,
-  MISSING: null
+  true: "ENABLED",
+  false: "DISABLED",
+  null: "MISSING"
 }
 
 export const routeGuard = (store, apollo) => async (to, from, next) => {
@@ -58,6 +58,6 @@ async function featureAvailable(apollo, networkId, to) {
   const networkCapabilityResult = NetworkCapabilityResult(feature)(data)
   // hack to ensure retro compatibility with old API (network capabilities as booleans)
   return typeof networkCapabilityResult === `string`
-    ? networkCapabilityDictionary[networkCapabilityResult]
+    ? networkCapabilityDictionary[networkCapabilityResult] === "ENABLED"
     : networkCapabilityResult
 }

--- a/src/router.js
+++ b/src/router.js
@@ -6,6 +6,12 @@ import Vue from "vue"
 /* istanbul ignore next */
 Vue.use(router)
 
+const networkCapabilityDictionary = {
+  ENABLED: true,
+  DISABLED: false,
+  MISSING: null
+}
+
 export const routeGuard = (store, apollo) => async (to, from, next) => {
   // Set any open modal to false
   store.state.session.currrentModalOpen = false
@@ -49,5 +55,9 @@ async function featureAvailable(apollo, networkId, to) {
   const { data } = await apollo.query({
     query: NetworkCapability(networkId)
   })
-  return NetworkCapabilityResult(feature)(data)
+  const networkCapabilityResult = NetworkCapabilityResult(feature)(data)
+  // hack to ensure retro compatibility with old API (network capabilities as booleans)
+  return typeof networkCapabilityResult === `string`
+    ? networkCapabilityDictionary[networkCapabilityResult]
+    : networkCapabilityResult
 }

--- a/tests/unit/specs/components/common/Address.spec.js
+++ b/tests/unit/specs/components/common/Address.spec.js
@@ -5,7 +5,7 @@ import { formatAddress } from "src/filters"
 
 const localVue = createLocalVue()
 localVue.directive(`clipboard`, VueClipboard)
-localVue.directive(`tooltip`, () => { })
+localVue.directive(`tooltip`, () => {})
 localVue.filter(`formatAddress`, formatAddress)
 
 describe(`Address Component`, () => {


### PR DESCRIPTION
Closes #ISSUE

**Description:**

<!-- Briefly describe what you're adding or fixing with this PR -->
Handles network capabilities both as a String and as a Boolean

Should be merged once luniehq/lunie-api#510 is in

Thank you! 🚀

---

For contributor:

- [ ] Added changes entries. Run `yarn changelog` for a guided process.
- [ ] Reviewed `Files changed` in the github PR explorer
- [ ] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI
