### PR TITLE
Fabo/fix extension accounts not read

### DIFF
--- a/changes/fabo_fix-extension-accounts-not-read
+++ b/changes/fabo_fix-extension-accounts-not-read
@@ -1,0 +1,1 @@
+[Fixed] Extension accounts where not loaded in the ActionModal so the error of not existing account would always show @faboweb

--- a/src/ActionModal/components/ActionModal.vue
+++ b/src/ActionModal/components/ActionModal.vue
@@ -593,6 +593,9 @@ export default {
       this.$store.commit(`setCurrrentModalOpen`, this)
       this.trackEvent(`event`, `modal`, this.title)
       this.show = true
+      if (this.session.sessionType === sessionType.EXTENSION) {
+        this.$store.dispatch(`getAddressesFromExtension`)
+      }
       if (config.isMobileApp) noScroll.on()
     },
     close() {


### PR DESCRIPTION
THe warning about extension account not available would always show