### PR TITLE
Ana/3738 & fix address is null

### DIFF
--- a/changes/ana_3855-fix-address-is-null
+++ b/changes/ana_3855-fix-address-is-null
@@ -1,0 +1,2 @@
+[Fixed] [#3738](https://github.com/cosmos/lunie/issues/3738) Fixes ActionModal getting stuck in loading @Bitcoinera
+[Fixed] [#3863](https://github.com/cosmos/lunie/pull/3863) Fixes $address is null in the ActionModal queries @Bitcoinera

--- a/src/ActionModal/components/ActionModal.vue
+++ b/src/ActionModal/components/ActionModal.vue
@@ -45,7 +45,7 @@
       <template v-if="!checkFeatureAvailable">
         <FeatureNotAvailable :feature="title" />
       </template>
-      <TmDataLoading v-else-if="!loaded" />
+      <TmDataLoading v-else-if="$apollo.loading && !$apollo.skipAll" />
       <template v-else>
         <div v-if="requiresSignIn" class="action-modal-form">
           <p class="form-message notice">
@@ -555,17 +555,11 @@ export default {
         }
       }
     },
-    "$apollo.loading": function(loading) {
-      this.loaded = this.loaded || !loading
-    },
     selectedBalance: {
       handler(selectedBalance) {
         this.gasPrice = selectedBalance.gasPrice
       }
     }
