### PR TITLE
Ana/3843 adjust seed validation on account restore

### DIFF
--- a/changes/ana_3843-adjust-seed-validation-on-account-restore
+++ b/changes/ana_3843-adjust-seed-validation-on-account-restore
@@ -1,0 +1,1 @@
+[Fixed] [#3843](https://github.com/cosmos/lunie/issues/3843) Improves de validation of seed phrases in account restore and removes extra spaces @Bitcoinera

--- a/src/components/common/TmFormMsg.vue
+++ b/src/components/common/TmFormMsg.vue
@@ -86,8 +86,8 @@ export default {
         case `words24`:
           msg = `phrase must be 24 words`
           break
-        case `spaces`:
-          msg = `phrase words must be separated by spaces`
+        case `lowercaseAndSpaces`:
+          msg = `phrase words must be all lowercase and separated by spaces`
           break
         case `url`:
           msg = `must be a valid URL (http:// required)`

--- a/src/components/common/TmFormMsg.vue
+++ b/src/components/common/TmFormMsg.vue
@@ -86,6 +86,9 @@ export default {
         case `words24`:
           msg = `phrase must be 24 words`
           break
+        case `espaces`:
+          msg = `phrase words must be separated by espaces`
+          break
         case `url`:
           msg = `must be a valid URL (http:// required)`
           break

--- a/src/components/common/TmFormMsg.vue
+++ b/src/components/common/TmFormMsg.vue
@@ -86,8 +86,8 @@ export default {
         case `words24`:
           msg = `phrase must be 24 words`
           break
-        case `espaces`:
-          msg = `phrase words must be separated by espaces`
+        case `spaces`:
+          msg = `phrase words must be separated by spaces`
           break
         case `url`:
           msg = `must be a valid URL (http:// required)`

--- a/src/components/common/TmSessionImport.vue
+++ b/src/components/common/TmSessionImport.vue
@@ -23,9 +23,14 @@
             type="required"
           />
           <TmFormMsg
-            v-else-if="$v.seed.$error && !$v.seed.validSeed"
+            v-else-if="$v.seed.$error && !$v.seed.seedHas24Words"
             name="Seed"
             type="words24"
+          />
+          <TmFormMsg
+            v-else-if="$v.seed.$error && !$v.seed.seedSeparatedByEspaces"
+            name="Seed"
+            type="espaces"
           />
         </TmFormGroup>
       </div>
@@ -49,6 +54,11 @@ import Steps from "../../ActionModal/components/Steps"
 
 const words24 = param => {
   return param && param.split(` `).length === 24
+}
+
+const espaces = param => {
+  const seedWordsSeparatedBySpaces = /^[a-zA-Z\s]+$/
+  return seedWordsSeparatedBySpaces.test(param)
 }
 
 const polkadotRawSeed = param => {
@@ -88,7 +98,8 @@ export default {
   validations: () => ({
     seed: {
       required,
-      validSeed: param => words24(param) || polkadotRawSeed(param)
+      seedHas24Words: param => words24(param) || polkadotRawSeed(param),
+      seedSeparatedByEspaces: param => espaces(param) || polkadotRawSeed(param)
     }
   })
 }

--- a/src/components/common/TmSessionImport.vue
+++ b/src/components/common/TmSessionImport.vue
@@ -28,9 +28,9 @@
             type="words24"
           />
           <TmFormMsg
-            v-else-if="$v.seed.$error && !$v.seed.seedSeparatedBySpaces"
+            v-else-if="$v.seed.$error && !$v.seed.seedIsLowerCaseAndSpaces"
             name="Seed"
-            type="spaces"
+            type="lowercaseAndSpaces"
           />
         </TmFormGroup>
       </div>
@@ -56,9 +56,9 @@ const words24 = param => {
   return param && param.split(` `).length === 24
 }
 
-const spaces = param => {
-  const seedWordsSeparatedBySpaces = /^[a-zA-Z\s]+$/
-  return seedWordsSeparatedBySpaces.test(param)
+const lowerCaseAndSpaces = param => {
+  const seedWordsAreLowerCaseAndSpaces = /^[a-z\s]+$/
+  return seedWordsAreLowerCaseAndSpaces.test(param)
 }
 
 const polkadotRawSeed = param => {
@@ -102,8 +102,9 @@ export default {
   validations: () => ({
     seed: {
       required,
-      seedHas24Words: param => words24(param) || polkadotRawSeed(param),
-      seedSeparatedBySpaces: param => spaces(param) || polkadotRawSeed(param)
+      seedIsLowerCaseAndSpaces: param =>
+        lowerCaseAndSpaces(param) || polkadotRawSeed(param),
+      seedHas24Words: param => words24(param) || polkadotRawSeed(param)
     }
   })
 }

--- a/src/components/common/TmSessionImport.vue
+++ b/src/components/common/TmSessionImport.vue
@@ -57,8 +57,11 @@ const words24 = param => {
 }
 
 const lowerCaseAndSpaces = param => {
-  const seedWordsAreLowerCaseAndSpaces = /^[a-z\s]+$/
-  return seedWordsAreLowerCaseAndSpaces.test(param)
+  const seedWordsAreLowerCaseAndSpaces = /^([a-z]+\s)*[a-z]+$/g
+  if (param.match(seedWordsAreLowerCaseAndSpaces)) {
+    return param === param.match(seedWordsAreLowerCaseAndSpaces)[0]
+  }
+  return false
 }
 
 const polkadotRawSeed = param => {
@@ -84,11 +87,10 @@ export default {
         return this.$store.state.recover.seed
       },
       set(value) {
-        // remove spaces from end of string
-        const seed = value.match(/^[a-z\s]+$/gi)
-          ? value.match(/^[a-z\s]+$/gi)[0]
-          : value.match(/0x[a-z0-9]{64}/gi)[0]
-        this.$store.commit(`updateField`, { field: `seed`, value: seed || "" })
+        this.$store.commit(`updateField`, {
+          field: `seed`,
+          value: value.trim() // remove spaces from beginning and end of string
+        })
       }
     }
   },

--- a/src/components/common/TmSessionImport.vue
+++ b/src/components/common/TmSessionImport.vue
@@ -84,7 +84,11 @@ export default {
         return this.$store.state.recover.seed
       },
       set(value) {
-        this.$store.commit(`updateField`, { field: `seed`, value })
+        // remove spaces from end of string
+        const seed = value.match(/^[a-z\s]+$/gi)
+          ? value.match(/^[a-z\s]+$/gi)[0]
+          : value.match(/0x[a-z0-9]{64}/gi)[0]
+        this.$store.commit(`updateField`, { field: `seed`, value: seed || "" })
       }
     }
   },

--- a/src/components/common/TmSessionImport.vue
+++ b/src/components/common/TmSessionImport.vue
@@ -28,9 +28,9 @@
             type="words24"
           />
           <TmFormMsg
-            v-else-if="$v.seed.$error && !$v.seed.seedSeparatedByEspaces"
+            v-else-if="$v.seed.$error && !$v.seed.seedSeparatedBySpaces"
             name="Seed"
-            type="espaces"
+            type="spaces"
           />
         </TmFormGroup>
       </div>
@@ -56,7 +56,7 @@ const words24 = param => {
   return param && param.split(` `).length === 24
 }
 
-const espaces = param => {
+const spaces = param => {
   const seedWordsSeparatedBySpaces = /^[a-zA-Z\s]+$/
   return seedWordsSeparatedBySpaces.test(param)
 }
@@ -99,7 +99,7 @@ export default {
     seed: {
       required,
       seedHas24Words: param => words24(param) || polkadotRawSeed(param),
-      seedSeparatedByEspaces: param => espaces(param) || polkadotRawSeed(param)
+      seedSeparatedBySpaces: param => spaces(param) || polkadotRawSeed(param)
     }
   })
 }


### PR DESCRIPTION
Closes #3843

**Description:**

<!-- Briefly describe what you're adding or fixing with this PR -->
Still need to erase all extra spaces in the seed phrase, but fixed another important thing in Polkadot addresses (the extra spaces there were causing an error).

Also adds a validation to make sure works are separated by spaces, not commas or anything else

Thank you! 🚀

---

For contributor:

- [ ] Added changes entries. Run `yarn changelog` for a guided process.
- [ ] Reviewed `Files changed` in the github PR explorer
- [ ] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI
