### PR TITLE
Use schnorrkel (sr25519) in Polkadot

### DIFF
--- a/changes/mario_3887-sr25519-polkadot
+++ b/changes/mario_3887-sr25519-polkadot
@@ -1,0 +1,1 @@
+[Added] [#3887](https://github.com/cosmos/lunie/issues/3887) Use schnorrkel (sr25519) in Polkadot @mariopino

--- a/src/ActionModal/utils/polkadot-signing.js
+++ b/src/ActionModal/utils/polkadot-signing.js
@@ -8,7 +8,7 @@ const curvePrefixes = {
 }
 
 function getSignature(rawSignature) {
-  const prefix = new Uint8Array(curvePrefixes["ed25519"])
+  const prefix = new Uint8Array(curvePrefixes["sr25519"])
   const signature = u8aToHex(u8aConcat(prefix, rawSignature))
   return signature
 }

--- a/src/vuex/modules/wallet.js
+++ b/src/vuex/modules/wallet.js
@@ -18,7 +18,7 @@ async function createPolkadotAddress(seedPhrase, addressPrefix) {
 
   const keyring = new Keyring({
     ss58Format: Number(addressPrefix),
-    type: "ed25519"
+    type: "sr25519"
   })
   const newPair = keyring.addFromUri(seedPhrase)
 

--- a/tests/unit/specs/store/keystore.spec.js
+++ b/tests/unit/specs/store/keystore.spec.js
@@ -263,4 +263,3 @@ describe(`Module: Keystore`, () => {
     )
   })
 })
-

--- a/tests/unit/specs/store/keystore.spec.js
+++ b/tests/unit/specs/store/keystore.spec.js
@@ -150,10 +150,10 @@ describe(`Module: Keystore`, () => {
       }
     }
     const address = await actions.getAddressFromSeed(store, {
-      seedPhrase: `enable story warrior detail cradle inherit over cattle unhappy concert reveal clay keep tourist tenant brief simple drum plug inform glue business ski dream`,
+      seedPhrase: `lunch primary know smoke track sustain parrot enact shock final rookie banana`,
       network: `polkadot-testnet`
     })
-    expect(address).toBe(`HKFeFq1CTzCfTNhNtQDqe3nCR6WzimGdUdLzr7v7ukw6fnx`)
+    expect(address).toBe(`DcjhGvTmsVvJHzqFR1SQVHs77cFTQTJrm59WPM4FRgbGFoR`)
   })
 
   it(`should create a key from a seed phrase`, async () => {

--- a/tests/unit/specs/store/keystore.spec.js
+++ b/tests/unit/specs/store/keystore.spec.js
@@ -263,3 +263,4 @@ describe(`Module: Keystore`, () => {
     )
   })
 })
+


### PR DESCRIPTION
Closes #3887 

**Description:**

Use schnorrkel (sr25519) keypair crypto type in Lunie account creation & importing.

Tested compatibility with accounts created in Polkadot JS UI.

Thank you! 🚀

---

For contributor:

- [ ] Added changes entries. Run `yarn changelog` for a guided process.
- [ ] Reviewed `Files changed` in the github PR explorer
- [ ] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI
