### PR TITLE
Ana/add especial warning for polkadot schnorrkel

### DIFF
--- a/changes/ana_add-schnorrkel-warning-for-polkadot-import
+++ b/changes/ana_add-schnorrkel-warning-for-polkadot-import
@@ -1,0 +1,1 @@
+[Changed] [#3955](https://github.com/cosmos/lunie/pull/3955) Adds a specific warning for Polkadot seed import: only Schnorrkel supported. Also adds a specific seed placeholder @Bitcoinera

--- a/src/components/common/TmSessionImport.vue
+++ b/src/components/common/TmSessionImport.vue
@@ -14,8 +14,17 @@
           <FieldSeed
             id="import-seed"
             :value="seed"
-            placeholder="Must be exactly 12 or 24 words"
+            :placeholder="
+              isPolkadot
+                ? 'Must be your seed phrase or private key hash'
+                : 'Must be exactly 12 or 24 words'
+            "
             @input="val => (seed = val)"
+          />
+          <TmFormMsg
+            v-if="isPolkadot"
+            type="custom"
+            msg="Currently only the Schnorrkel algorithm is supported"
           />
           <TmFormMsg
             v-if="$v.seed.$error && !$v.seed.required"
@@ -83,7 +92,7 @@ export default {
     Steps
   },
   computed: {
-    ...mapGetters([`recover`]),
+    ...mapGetters([`recover`, `network`]),
     seed: {
       get() {
         return this.$store.state.recover.seed
@@ -94,6 +103,9 @@ export default {
           value: value.trim() // remove spaces from beginning and end of string
         })
       }
+    },
+    isPolkadot() {
+      return this.network.startsWith("polkadot")
     }
   },
   methods: {

--- a/tests/unit/specs/components/common/TmSessionImport.spec.js
+++ b/tests/unit/specs/components/common/TmSessionImport.spec.js
@@ -14,7 +14,8 @@ describe(`TmSessionImport`, () => {
 
   beforeEach(() => {
     getters = {
-      connected: () => true
+      connected: () => true,
+      network: "cosmos-hub-mainnet"
     }
     $store = {
       state: {

--- a/tests/unit/specs/components/common/__snapshots__/TmSessionImport.spec.js.snap
+++ b/tests/unit/specs/components/common/__snapshots__/TmSessionImport.spec.js.snap
@@ -33,6 +33,8 @@ exports[`TmSessionImport has the expected html structure 1`] = `
         />
          
         <!---->
+         
+        <!---->
       </tmformgroup-stub>
     </div>
      


### PR DESCRIPTION
Related to #3929 

**Description:**

<!-- Briefly describe what you're adding or fixing with this PR -->

I think before we deliver M1 we should at least include some warning message about how we are handling account import right now for Kusama.

<img width="510px" src="https://user-images.githubusercontent.com/40721795/80816868-9ce60480-8bd0-11ea-86d4-b286217035a1.png">


Thank you! 🚀

---

For contributor:

- [ ] Added changes entries. Run `yarn changelog` for a guided process.
- [ ] Reviewed `Files changed` in the github PR explorer
- [ ] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI
