### PR TITLE
Ana/remove red of death for schnorrkel warning

### DIFF
--- a/changes/ana_remove-red-of-death-for-schnorkell-warning
+++ b/changes/ana_remove-red-of-death-for-schnorkell-warning
@@ -1,0 +1,1 @@
+[Changed] [#3990](https://github.com/cosmos/lunie/pull/3990) Changes the Schnorrkel warning color to warning color @Bitcoinera

--- a/src/components/common/TmSessionImport.vue
+++ b/src/components/common/TmSessionImport.vue
@@ -24,6 +24,7 @@
           <TmFormMsg
             v-if="isPolkadot"
             type="custom"
+            class="tm-form-msg--desc"
             msg="Currently only the Schnorrkel algorithm is supported"
           />
           <TmFormMsg
@@ -139,3 +140,8 @@ export default {
   }
 }
 </script>
+<style scoped>
+.schnorrkel-warning {
+  color: var(--warning)
+}
+</style>


### PR DESCRIPTION
Closes #ISSUE

**Description:**

<!-- Briefly describe what you're adding or fixing with this PR -->

@jbibla you were so right. That red for a simple warning was a terrible idea. Too scary.

Fixed here:

<img width="380px" src="https://user-images.githubusercontent.com/40721795/81215517-c5f40400-8fd9-11ea-8f52-48bc1a2ccdfd.png">

Versus red of death (super scary)

<img width="380px" src="https://user-images.githubusercontent.com/40721795/81215629-e8861d00-8fd9-11ea-9711-7d666ed6abb4.png">

One line change 🍾 





Thank you! 🚀

---

For contributor:

- [ ] Added changes entries. Run `yarn changelog` for a guided process.
- [ ] Reviewed `Files changed` in the github PR explorer
- [ ] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI
