### PR TITLE
buttons should have a loading state

### DIFF
--- a/changes/jordan_button-loading-state
+++ b/changes/jordan_button-loading-state
@@ -1,0 +1,1 @@
+[Changed] buttons now have an optional loading state @jbibla

--- a/src/components/common/TmBtn.vue
+++ b/src/components/common/TmBtn.vue
@@ -5,11 +5,38 @@
       secondary: type === `secondary`,
       small: size === `small`,
       active: type === `active`,
-      sidebar: type === `sidebar`
+      sidebar: type === `sidebar`,
+      loading: loading
     }"
     :disabled="disabled"
   >
-    {{ value }}
+    <svg
+      v-if="loading"
+      width="24"
+      height="24"
+      viewBox="0 0 40 40"
+      xmlns="http://www.w3.org/2000/svg"
+      stroke="#8c8fa6"
+    >
+      <g fill="none" fill-rule="evenodd">
+        <g transform="translate(1 1)" stroke-width="2">
+          <circle stroke="white" stroke-opacity=".2" cx="18" cy="18" r="18" />
+          <path stroke="white" d="M36 18c0-9.94-8.06-18-18-18">
+            <animateTransform
+              attributeName="transform"
+              type="rotate"
+              from="0 18 18"
+              to="360 18 18"
+              dur="1s"
+              repeatCount="indefinite"
+            />
+          </path>
+        </g>
+      </g>
+    </svg>
+    <template v-else>
+      {{ value }}
+    </template>
   </button>
 </template>
 
@@ -29,6 +56,10 @@ export default {
       type: String,
       default: null
     },
+    loading: {
+      type: Boolean,
+      default: false
+    },
     disabled: {
       type: Boolean,
       default: false
@@ -42,7 +73,9 @@ export default {
   font-family: var(--sans);
   font-size: 14px;
   font-weight: 400;
-  padding: 8px 16px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   width: auto;
   min-width: 100px;
   color: var(--menu-bright);
@@ -54,6 +87,7 @@ export default {
   transition: all 0.5s ease;
   white-space: nowrap;
   outline: none;
+  height: 36px;
 }
 
 .button:hover {

--- a/src/components/common/TmSessionHardware.vue
+++ b/src/components/common/TmSessionHardware.vue
@@ -238,7 +238,6 @@ export default {
 }
 
 .session-main .button {
-  margin: 0 auto;
-  display: block;
+  margin: 2rem auto 0;
 }
 </style>

--- a/tests/unit/specs/components/common/__snapshots__/TmBtn.spec.js.snap
+++ b/tests/unit/specs/components/common/__snapshots__/TmBtn.spec.js.snap
@@ -5,8 +5,8 @@ exports[`TmBtn allows for customization 1`] = `
   class="button"
 >
   
-  button
-
+    button
+  
 </button>
 `;
 
@@ -15,8 +15,8 @@ exports[`TmBtn displays as a link 1`] = `
   class="button"
 >
   
-  button
-
+    button
+  
 </button>
 `;
 
@@ -25,8 +25,8 @@ exports[`TmBtn displays as an external link 1`] = `
   class="button"
 >
   
-  button
-
+    button
+  
 </button>
 `;
 
@@ -35,8 +35,8 @@ exports[`TmBtn displays as an icon 1`] = `
   class="button"
 >
   
-  button
-
+    button
+  
 </button>
 `;
 
@@ -45,8 +45,8 @@ exports[`TmBtn displays as an img as an icon 1`] = `
   class="button"
 >
   
-  button
-
+    button
+  
 </button>
 `;
 
@@ -55,7 +55,7 @@ exports[`TmBtn has the expected html structure 1`] = `
   class="button"
 >
   
-  button
-
+    button
+  
 </button>
 `;

--- a/tests/unit/specs/components/common/__snapshots__/TmSessionHardware.spec.js.snap
+++ b/tests/unit/specs/components/common/__snapshots__/TmSessionHardware.spec.js.snap
@@ -165,8 +165,8 @@ exports[`TmSessionHardware shows the ledger conection view when there're errors 
                 class="button"
               >
                 
-  Sign In
-
+    Sign In
+  
               </button>
             </div>
           </div>
@@ -249,8 +249,8 @@ exports[`TmSessionHardware shows the ledger conection view with no errors 1`] = 
                 class="button"
               >
                 
-  Sign In
-
+    Sign In
+  
               </button>
             </div>
           </div>


### PR DESCRIPTION
**Description:**
- buttons have a loading state! 
- this doesn't implement it anywhere but will allow us to use the loading prop later and in https://github.com/luniehq/lunie-browser-extension/pull/215

<img width="126" alt="Screen Shot 2020-05-12 at 8 56 36 AM" src="https://user-images.githubusercontent.com/6021933/81693837-80e32e00-942e-11ea-9887-2c725021bc76.png">
<img width="123" alt="Screen Shot 2020-05-12 at 8 56 27 AM" src="https://user-images.githubusercontent.com/6021933/81693843-82acf180-942e-11ea-9777-871eff70ba1c.png">

Thank you! 🚀

---

For contributor:

- [ ] Added changes entries. Run `yarn changelog` for a guided process.
- [ ] Reviewed `Files changed` in the github PR explorer
- [ ] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI
