### PR TITLE
Fix broken polkadot tx sign with sr25519

### DIFF
--- a/changes/mario_3902-fix-polkadot-tx-sign-sr25519
+++ b/changes/mario_3902-fix-polkadot-tx-sign-sr25519
@@ -1,0 +1,1 @@
+[Fixed] [#3902](https://github.com/cosmos/lunie/issues/3902) Fix broken tx sign with Schnorrkel accounts in polkadot @mariopino

--- a/src/ActionModal/utils/polkadot-signing.js
+++ b/src/ActionModal/utils/polkadot-signing.js
@@ -14,7 +14,7 @@ function getSignature(rawSignature) {
 }
 
 export function getSignedMessage({ payload, transaction }, seed) {
-  const keyring = new Keyring({ type: "sr25519" })
+  const keyring = new Keyring()
   const keypair = keyring.createFromUri(seed, {}, "sr25519")
 
   const rawSignature = keypair.sign(hexToU8a(payload.toRaw().data))

--- a/src/ActionModal/utils/polkadot-signing.js
+++ b/src/ActionModal/utils/polkadot-signing.js
@@ -14,8 +14,8 @@ function getSignature(rawSignature) {
 }
 
 export function getSignedMessage({ payload, transaction }, seed) {
-  const keyring = new Keyring()
-  const keypair = keyring.createFromUri(seed)
+  const keyring = new Keyring({ type: "sr25519" })
+  const keypair = keyring.createFromUri(seed, {}, "sr25519")
 
   const rawSignature = keypair.sign(hexToU8a(payload.toRaw().data))
   const signature = getSignature(rawSignature)


### PR DESCRIPTION
Closes #3902 

**Description:**

Fix broken polkadot tx sign with sr25519, we need to pass sr25519 type when calling `createFromUri`. 

Thank you! 🚀

---

For contributor:

- [ ] Added changes entries. Run `yarn changelog` for a guided process.
- [ ] Reviewed `Files changed` in the github PR explorer
- [ ] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI
