### PR TITLE
Ana/fix 3825, staking max amount not working as expected

### DIFF
--- a/changes/ana_3825-staking-max-amount-not-working-as-it-should
+++ b/changes/ana_3825-staking-max-amount-not-working-as-it-should
@@ -1,0 +1,1 @@
+[Fixed] [#3825](https://github.com/cosmos/lunie/issues/3825) Fixes fees being added on top of max amount for any transaction @Bitcoinera

--- a/src/ActionModal/components/ActionModal.vue
+++ b/src/ActionModal/components/ActionModal.vue
@@ -473,6 +473,12 @@ export default {
       return this.featureFlag === "undelegate" ? 0 : this.amount
     },
     invoiceTotal() {
+      if (
+        Number(this.subTotal) + this.estimatedFee >
+        this.selectedBalance.amount
+      ) {
+        this.adjustFeesToMaxPayable()
+      }
       return Number(this.subTotal) + this.estimatedFee
     },
     isValidChildForm() {
@@ -685,16 +691,14 @@ export default {
     },
     // limit fees to the maximum the user has
     adjustFeesToMaxPayable() {
-      if (this.invoiceTotal > this.selectedBalance.amount) {
-        let payable = Number(this.subTotal)
-        // in terra we also have to pay the tax
-        // TODO refactor using a `fixedFee` property
-        if (this.chainAppliedFees) {
-          payable += this.chainAppliedFees
-        }
-        this.gasPrice =
-          (Number(this.selectedBalance.amount) - payable) / this.gasEstimate
+      let payable = Number(this.subTotal)
+      // in terra we also have to pay the tax
+      // TODO refactor using a `fixedFee` property
+      if (this.chainAppliedFees) {
+        payable += this.chainAppliedFees
       }
+      this.gasPrice =
+        (Number(this.selectedBalance.amount) - payable) / this.gasEstimate
       // BACKUP HACK, the gasPrice can never be negative, this should not happen :shrug:
       this.gasPrice = this.gasPrice >= 0 ? this.gasPrice : 0
     },

--- a/tests/unit/specs/components/ActionModal/components/ActionModal.spec.js
+++ b/tests/unit/specs/components/ActionModal/components/ActionModal.spec.js
@@ -558,6 +558,18 @@ describe(`ActionModal`, () => {
     expect(self.gasPrice).toBe(1.0000000000000008e-8) // a bit lower then gasEstimate. feels right
   })
 
+  it(`should take chain applied fees into account when adjusting fees for max amount`, async () => {
+    const self = {
+      invoiceTotal: 1.001,
+      selectedBalance: balances[1],
+      subTotal: 0.999,
+      gasEstimate: 100000,
+      chainAppliedFees: 0.001
+    }
+    ActionModal.methods.adjustFeesToMaxPayable.call(self)
+    expect(self.gasPrice).toBe(0.00001)
+  })
+
   describe(`submit`, () => {
     it(`should submit transaction`, async () => {
       const transactionProperties = {


### PR DESCRIPTION
Closes #3825 

**Description:**

<!-- Briefly describe what you're adding or fixing with this PR -->
This is a possible fix. Another possibility:

Add a fee service/helper in the FE, so the fees are calculated separately (not only in ActionModal like now), and then we can just import the function to the Delegation and SendModal (the only ones needing this actually). 

Note: I still need to fix this on the SendModal. There the same is happening.

Note2: it would be also interesting to allow 0 fees in testnets.

Thank you! 🚀

---

For contributor:

- [ ] Added changes entries. Run `yarn changelog` for a guided process.
- [ ] Reviewed `Files changed` in the github PR explorer
- [ ] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI
