### PR TITLE
Ana/filter out inactive validators for restaking

### DIFF
--- a/src/ActionModal/components/UndelegationModal.vue
+++ b/src/ActionModal/components/UndelegationModal.vue
@@ -266,7 +266,9 @@ export default {
           // exclude the validator we are redelegating from
           .filter(
             validator =>
-              validator.operatorAddress !== this.sourceValidator.operatorAddress
+              validator.operatorAddress !==
+                this.sourceValidator.operatorAddress &&
+              validator.status !== "INACTIVE"
           )
           .map(validator => {
             return {


### PR DESCRIPTION
Closes #3876

**Description:**

<!-- Briefly describe what you're adding or fixing with this PR -->

Very easy fix.

To consider: maybe it would be better to leave the option out there for some to stake on inactive validators? For example, in Polkadot, the statuses change often and maybe I want to restake on a friend who is currently inactive.

So the alternative would be to display on the dropdown each validator's status along with the name.

What do you think?

Thank you! 🚀

---

For contributor:

- [ ] Added changes entries. Run `yarn changelog` for a guided process.
- [ ] Reviewed `Files changed` in the github PR explorer
- [ ] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI
