### PR TITLE
changed footer message directing to help center article

### DIFF
--- a/changes/james_add-activity-link-to-helpcenter-article
+++ b/changes/james_add-activity-link-to-helpcenter-article
@@ -1,0 +1,1 @@
+[Changed] [#3676](https://github.com/cosmos/lunie/issues/3676) changed copy in activity footer directing to helpcenter link about viewing past chain data @jrmoreau

--- a/src/components/wallet/PageTransactions.vue
+++ b/src/components/wallet/PageTransactions.vue
@@ -25,10 +25,13 @@
           Looking for older transactions?
         </div>
         <div slot="subtitle">
-          Unfortunately, we can't display transactions from previous chains
-          right now.
-          <a class="intercom-button" @click="handleIntercom()">Let us know</a>
-          if you'd like access these transactions.
+          <p>
+            Lunie cannot display transactions from previous chains in your activity page. 
+          </p>
+          <p>if you would like to view information from previous chain upgrades
+          please click <a href="https://intercom.help/lunie/en/articles/3787014-how-to-get-blockchain-data-from-previous-chain-upgrades">here.</a>
+          </p>
+          
         </div>
       </TmDataMsg>
     </template>

--- a/src/components/wallet/PageTransactions.vue
+++ b/src/components/wallet/PageTransactions.vue
@@ -28,8 +28,8 @@
           <p>
             Lunie cannot display transactions from previous chains in your activity page. 
           </p>
-          <p>if you would like to view information from previous chain upgrades
-          please click <a href="https://intercom.help/lunie/en/articles/3787014-how-to-get-blockchain-data-from-previous-chain-upgrades">here.</a>
+          <p>If you would like to view information from previous chain upgrades
+          please visit our <a href="https://intercom.help/lunie/en/articles/3787014-how-to-get-blockchain-data-from-previous-chain-upgrades">Help Center.</a>
           </p>
           
         </div>

--- a/tests/unit/specs/components/wallet/__snapshots__/PageTransactions.spec.js.snap
+++ b/tests/unit/specs/components/wallet/__snapshots__/PageTransactions.spec.js.snap
@@ -40,12 +40,12 @@ exports[`PageTransactions Renders correctly and does not load transactions if th
         </p>
          
         <p>
-          if you would like to view information from previous chain upgrades
-        please click 
+          If you would like to view information from previous chain upgrades
+        please visit our 
           <a
             href="https://intercom.help/lunie/en/articles/3787014-how-to-get-blockchain-data-from-previous-chain-upgrades"
           >
-            here.
+            Help Center.
           </a>
         </p>
       </div>
@@ -96,12 +96,12 @@ exports[`PageTransactions Renders correctly and loads transactions 1`] = `
         </p>
          
         <p>
-          if you would like to view information from previous chain upgrades
-        please click 
+          If you would like to view information from previous chain upgrades
+        please visit our 
           <a
             href="https://intercom.help/lunie/en/articles/3787014-how-to-get-blockchain-data-from-previous-chain-upgrades"
           >
-            here.
+            Help Center.
           </a>
         </p>
       </div>

--- a/tests/unit/specs/components/wallet/__snapshots__/PageTransactions.spec.js.snap
+++ b/tests/unit/specs/components/wallet/__snapshots__/PageTransactions.spec.js.snap
@@ -33,18 +33,21 @@ exports[`PageTransactions Renders correctly and does not load transactions if th
       </div>
        
       <div>
+        <p>
+          
+          Lunie cannot display transactions from previous chains in your activity page. 
         
-        Unfortunately, we can't display transactions from previous chains
-        right now.
-        
-        <a
-          class="intercom-button"
-        >
-          Let us know
-        </a>
-        
-        if you'd like access these transactions.
-      
+        </p>
+         
+        <p>
+          if you would like to view information from previous chain upgrades
+        please click 
+          <a
+            href="https://intercom.help/lunie/en/articles/3787014-how-to-get-blockchain-data-from-previous-chain-upgrades"
+          >
+            here.
+          </a>
+        </p>
       </div>
     </tmdatamsg-stub>
   </template>
@@ -86,18 +89,21 @@ exports[`PageTransactions Renders correctly and loads transactions 1`] = `
       </div>
        
       <div>
+        <p>
+          
+          Lunie cannot display transactions from previous chains in your activity page. 
         
-        Unfortunately, we can't display transactions from previous chains
-        right now.
-        
-        <a
-          class="intercom-button"
-        >
-          Let us know
-        </a>
-        
-        if you'd like access these transactions.
-      
+        </p>
+         
+        <p>
+          if you would like to view information from previous chain upgrades
+        please click 
+          <a
+            href="https://intercom.help/lunie/en/articles/3787014-how-to-get-blockchain-data-from-previous-chain-upgrades"
+          >
+            here.
+          </a>
+        </p>
       </div>
     </tmdatamsg-stub>
   </template>


### PR DESCRIPTION
Closes #3676

**Description:**

Changed copy in activity page footer to direct users to help center article on previous chain data retrieval 

Thank you! 🚀

---

For contributor:

- [ ] Added changes entries. Run `yarn changelog` for a guided process.
- [ ] Reviewed `Files changed` in the github PR explorer
- [ ] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI
