### PR TITLE
Fabo/3835 note about txs not showing

### DIFF
--- a/changes/fabo_3835-note-about-txs-not-showing
+++ b/changes/fabo_3835-note-about-txs-not-showing
@@ -1,0 +1,1 @@
+[Added] [#3835](https://github.com/cosmos/lunie/issues/3835) Not about not showing some transactions @faboweb

--- a/src/components/network/PageBlock.vue
+++ b/src/components/network/PageBlock.vue
@@ -26,6 +26,12 @@
         <div class="column">
           <h3 class="page-profile__section-title">
             Transactions ({{ block.transactions.length }})
+            <template v-if="unknownTxs.length">
+              ({{ unknownTxs.length }} transaction{{
+                unknownTxs.length > 1 ? "s" : ""
+              }}
+              not showing)
+            </template>
           </h3>
 
           <TmDataMsg v-if="block.transactions.length === 0" icon="info_outline">
@@ -42,6 +48,7 @@
             :address="address"
             :validators="validatorsAddressMap"
           />
+
           <br />
         </div>
       </div>
@@ -160,6 +167,14 @@ export default {
         names[item.operatorAddress] = item
       })
       return names
+    },
+    unknownTxs() {
+      if (this.block && this.block.transactions) {
+        return this.block.transactions.filter(
+          transaction => transaction.type === `UnknownTx`
+        )
+      }
+      return []
     },
     filteredTransactions() {
       if (this.block && this.block.transactions) {

--- a/tests/unit/specs/components/network/__snapshots__/PageBlock.spec.js.snap
+++ b/tests/unit/specs/components/network/__snapshots__/PageBlock.spec.js.snap
@@ -58,7 +58,8 @@ exports[`PageBlock shows a page with information about a certain block 1`] = `
         >
           
           Transactions (1)
-        
+          
+          <!---->
         </h3>
          
         <!---->
@@ -134,7 +135,8 @@ exports[`PageBlock shows the block page with no txs 1`] = `
         >
           
           Transactions (0)
-        
+          
+          <!---->
         </h3>
          
         <tmdatamsg-stub


### PR DESCRIPTION
Closes #3835 
Simple solution with adding a note about the missing txs:

![image](https://user-images.githubusercontent.com/5869273/79526309-9bdaa200-802a-11ea-810d-2a39322f0921.png)
