### PR TITLE
Ana/3925 use proper keyboar input for mobile android 6

### DIFF
--- a/changes/ana_3925-use-proper-keyboar-input-for-mobile-android-6
+++ b/changes/ana_3925-use-proper-keyboar-input-for-mobile-android-6
@@ -1,0 +1,1 @@
+[Changed] [#4028](https://github.com/cosmos/lunie/pull/4028) Aims to fix numeric keyboard on some mobile devices lacking of decimal point @Bitcoinera

--- a/src/components/common/TmField.vue
+++ b/src/components/common/TmField.vue
@@ -70,6 +70,7 @@
     :class="css"
     :placeholder="placeholder"
     :value="value"
+    step="0.000001"
     @change="onChange"
     @keyup="onKeyup"
     @keydown="onKeydown"

--- a/tests/unit/specs/components/common/__snapshots__/TmField.spec.js.snap
+++ b/tests/unit/specs/components/common/__snapshots__/TmField.spec.js.snap
@@ -3,6 +3,7 @@
 exports[`TmField allows for style customization 1`] = `
 <input
   class="tm-field tm-field-size-lg"
+  step="0.000001"
   type="text"
 />
 `;
@@ -94,6 +95,7 @@ exports[`TmField displays a disabled toggle 2`] = `
 exports[`TmField displays a number input 1`] = `
 <input
   class="tm-field"
+  step="0.000001"
   type="number"
 />
 `;
@@ -354,6 +356,7 @@ exports[`TmField displays as a select 3`] = `
 exports[`TmField has the expected html structure 1`] = `
 <input
   class="tm-field"
+  step="0.000001"
   type="text"
 />
 `;


### PR DESCRIPTION
Closes #3925 (at least aims to)

**Description:**

<!-- Briefly describe what you're adding or fixing with this PR -->

I don't have Android Studio to test this, but it is not harmful at all (one line change 😝 ) and we can so give it a shot 🤷 Better than nothing

I was reading quite a couple of threads about this, but mostly are React Native developers complaining. And our Android code comes directly from capacitor, so it is a very concrete case.

Let's just give it a shot

Thank you! 🚀

---

For contributor:

- [ ] Added changes entries. Run `yarn changelog` for a guided process.
- [ ] Reviewed `Files changed` in the github PR explorer
- [ ] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI
