### PR TITLE
Ana/change to blockV2 query in TmConnectedNetwork

### DIFF
--- a/changes/ana_change-to-blockV2-in-tmconnectednetwork
+++ b/changes/ana_change-to-blockV2-in-tmconnectednetwork
@@ -1,0 +1,1 @@
+[Changed] [#3801](https://github.com/cosmos/lunie/pull/3801) Chnages the query block in TmConnectedNetwork to blockV2 @Bitcoinera

--- a/src/components/common/TmConnectedNetwork.vue
+++ b/src/components/common/TmConnectedNetwork.vue
@@ -127,18 +127,23 @@ export default {
   apollo: {
     block: {
       query: gql`
-        query Block($networkId: String!) {
-          block(networkId: $networkId) {
+        query blockV2($networkId: String!) {
+          blockV2(networkId: $networkId) {
             height
             chainId
           }
         }
       `,
+      /* istanbul ignore next */
       variables() {
         /* istanbul ignore next */
         return {
           networkId: this.network
         }
+      },
+      /* istanbul ignore next */
+      update: function(result) {
+        return result.blockV2
       }
     },
     $subscribe: {


### PR DESCRIPTION
Closes #ISSUE

**Description:**

<!-- Briefly describe what you're adding or fixing with this PR -->
Needed for release.

Changes the TmConnectedNetwork query from "block" to "blockV2" so it doesn't error

Thank you! 🚀

---

For contributor:

- [ ] Added changes entries. Run `yarn changelog` for a guided process.
- [ ] Reviewed `Files changed` in the github PR explorer
- [ ] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI
