### PR TITLE
Check testnet checkbox if current network is a testnet in explore mode

### DIFF
--- a/changes/mario_3557-testnet-checkbox
+++ b/changes/mario_3557-testnet-checkbox
@@ -1,0 +1,1 @@
+[Changed] [#3557](https://github.com/cosmos/lunie/issues/3557) Check testnet checkbox if current network is a testnet in explore mode @mariopino

--- a/src/components/common/TmSessionExplore.vue
+++ b/src/components/common/TmSessionExplore.vue
@@ -120,6 +120,10 @@ export default {
   },
   mounted() {
     this.address = localStorage.getItem(`prevAddress`)
+    // Check testnet checkbox if current network is a testnet
+    this.testnet = this.networks.find(
+      network => network.id === this.network
+    ).testnet
   },
   methods: {
     async onSubmit() {

--- a/tests/unit/specs/components/common/TmSessionExplore.spec.js
+++ b/tests/unit/specs/components/common/TmSessionExplore.spec.js
@@ -138,4 +138,3 @@ describe(`TmSessionExplore`, () => {
     expect(wrapper.vm.testnet).toBe(true)
   })
 })
-

--- a/tests/unit/specs/components/common/TmSessionExplore.spec.js
+++ b/tests/unit/specs/components/common/TmSessionExplore.spec.js
@@ -109,13 +109,13 @@ describe(`TmSessionExplore`, () => {
 
   it(`should show the last account used`, () => {
     localStorage.setItem(`prevAddress`, `cosmos1xxx`)
-
-    const self = {
-      address: ``
-    }
-    TmSessionExplore.mounted.call(self)
-
-    expect(self.address).toBe(`cosmos1xxx`)
+    wrapper = shallowMount(TmSessionExplore, {
+      localVue,
+      mocks: {
+        $store
+      }
+    })
+    expect(wrapper.vm.address).toBe(`cosmos1xxx`)
   })
 
   it(`should explore with a previously used address`, async () => {
@@ -127,10 +127,14 @@ describe(`TmSessionExplore`, () => {
     })
   })
 
-  it(`should set an error message if the address sin't recognised by Lunie`, async () => {
+  it(`should set an error message if the address isn't recognised by Lunie`, async () => {
     let address = `cosmos1z8mzakma7vnaajysmtkwt4wgjqr2m84tzvyfkz`
     $store.dispatch = () => Promise.reject(new Error("Not recognised address"))
     await wrapper.vm.addressValidate(address)
     expect(wrapper.vm.addressError).toBe("Not recognised address")
+  })
+
+  it(`should check testnet checkbox if current network is a testnet`, async () => {
+    expect(wrapper.vm.testnet).toBe(true)
   })
 })

--- a/tests/unit/specs/components/common/TmSessionExplore.spec.js
+++ b/tests/unit/specs/components/common/TmSessionExplore.spec.js
@@ -138,3 +138,4 @@ describe(`TmSessionExplore`, () => {
     expect(wrapper.vm.testnet).toBe(true)
   })
 })
+


### PR DESCRIPTION
Closes #3557 

**Description:**

Check testnet checkbox if current network is a testnet in explore mode.

Thank you! 🚀

---

For contributor:

- [x] Added changes entries. Run `yarn changelog` for a guided process.
- [x] Reviewed `Files changed` in the github PR explorer
- [x] Attach screenshots of the UI components on the PR description (if applicable)
- [x] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI
