### PR TITLE
Ana/show fiatvalues only on mainnet. display 0 values

### DIFF
--- a/changes/ana_display-fiatvalues-in-mainnet
+++ b/changes/ana_display-fiatvalues-in-mainnet
@@ -1,0 +1,1 @@
+[Changed] [#3950](https://github.com/cosmos/lunie/pull/3950) Now fiatValues are only displayed on mainnets and also 0 fiatValues are shown @Bitcoinera

--- a/src/components/common/TmBalance.vue
+++ b/src/components/common/TmBalance.vue
@@ -39,7 +39,7 @@
             </i>
             <span v-else>Need some tokens?</span>
           </button>
-          <div class="currency-selector">
+          <div v-if="!isTestnet" class="currency-selector">
             <img
               v-if="preferredCurrency"
               class="currency-flag"
@@ -104,12 +104,7 @@
               {{ overview.totalStake | bigFigureOrShortDecimals | noBlanks }}
               {{ stakingDenom }}
             </span>
-            <template
-              v-if="
-                overview.totalStakeFiatValue &&
-                  overview.totalStakeFiatValue.amount > 0
-              "
-            >
+            <template v-if="overview.totalStakeFiatValue && !isTestnet">
               <span class="fiat">
                 {{
                   bigFigureOrShortDecimals(overview.totalStakeFiatValue.amount)
@@ -170,7 +165,7 @@
                 {{ balance.amount | bigFigureOrShortDecimals }}
                 {{ balance.denom }}
               </span>
-              <span v-if="balance.fiatValue" class="fiat">
+              <span v-if="balance.fiatValue && !isTestnet" class="fiat">
                 {{ bigFigureOrShortDecimals(balance.fiatValue.amount) }}
                 {{ balance.fiatValue.denom }}</span
               >
@@ -299,7 +294,7 @@ export default {
   },
   computed: {
     ...mapState([`connection`]),
-    ...mapGetters([`address`, `network`, `stakingDenom`]),
+    ...mapGetters([`address`, `networks`, `network`, `stakingDenom`]),
     // only be ready to withdraw of the validator rewards are loaded and the user has rewards to withdraw
     // the validator rewards are needed to filter the top 5 validators to withdraw from
     readyToWithdraw() {
@@ -343,6 +338,9 @@ export default {
     },
     totalRewards() {
       return this.totalRewardsPerDenom[this.stakingDenom] || 0
+    },
+    isTestnet() {
+      return this.networks.find(network => network.id === this.network).testnet
     }
   },
   watch: {

--- a/tests/unit/specs/components/common/TmBalance.spec.js
+++ b/tests/unit/specs/components/common/TmBalance.spec.js
@@ -9,7 +9,13 @@ describe(`TmBalance`, () => {
       getters: {
         address: "cosmos1address",
         network: "test-network",
-        stakingDenom: "ATOM"
+        stakingDenom: "ATOM",
+        networks: [
+          {
+            id: "test-network",
+            testnet: false
+          }
+        ]
       },
       state: {
         connection: {


### PR DESCRIPTION
Closes #ISSUE

**Description:**

<!-- Briefly describe what you're adding or fixing with this PR -->

Applyes suggestions made by @jbibla 

This is how it would look like for Terra mainnet for example:

![image](https://user-images.githubusercontent.com/40721795/80743344-17ede300-8b1d-11ea-9361-2de2ae088be8.png)

And like this for gaia. Nothing fiatValue related on sight:

![image](https://user-images.githubusercontent.com/40721795/80743418-33f18480-8b1d-11ea-9871-9fc62ff6f1bc.png)


Thank you! 🚀

---

For contributor:

- [ ] Added changes entries. Run `yarn changelog` for a guided process.
- [ ] Reviewed `Files changed` in the github PR explorer
- [ ] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI
