### PR TITLE
Ana/fix source maps for browser debugging

### DIFF
--- a/changes/ana_fix-source-maps-for-debugging
+++ b/changes/ana_fix-source-maps-for-debugging
@@ -1,0 +1,1 @@
+[Changed] [#3957](https://github.com/cosmos/lunie/pull/3957) Brings webpack-internal back @Bitcoinera

--- a/vue.config.js
+++ b/vue.config.js
@@ -49,7 +49,7 @@ const config = {
           chunks: "all"
         }
       },
-      devtool: "source-map"
+      devtool: "eval-source-map"
     }
 
     return config


### PR DESCRIPTION
Closes #ISSUE

**Description:**

<!-- Briefly describe what you're adding or fixing with this PR -->

It seems the `devtool: "source-map"` option is not ideal for development, as I was reading in the [docs](https://webpack.js.org/configuration/devtool/).

I then tried `eval-cheap-source-map` but found out `eval-source-map` does include the original files. So perfect for debugging.

webpack-internal is now back:

<img width="480px" src="https://user-images.githubusercontent.com/40721795/80823368-cdcc3680-8bdc-11ea-8508-addd533e3b2b.png">


Thank you! 🚀

---

For contributor:

- [ ] Added changes entries. Run `yarn changelog` for a guided process.
- [ ] Reviewed `Files changed` in the github PR explorer
- [ ] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI
