### PR TITLE
Allow 12 words seeds import in Polkadot

### DIFF
--- a/changes/mario_3793-allow-12-words-seed-import-polkadot
+++ b/changes/mario_3793-allow-12-words-seed-import-polkadot
@@ -1,0 +1,1 @@
+[Added] [#3793](https://github.com/cosmos/lunie/issues/3793) Allow 12 words seeds import in Polkadot @mariopino

--- a/src/components/common/TmFormMsg.vue
+++ b/src/components/common/TmFormMsg.vue
@@ -92,6 +92,9 @@ export default {
         case `words24`:
           msg = `phrase must be 24 words`
           break
+        case `words12or24`:
+          msg = `phrase must be 12 or 24 words`
+          break
         case `lowercaseAndSpaces`:
           msg = `phrase words must be all lowercase and separated by spaces`
           break

--- a/src/components/common/TmSessionImport.vue
+++ b/src/components/common/TmSessionImport.vue
@@ -23,9 +23,9 @@
             type="required"
           />
           <TmFormMsg
-            v-else-if="$v.seed.$error && !$v.seed.seedHas24Words"
+            v-else-if="$v.seed.$error && !$v.seed.seedHasCorrectLength"
             name="Seed"
-            type="words24"
+            type="words12or24"
           />
           <TmFormMsg
             v-else-if="$v.seed.$error && !$v.seed.seedIsLowerCaseAndSpaces"
@@ -52,8 +52,10 @@ import SessionFrame from "common/SessionFrame"
 import { mapGetters } from "vuex"
 import Steps from "../../ActionModal/components/Steps"
 
-const words24 = param => {
-  return param && param.split(` `).length === 24
+const has12or24words = param => {
+  return (
+    param && (param.split(` `).length === 24 || param.split(` `).length === 12)
+  )
 }
 
 const lowerCaseAndSpaces = param => {
@@ -106,7 +108,8 @@ export default {
       required,
       seedIsLowerCaseAndSpaces: param =>
         lowerCaseAndSpaces(param) || polkadotRawSeed(param),
-      seedHas24Words: param => words24(param) || polkadotRawSeed(param)
+      seedHasCorrectLength: param =>
+        has12or24words(param) || polkadotRawSeed(param)
     }
   })
 }

--- a/src/components/common/TmSessionImport.vue
+++ b/src/components/common/TmSessionImport.vue
@@ -54,7 +54,7 @@ import Steps from "../../ActionModal/components/Steps"
 
 const has12or24words = param => {
   return (
-    param && (param.split(` `).length === 24 || param.split(` `).length === 12)
+    param && (param.split(` `).length === 12 || param.split(` `).length === 24)
   )
 }
 

--- a/src/components/common/TmSessionImport.vue
+++ b/src/components/common/TmSessionImport.vue
@@ -14,7 +14,7 @@
           <FieldSeed
             id="import-seed"
             :value="seed"
-            placeholder="Must be exactly 24 words"
+            placeholder="Must be exactly 12 or 24 words"
             @input="val => (seed = val)"
           />
           <TmFormMsg

--- a/tests/unit/specs/components/common/TmFormMsg.spec.js
+++ b/tests/unit/specs/components/common/TmFormMsg.spec.js
@@ -22,6 +22,11 @@ describe(`TmFormMsg`, () => {
       error: `Seed phrase must be 24 words`
     },
     {
+      type: `words12or24`,
+      name: `Seed`,
+      error: `Seed phrase must be 12 or 24 words`
+    },
+    {
       type: `alphaNum`,
       name: `Asdf`,
       error: `Asdf must contain only alphanumeric characters`

--- a/tests/unit/specs/components/common/TmSessionImport.spec.js
+++ b/tests/unit/specs/components/common/TmSessionImport.spec.js
@@ -54,14 +54,17 @@ describe(`TmSessionImport`, () => {
     expect(wrapper.vm.$v.seed.$error).toBe(true)
   })
 
-  it(`validation should fail if seed is not 24 words long`, async () => {
+  it(`validation should fail if seed is not 12 or 24 words long`, async () => {
     wrapper.vm.$store.state.recover.seed = `asdf asdf asdf asdf`
     await wrapper.vm.onSubmit()
     expect(wrapper.vm.$v.seed.$error).toBe(true)
   })
 
-  it(`should validate if seed is 24 words long`, async () => {
+  it(`should validate if seed is 12 or 24 words long`, async () => {
     wrapper.vm.$store.state.recover.seed = `asdf asdf asdf asdf asdf asdf asdf asdf asdf asdf asdf asdf asdf asdf asdf asdf asdf asdf asdf asdf asdf asdf asdf asdf`
+    await wrapper.vm.onSubmit()
+    expect(wrapper.vm.$v.seed.$error).toBe(false)
+    wrapper.vm.$store.state.recover.seed = `asdf asdf asdf asdf asdf asdf asdf asdf asdf asdf asdf asdf`
     await wrapper.vm.onSubmit()
     expect(wrapper.vm.$v.seed.$error).toBe(false)
   })

--- a/tests/unit/specs/components/common/__snapshots__/TmSessionImport.spec.js.snap
+++ b/tests/unit/specs/components/common/__snapshots__/TmSessionImport.spec.js.snap
@@ -28,7 +28,7 @@ exports[`TmSessionImport has the expected html structure 1`] = `
       >
         <fieldseed-stub
           id="import-seed"
-          placeholder="Must be exactly 24 words"
+          placeholder="Must be exactly 12 or 24 words"
           value=""
         />
          


### PR DESCRIPTION
Closes #3793

**Description:**

Allow 12 words seeds import in Polkadot.

Thank you! 🚀

---

For contributor:

- [ ] Added changes entries. Run `yarn changelog` for a guided process.
- [ ] Reviewed `Files changed` in the github PR explorer
- [ ] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI
