### PR TITLE
Always hide cookies bar after closing it

### DIFF
--- a/changes/mario_3771-hide-cookie-bar
+++ b/changes/mario_3771-hide-cookie-bar
@@ -1,0 +1,1 @@
+[Fixed] [#3771](https://github.com/cosmos/lunie/issues/3771) Always hide cookies bar after closing it @mariopino

--- a/src/components/common/Bar.vue
+++ b/src/components/common/Bar.vue
@@ -25,6 +25,7 @@ export default {
   methods: {
     close() {
       this.showMessage = false
+      this.$emit(`close`)
     }
   }
 }

--- a/src/components/common/CookieBar.vue
+++ b/src/components/common/CookieBar.vue
@@ -1,6 +1,6 @@
 <template>
   <div v-if="!session.cookiesAccepted">
-    <Bar :show="show" :bar-type="'primary'">
+    <Bar :show="show" :bar-type="'primary'" @close="onClose">
       <span class="hide-on-mobile"
         >This site uses cookies to help improve your experience.</span
       >
@@ -25,13 +25,11 @@ export default {
   computed: {
     ...mapState([`session`])
   },
-  watch: {
-    show: function(val) {
-      if (val === false) {
-        this.$store.dispatch(`setAnalyticsCollection`, true)
-        this.$store.dispatch(`setErrorCollection`, true)
-        this.$store.dispatch(`storeLocalPreferences`)
-      }
+  methods: {
+    onClose: function() {
+      this.$store.dispatch(`setAnalyticsCollection`, true)
+      this.$store.dispatch(`setErrorCollection`, true)
+      this.$store.dispatch(`storeLocalPreferences`)
     }
   }
 }

--- a/src/vuex/modules/session.js
+++ b/src/vuex/modules/session.js
@@ -173,11 +173,16 @@ export default () => {
         state.cookiesAccepted = false
         return
       }
-      state.cookiesAccepted = true
 
-      const { errorCollection, analyticsCollection } = JSON.parse(
-        localPreferences
-      )
+      const {
+        cookiesAccepted,
+        errorCollection,
+        analyticsCollection
+      } = JSON.parse(localPreferences)
+
+      if (cookiesAccepted) {
+        state.cookiesAccepted = true
+      }
       if (state.errorCollection !== errorCollection)
         dispatch(`setErrorCollection`, errorCollection)
       if (state.analyticsCollection !== analyticsCollection)
@@ -188,6 +193,7 @@ export default () => {
       localStorage.setItem(
         USER_PREFERENCES_KEY,
         JSON.stringify({
+          cookiesAccepted: state.cookiesAccepted,
           errorCollection: state.errorCollection,
           analyticsCollection: state.analyticsCollection
         })

--- a/tests/unit/specs/components/common/Bar.spec.js
+++ b/tests/unit/specs/components/common/Bar.spec.js
@@ -22,4 +22,12 @@ describe(`Bar`, () => {
     wrapper.vm.close()
     expect(wrapper.text()).toBe("")
   })
+
+  it(`should emit a close event when we click on close link`, () => {
+    const self = {
+      $emit: jest.fn()
+    }
+    Bar.methods.close.call(self)
+    expect(self.$emit).toHaveBeenCalledWith("close")
+  })
 })

--- a/tests/unit/specs/components/common/CookieBar.spec.js
+++ b/tests/unit/specs/components/common/CookieBar.spec.js
@@ -29,7 +29,7 @@ describe(`CookieBar`, () => {
   })
 
   it(`can triggers cookie acceptance on close`, () => {
-    wrapper.setData({ show: false })
+    wrapper.vm.onClose()
     expect(dispatch).toHaveBeenCalledWith(`setAnalyticsCollection`, true)
     expect(dispatch).toHaveBeenCalledWith(`setErrorCollection`, true)
     expect(dispatch).toHaveBeenCalledWith(`storeLocalPreferences`)

--- a/tests/unit/specs/store/session.spec.js
+++ b/tests/unit/specs/store/session.spec.js
@@ -354,6 +354,7 @@ describe(`Module: Session`, () => {
     localStorage.setItem(
       `lunie_user_preferences`,
       JSON.stringify({
+        cookiesAccepted: true,
         errorCollection: true,
         analyticsCollection: true
       })
@@ -371,6 +372,7 @@ describe(`Module: Session`, () => {
     localStorage.setItem(
       `lunie_user_preferences`,
       JSON.stringify({
+        cookiesAccepted: false,
         errorCollection: false,
         analyticsCollection: false
       })
@@ -383,7 +385,6 @@ describe(`Module: Session`, () => {
       state,
       dispatch
     })
-
     expect(dispatch).toHaveBeenCalledWith(`setErrorCollection`, false)
     expect(dispatch).toHaveBeenCalledWith(`setAnalyticsCollection`, false)
   })
@@ -398,7 +399,7 @@ describe(`Module: Session`, () => {
     })
 
     expect(localStorage.getItem(`lunie_user_preferences`)).toBe(
-      `{"errorCollection":true,"analyticsCollection":true}`
+      `{"cookiesAccepted":true,"errorCollection":true,"analyticsCollection":true}`
     )
   })
 


### PR DESCRIPTION
Closes #3771 

**Description:**

Store and load `cookiesAccepted` from localStorage, now if you close the cookies bar and refresh the page the cookies bar is not shown.

Thank you! 🚀

---

For contributor:

- [ ] Added changes entries. Run `yarn changelog` for a guided process.
- [ ] Reviewed `Files changed` in the github PR explorer
- [ ] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI
