### PR TITLE
Fabo/add development flag in gql

### DIFF
--- a/changes/fabo_add-development-flag-in-gql
+++ b/changes/fabo_add-development-flag-in-gql
@@ -1,0 +1,1 @@
+[Changed] Add ability to not track certain statistics in development mode @faboweb

--- a/src/ActionModal/utils/ActionManager.js
+++ b/src/ActionModal/utils/ActionManager.js
@@ -14,7 +14,8 @@ const txFetchOptions = fingerprint => ({
   method: "POST",
   headers: {
     "Content-Type": "application/json",
-    fingerprint
+    fingerprint,
+    development: config.development
   }
 })
 

--- a/src/gql/apollo.js
+++ b/src/gql/apollo.js
@@ -46,10 +46,11 @@ const makeWebSocketLink = () => {
 const createApolloClient = async () => {
   const fingerprint = await getFingerprint()
   const middleware = new ApolloLink((operation, forward) => {
-    // add the authorization to the headers
+    // add the authentication to the headers
     operation.setContext({
       headers: {
-        fingerprint
+        fingerprint,
+        development: config.development
       }
     })
     return forward(operation)


### PR DESCRIPTION
Adds headers so we can ignore statistics from development builds