-  },
-  created() {
-    this.$apollo.skipAll = true
   },
   updated: function() {
     if (
@@ -597,7 +591,11 @@ export default {
       }
     },
     async open() {
-      this.$apollo.skipAll = false
+      if (!this.address) {
+        this.$apollo.skipAll = true
+      } else {
+        this.$apollo.skipAll = false
+      }
       // checking if there is something in a queue
       const queue = await this.actionManager.getSignQueue(
         this.selectedSignMethod
@@ -630,7 +628,6 @@ export default {
       this.show = false
       this.sending = false
       this.includedHeight = undefined
-      this.$apollo.skipAll = true
 
       // reset form
       // in some cases $v is not yet set

--- a/src/ActionModal/components/ActionModal.vue
+++ b/src/ActionModal/components/ActionModal.vue
@@ -932,7 +932,7 @@ export default {
         },
         /* istanbul ignore next */
         skip() {
-          return !this.txHash
+          return !this.session.address || !this.txHash
         },
         query: UserTransactionAdded,
         /* istanbul ignore next */

--- a/src/ActionModal/components/ActionModal.vue
+++ b/src/ActionModal/components/ActionModal.vue
@@ -45,7 +45,11 @@
       <template v-if="!checkFeatureAvailable">
         <FeatureNotAvailable :feature="title" />
       </template>
-      <TmDataLoading v-else-if="$apollo.loading && !$apollo.skipAll" />
+      <TmDataLoading
+        v-else-if="
+          $apollo.queries.overview.loading || $apollo.queries.balances.loading
+        "
+      />
       <template v-else>
         <div v-if="requiresSignIn" class="action-modal-form">
           <p class="form-message notice">
@@ -593,8 +597,6 @@ export default {
     async open() {
       if (!this.address) {
         this.$apollo.skipAll = true
-      } else {
-        this.$apollo.skipAll = false
       }
       // checking if there is something in a queue
       const queue = await this.actionManager.getSignQueue(

--- a/src/ActionModal/components/ActionModal.vue
+++ b/src/ActionModal/components/ActionModal.vue
@@ -47,7 +47,8 @@
       </template>
       <TmDataLoading
         v-else-if="
-          $apollo.queries.overview.loading || $apollo.queries.balances.loading
+          $apollo.loading &&
+            (!balancesLoaded || !overviewLoaded || gasEstimateLoaded)
         "
       />
       <template v-else>
@@ -449,7 +450,10 @@ export default {
     balances: [],
     queueEmpty: true,
     includedHeight: undefined,
-    smallestAmount: SMALLEST
+    smallestAmount: SMALLEST,
+    overviewLoaded: false,
+    balancesLoaded: false,
+    gasEstimateLoaded: false
   }),
   computed: {
     ...mapState([`extension`, `session`]),
@@ -853,6 +857,11 @@ export default {
         }
       },
       /* istanbul ignore next */
+      update(data) {
+        this.balancesLoaded = true
+        return data.balances || []
+      },
+      /* istanbul ignore next */
       skip() {
         return !this.session.address
       }
@@ -877,6 +886,7 @@ export default {
       },
       /* istanbul ignore next */
       update(data) {
+        this.overviewLoaded = true
         return data.overview || {}
       },
       /* istanbul ignore next */
@@ -908,6 +918,7 @@ export default {
       /* istanbul ignore next */
       update(data) {
         if (data.networkFees) {
+          this.gasEstimateLoaded = true
           return data.networkFees.gasEstimate
         }
       },

--- a/src/ActionModal/components/DelegationModal.vue
+++ b/src/ActionModal/components/DelegationModal.vue
@@ -358,6 +358,9 @@ export default {
       /* istanbul ignore next */
       update(data) {
         return data.validators
+      },
+      skip() {
+        return !this.address
       }
     },
     delegations: {

--- a/src/ActionModal/components/DelegationModal.vue
+++ b/src/ActionModal/components/DelegationModal.vue
@@ -359,6 +359,7 @@ export default {
       update(data) {
         return data.validators
       },
+      /* istanbul ignore next */
       skip() {
         return !this.address
       }

--- a/src/ActionModal/components/UndelegationModal.vue
+++ b/src/ActionModal/components/UndelegationModal.vue
@@ -375,13 +375,13 @@ export default {
       `,
       /* istanbul ignore next */
       skip() {
-        return !this.userAddress
+        return !this.address
       },
       /* istanbul ignore next */
       variables() {
         return {
           networkId: this.network,
-          address: this.userAddress,
+          address: this.address,
           denom: this.stakingDenom
         }
       },
@@ -410,6 +410,10 @@ export default {
       /* istanbul ignore next */
       update(data) {
         return data.validators || []
+      },
+      /* istanbul ignore next */
+      skip() {
+        return !this.address
       }
     },
 
@@ -419,12 +423,12 @@ export default {
         variables() {
           return {
             networkId: this.network,
-            address: this.userAddress
+            address: this.address
           }
         },
         /* istanbul ignore next */
         skip() {
-          return !this.userAddress
+          return !this.address
         },
         query: UserTransactionAdded,
         /* istanbul ignore next */

--- a/tests/unit/specs/components/ActionModal/components/ActionModal.spec.js
+++ b/tests/unit/specs/components/ActionModal/components/ActionModal.spec.js
@@ -309,6 +309,17 @@ describe(`ActionModal`, () => {
   it("shows loading when there is still data to be loaded", () => {
     wrapper = shallowMount(ActionModal, {
       localVue,
+      propsData: {
+        title: `Send`,
+        validate: jest.fn(),
+        featureFlag: `send`,
+        queueNotEmpty: false,
+        transactionData: {
+          type: "MsgSend",
+          denom: "uatom",
+          validatorAddress: "cosmos12345"
+        }
+      },
       mocks: {
         $store,
         $router: {
@@ -327,8 +338,6 @@ describe(`ActionModal`, () => {
       },
       stubs: ["router-link"]
     })
-
-    expect(wrapper.find("TmDataLoading-stub").exists()).toBe(true)
     expect(wrapper.element).toMatchSnapshot()
   })
 

--- a/tests/unit/specs/components/ActionModal/components/ActionModal.spec.js
+++ b/tests/unit/specs/components/ActionModal/components/ActionModal.spec.js
@@ -95,7 +95,6 @@ describe(`ActionModal`, () => {
   ]
 
   $apollo = {
-    skipAll: jest.fn(() => false),
     queries: {
       overview: {
         refetch: jest.fn()
@@ -169,7 +168,7 @@ describe(`ActionModal`, () => {
     wrapper.vm.actionManager.getSignQueue = jest.fn(
       () => new Promise(resolve => resolve(0))
     )
-    wrapper.setData({ network, overview, balances, loaded: true })
+    wrapper.setData({ network, overview, balances })
     wrapper.vm.open()
   })
 
@@ -308,7 +307,26 @@ describe(`ActionModal`, () => {
   })
 
   it("shows loading when there is still data to be loaded", () => {
-    wrapper.setData({ $apollo: { loading: true, skipAll: false } })
+    wrapper = shallowMount(ActionModal, {
+      localVue,
+      mocks: {
+        $store,
+        $router: {
+          push: jest.fn()
+        },
+        $apollo: {
+          queries: {
+            overview: {
+              loading: true
+            },
+            balances: {
+              loading: true
+            }
+          }
+        }
+      },
+      stubs: ["router-link"]
+    })
 
     expect(wrapper.find("TmDataLoading-stub").exists()).toBe(true)
     expect(wrapper.element).toMatchSnapshot()

--- a/tests/unit/specs/components/ActionModal/components/ActionModal.spec.js
+++ b/tests/unit/specs/components/ActionModal/components/ActionModal.spec.js
@@ -308,19 +308,10 @@ describe(`ActionModal`, () => {
   })
 
   it("shows loading when there is still data to be loaded", () => {
-    wrapper.setData({ loaded: false })
+    wrapper.setData({ $apollo: { loading: true, skipAll: false } })
 
     expect(wrapper.find("TmDataLoading-stub").exists()).toBe(true)
     expect(wrapper.element).toMatchSnapshot()
-  })
-
-  it("sets the loaded state when apollo is done loading", () => {
-    let self = { loaded: false }
-    ActionModal.watch["$apollo.loading"].call(self, true)
-    expect(self.loaded).toBe(false)
-
-    ActionModal.watch["$apollo.loading"].call(self, false)
-    expect(self.loaded).toBe(true)
   })
 
   it(`should confirm modal closing`, () => {
@@ -344,7 +335,12 @@ describe(`ActionModal`, () => {
 
   it(`opens session modal and closes itself`, () => {
     const $store = { commit: jest.fn(), dispatch: jest.fn() }
-    const self = { $store, close: jest.fn(), $router: { push: jest.fn() }, $route: { name: `route` } }
+    const self = {
+      $store,
+      close: jest.fn(),
+      $router: { push: jest.fn() },
+      $route: { name: `route` }
+    }
     ActionModal.methods.goToSession.call(self)
     expect(self.close).toHaveBeenCalled()
     expect(self.$router.push).toHaveBeenCalledWith(`portfolio`)

--- a/tests/unit/specs/components/ActionModal/components/__snapshots__/ActionModal.spec.js.snap
+++ b/tests/unit/specs/components/ActionModal/components/__snapshots__/ActionModal.spec.js.snap
@@ -1493,46 +1493,4 @@ exports[`ActionModal shows a feature unavailable message 1`] = `
 </div>
 `;
 
-exports[`ActionModal shows loading when there is still data to be loaded 1`] = `
-<div
-  class="action-modal"
-  name="slide-fade"
-  tabindex="0"
->
-  <!---->
-   
-  <div
-    class="action-modal-icon action-modal-close"
-    id="closeBtn"
-  >
-    <i
-      class="material-icons notranslate"
-    >
-      close
-    </i>
-  </div>
-   
-  <div
-    class="action-modal-header"
-  >
-    <span
-      class="action-modal-title"
-    >
-      
-        Send
-      
-    </span>
-     
-    <steps-stub
-      activestep="details"
-      steps="Details,Fees,Sign"
-    />
-     
-    <!---->
-  </div>
-   
-  <tmdataloading-stub
-    title="Data is loading…"
-  />
-</div>
-`;
+exports[`ActionModal shows loading when there is still data to be loaded 1`] = `<!---->`;


### PR DESCRIPTION
Fixes address is null in Action Modal
Closes #3738 (this one for sure)

**Description:**

<!-- Briefly describe what you're adding or fixing with this PR -->
The error I encountered when following the steps from [this sentry error](https://monitoring.lunie.io:9000/lunie/frontend/issues/373/?referrer=github_integration) is slightly different than anything with an `Object.a`, but it was `variable $address is null` or something similar.

The reason is because acting on the `open` method, the ActionModal was still triggering the smartqueries despite the skips.

I have found some code there with `skipAll` kind of cumbersome (and actually here was the bug for the skips not being triggered) and also have not seen the need of the `loaded` logic at all. Removing the `loaded` logic makes the ActionModals open automatically (fixes #3738)

The only problem I have left is the test for the TmDataLoading. But maybe it failing like this means something is still wrong.

Thank you! 🚀

---

For contributor:

- [ ] Added changes entries. Run `yarn changelog` for a guided process.
- [ ] Reviewed `Files changed` in the github PR explorer
- [ ] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI
