### PR TITLE
Ana/fix top 5 validator list

### DIFF
--- a/changes/ana_fix-top-5-validator-list
+++ b/changes/ana_fix-top-5-validator-list
@@ -1,0 +1,1 @@
+[Fixed] [#3819](https://github.com/cosmos/lunie/pull/3819) Fixes the getTop5RewardsValidators function logic, to pick unique validators with the highest total rewards balances @Bitcoinera

--- a/src/ActionModal/utils/ActionManager.js
+++ b/src/ActionModal/utils/ActionManager.js
@@ -157,7 +157,16 @@ export function getTop5RewardsValidators(rewards) {
         (Number(all[reward.validator.operatorAddress]) || 0)
     }
   }, {})
-  return Object.keys(rewardsPerValidatorObject).reverse()
-  // const rewardsPerValidatorAddresses = Object.entries(rewardsPerValidatorObject)
-  // return rewardsPerValidatorAddresses.map(([a, b]) => {a, b}).sort((a, b) => b - a)
+  const rewardsPerValidatorAddresses = Object.keys(rewardsPerValidatorObject)
+  let rewardsPerValidatorArray = []
+  rewardsPerValidatorAddresses.forEach((validatorAddress, index) => {
+    rewardsPerValidatorArray.push({
+      validator: validatorAddress,
+      totalRewardAmount: Object.values(rewardsPerValidatorObject)[index]
+    })
+  })
+  return rewardsPerValidatorArray
+    .sort((a, b) => b.totalRewardAmount - a.totalRewardAmount)
+    .slice(0, 5)
+    .map(rewardPerValidator => rewardPerValidator.validator)
 }

--- a/src/ActionModal/utils/ActionManager.js
+++ b/src/ActionModal/utils/ActionManager.js
@@ -149,20 +149,15 @@ function convertCurrencyData(amounts, network) {
 
 // limitation of the Ledger Nano S, so we pick the top 5 rewards and inform the user.
 export function getTop5RewardsValidators(rewards) {
-  const mostClaimableToken = rewards.reduce((topRewardToken, reward) => {
-    if (Number(reward.amount) > Number(topRewardToken.amount)) {
-      return reward
+  const rewardsPerValidatorObject = rewards.reduce((all, reward) => {
+    return {
+      ...all,
+      [reward.validator.operatorAddress]:
+        Number(reward.amount) +
+        (Number(all[reward.validator.operatorAddress]) || 0)
     }
-    return topRewardToken
-  })
-  // Compares the amount in a [address1, {denom: amount}] array
-  // sorts by highest reward token and then fills up with other validators
-  const byBalance = (a, b) =>
-    a.denom === mostClaimableToken.denom ? b.amount - a.amount : -1000
-  const validatorList = rewards
-    .sort(byBalance)
-    .slice(0, 5) // Just the top 5
-    .map(({ validator }) => validator.operatorAddress)
-
-  return validatorList
+  }, {})
+  return Object.keys(rewardsPerValidatorObject).reverse()
+  // const rewardsPerValidatorAddresses = Object.entries(rewardsPerValidatorObject)
+  // return rewardsPerValidatorAddresses.map(([a, b]) => {a, b}).sort((a, b) => b - a)
 }


### PR DESCRIPTION
Closes #ISSUE

**Description:**

<!-- Briefly describe what you're adding or fixing with this PR -->
Right now the version in develop&production is buggy, repeating the same validator multiple times in the list, and therefore not claiming rewards it could and also not matching the numbers displayed on the Claim Rewards modal.

Here I aim to fix the validator picking logic.

FIXES this:

<img width="380px" src="https://user-images.githubusercontent.com/40721795/78137295-59f40e00-7425-11ea-8365-fe88132b259e.png">

And this (numbers not matching from modal and effectively claimed):

<img width="390px" src="https://user-images.githubusercontent.com/40721795/78137376-7db75400-7425-11ea-9ac8-7a860ba7fb78.png">

![image](https://user-images.githubusercontent.com/40721795/78137447-9fb0d680-7425-11ea-9a08-fb60ac85c7cd.png)



Thank you! 🚀

---

For contributor:

- [ ] Added changes entries. Run `yarn changelog` for a guided process.
- [ ] Reviewed `Files changed` in the github PR explorer
- [ ] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI
