### PR TITLE
Replace {} by a loading spinner in account import

### DIFF
--- a/changes/mario_3927-include-loading-import-account
+++ b/changes/mario_3927-include-loading-import-account
@@ -1,0 +1,1 @@
+[Changed] [#3927](https://github.com/cosmos/lunie/issues/3927) Add a loading spinner icon in import account @mariopino

--- a/src/components/common/TmSessionImportName.vue
+++ b/src/components/common/TmSessionImportName.vue
@@ -7,7 +7,13 @@
       <div class="session-main bottom-indent">
         <Steps :steps="[`Recover`, `Name`, `Password`]" active-step="Name" />
         <TmFormGroup field-id="import-name" field-label="Your Address">
-          <p class="address">{{ importCosmosAddress }}</p>
+          <img
+            v-if="importCosmosAddress !== {}"
+            class="tm-data-msg__icon"
+            src="~assets/images/loader.svg"
+            alt="a small spinning circle to display loading"
+          />
+          <p v-else class="address">{{ importCosmosAddress }}</p>
         </TmFormGroup>
         <TmFormGroup
           :error="$v.$error && $v.name.$invalid"

--- a/src/components/common/TmSessionImportName.vue
+++ b/src/components/common/TmSessionImportName.vue
@@ -8,7 +8,7 @@
         <Steps :steps="[`Recover`, `Name`, `Password`]" active-step="Name" />
         <TmFormGroup field-id="import-name" field-label="Your Address">
           <img
-            v-if="importedAddress !== {}"
+            v-if="importedAddress === undefined"
             class="tm-data-msg__icon"
             src="~assets/images/loader.svg"
             alt="a small spinning circle to display loading"
@@ -86,7 +86,7 @@ export default {
     Steps
   },
   data: () => ({
-    importedAddress: {}
+    importedAddress: undefined
   }),
   computed: {
     ...mapGetters([`connected`, `recover`]),
@@ -101,13 +101,10 @@ export default {
     }
   },
   async created() {
-    this.importedAddress = await this.$store.dispatch(
-      `getAddressFromSeed`,
-      {
-        seedPhrase: this.$store.state.recover.seed,
-        network: this.network
-      }
-    )
+    this.importedAddress = await this.$store.dispatch(`getAddressFromSeed`, {
+      seedPhrase: this.$store.state.recover.seed,
+      network: this.network
+    })
   },
   methods: {
     onSubmit() {

--- a/src/components/common/TmSessionImportName.vue
+++ b/src/components/common/TmSessionImportName.vue
@@ -8,12 +8,12 @@
         <Steps :steps="[`Recover`, `Name`, `Password`]" active-step="Name" />
         <TmFormGroup field-id="import-name" field-label="Your Address">
           <img
-            v-if="importCosmosAddress !== {}"
+            v-if="importedAddress !== {}"
             class="tm-data-msg__icon"
             src="~assets/images/loader.svg"
             alt="a small spinning circle to display loading"
           />
-          <p v-else class="address">{{ importCosmosAddress }}</p>
+          <p v-else class="address">{{ importedAddress }}</p>
         </TmFormGroup>
         <TmFormGroup
           :error="$v.$error && $v.name.$invalid"
@@ -86,7 +86,7 @@ export default {
     Steps
   },
   data: () => ({
-    importCosmosAddress: {}
+    importedAddress: {}
   }),
   computed: {
     ...mapGetters([`connected`, `recover`]),
@@ -101,7 +101,7 @@ export default {
     }
   },
   async created() {
-    this.importCosmosAddress = await this.$store.dispatch(
+    this.importedAddress = await this.$store.dispatch(
       `getAddressFromSeed`,
       {
         seedPhrase: this.$store.state.recover.seed,

--- a/tests/unit/specs/components/common/__snapshots__/TmSessionImportName.spec.js.snap
+++ b/tests/unit/specs/components/common/__snapshots__/TmSessionImportName.spec.js.snap
@@ -26,11 +26,11 @@ exports[`TmSessionImportName has the expected html structure 1`] = `
         fieldid="import-name"
         fieldlabel="Your Address"
       >
-        <p
-          class="address"
-        >
-          cosmos1234
-        </p>
+        <img
+          alt="a small spinning circle to display loading"
+          class="tm-data-msg__icon"
+          src="~assets/images/loader.svg"
+        />
       </tmformgroup-stub>
        
       <tmformgroup-stub

--- a/tests/unit/specs/components/common/__snapshots__/TmSessionImportName.spec.js.snap
+++ b/tests/unit/specs/components/common/__snapshots__/TmSessionImportName.spec.js.snap
@@ -26,11 +26,11 @@ exports[`TmSessionImportName has the expected html structure 1`] = `
         fieldid="import-name"
         fieldlabel="Your Address"
       >
-        <img
-          alt="a small spinning circle to display loading"
-          class="tm-data-msg__icon"
-          src="~assets/images/loader.svg"
-        />
+        <p
+          class="address"
+        >
+          cosmos1234
+        </p>
       </tmformgroup-stub>
        
       <tmformgroup-stub


### PR DESCRIPTION
Closes #3927 

**Description:**

Replace {} by a loading spinner in account import, that's it!

Thank you! 🚀

---

For contributor:

- [ ] Added changes entries. Run `yarn changelog` for a guided process.
- [ ] Reviewed `Files changed` in the github PR explorer
- [ ] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI
