### PR TITLE
Ana/fix rewards denoms in am misplaced

### DIFF
--- a/changes/ana_4024-fix-claiming-rewards-denoms-misplaced
+++ b/changes/ana_4024-fix-claiming-rewards-denoms-misplaced
@@ -1,0 +1,1 @@
+[Fixed] [#4024](https://github.com/cosmos/lunie/issues/4024) Fixes claim rewards denoms misplaces on ModalWithdrawRewards (multi-denom) @Bitcoinera

--- a/src/ActionModal/components/ModalWithdrawRewards.vue
+++ b/src/ActionModal/components/ModalWithdrawRewards.vue
@@ -28,7 +28,7 @@
     >
       <div
         v-for="reward in totalRewards"
-        :key="JSON.stringify(reward.denom)"
+        :key="reward.denom"
         class="rewards-list-item"
       >
         <input

--- a/src/ActionModal/components/ModalWithdrawRewards.vue
+++ b/src/ActionModal/components/ModalWithdrawRewards.vue
@@ -26,13 +26,17 @@
         }`
       "
     >
-      <div v-for="reward in totalRewards" :key="JSON.stringify(reward.denom)">
-        <span class="input-suffix">{{ reward.denom }}</span>
+      <div
+        v-for="reward in totalRewards"
+        :key="JSON.stringify(reward.denom)"
+        class="rewards-list-item"
+      >
         <input
           class="tm-field-addon"
           disabled="disabled"
           :value="reward.amount | fullDecimals"
         />
+        <span class="input-suffix">{{ reward.denom }}</span>
       </div>
       <TmFormMsg
         v-if="currentNetwork.network_type === 'polkadot'"
@@ -205,5 +209,8 @@ export default {
 }
 .tm-field-addon {
   margin-bottom: 0.25rem;
+}
+.rewards-list-item {
+  position: relative;
 }
 </style>

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -99,7 +99,7 @@ input.tm-field {
   padding: 7px;
   font-size: var(--sm);
   text-transform: uppercase;
-  top: 2px;
+  top: 0;
   right: 30px;
   letter-spacing: 1px;
   text-align: right;


### PR DESCRIPTION
Closes #4024

**Description:**

<!-- Briefly describe what you're adding or fixing with this PR -->

Fixes claim rewards denoms misplaced on ModalWithdrawRewards:

<h3>Before:</h3>

<img width="440px" src="https://user-images.githubusercontent.com/40721795/81723224-d5b09400-9482-11ea-8384-013747a3f5c7.png">

<h3>After:</h3>

<img width="440px" src="https://user-images.githubusercontent.com/40721795/81840438-49b56f80-9549-11ea-8356-974e41cdf094.png">



Thank you! 🚀

---

For contributor:

- [ ] Added changes entries. Run `yarn changelog` for a guided process.
- [ ] Reviewed `Files changed` in the github PR explorer
- [ ] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI
