### PR TITLE
Ana/remove ismultidenomnetwork from tmbalance

### DIFF
--- a/changes/ana_remove-ismultidenomnetwork
+++ b/changes/ana_remove-ismultidenomnetwork
@@ -1,0 +1,1 @@
+[Fixed] [#3848](https://github.com/cosmos/lunie/issues/3848) Fixes currencySelector not appearing for e-Money accounts with just NGM balance. Simply deletes isMultiDenomNetwork checker @Bitcoinera

--- a/src/components/common/TmBalance.vue
+++ b/src/components/common/TmBalance.vue
@@ -326,23 +326,8 @@ export default {
         return [this.stakingDenom]
       }
     },
-    isMultiDenomNetwork() {
-      if (this.balances && this.balances.length > 0) {
-        return this.balances.find(
-          balance => balance.denom !== this.stakingDenom
-        )
-          ? true
-          : false
-      } else {
-        return false
-      }
-    },
     currencySupport() {
-      return (
-        this.isMultiDenomNetwork &&
-        this.stakingBalance &&
-        this.stakingBalance.fiatValue
-      )
+      return this.stakingBalance && this.stakingBalance.fiatValue
     },
     totalRewardsPerDenom() {
       return this.rewards.reduce((all, reward) => {

--- a/tests/unit/specs/components/common/TmBalance.spec.js
+++ b/tests/unit/specs/components/common/TmBalance.spec.js
@@ -129,24 +129,6 @@ describe(`TmBalance`, () => {
     expect(wrapper.vm.getAllDenoms).toEqual(["ATOM"])
   })
 
-  it(`should return true if rewards contain multiple denoms`, () => {
-    wrapper.setData({
-      balances: [
-        {
-          amount: 1,
-          denom: "ATOM",
-          fiatValue: `33€`
-        },
-        {
-          amount: 2,
-          denom: "TOKEN1",
-          fiatValue: `1.5€`
-        }
-      ]
-    })
-    expect(wrapper.vm.isMultiDenomNetwork).toBe(true)
-  })
-
   it(`should show How To Get Tokens tutorial`, () => {
     wrapper.setData({
       showTutorial: false


### PR DESCRIPTION
Closes #3848 

**Description:**

<!-- Briefly describe what you're adding or fixing with this PR -->
Actually this piece of code wasn't needed. `fiatValue` is `null` in the balances of all other networks, so it doesn't appear there 😉 

Yes, once more the solution consisted of actually deleting code!

Let's rejoice and celebrate 🍾 🎉 

Thank you! 🚀

---

For contributor:

- [ ] Added changes entries. Run `yarn changelog` for a guided process.
- [ ] Reviewed `Files changed` in the github PR explorer
- [ ] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI
