### PR TITLE
Fix NaN self stake % in inactive validator in Polkadot

### DIFF
--- a/changes/mario_3931-wrong-self-stake-inactive-val-polkadot
+++ b/changes/mario_3931-wrong-self-stake-inactive-val-polkadot
@@ -1,0 +1,1 @@
+[Fixed] [#3931](https://github.com/cosmos/lunie/issues/3931) Fix wrong Self Stake percentage in inactive validators in polkadot  @mariopino

--- a/src/components/staking/PageValidator.vue
+++ b/src/components/staking/PageValidator.vue
@@ -504,7 +504,6 @@ export default {
   }
 }
 </script>
-
 <style scoped>
 .back-button,
 .tutorial-button {

--- a/src/components/staking/PageValidator.vue
+++ b/src/components/staking/PageValidator.vue
@@ -504,6 +504,7 @@ export default {
   }
 }
 </script>
+
 <style scoped>
 .back-button,
 .tutorial-button {

--- a/src/components/staking/PageValidator.vue
+++ b/src/components/staking/PageValidator.vue
@@ -144,7 +144,7 @@
           <h4>Self Stake</h4>
           <span id="page-profile__self-bond">
             {{ validator.selfStake | shortDecimals }} /
-            {{ (validator.selfStake / validator.tokens) | percent }}
+            {{ (validator.selfStake / validator.tokens || 0) | percent }}
           </span>
         </li>
         <li>


### PR DESCRIPTION
Closes #3931 

**Description:**

Handle undefined caused by 0/0 div.

Thank you! 🚀

---

For contributor:

- [x] Added changes entries. Run `yarn changelog` for a guided process.
- [x] Reviewed `Files changed` in the github PR explorer
- [x] Attach screenshots of the UI components on the PR description (if applicable)
- [x] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI
