### PR TITLE
[WIP] Limit actions based on address role in Polkadot

### DIFF
--- a/changes/4017-polkadot-address-role-2
+++ b/changes/4017-polkadot-address-role-2
@@ -1,0 +1,1 @@
+[Changed] [#4017](https://github.com/cosmos/lunie/issues/4017) Get Polkadot address role and set restrictions according to it @mariopino&Bitcoinera

--- a/src/ActionModal/components/ActionModal.vue
+++ b/src/ActionModal/components/ActionModal.vue
@@ -576,8 +576,8 @@ export default {
     },
     isRestrictedAddressRole() {
       return (
-        this.session.addressRole === "stash" ||
-        this.session.addressRole === "controller"
+        this.session.accountRole === "stash" ||
+        this.session.accountRole === "controller"
       )
     }
   },

--- a/src/ActionModal/components/ActionModal.vue
+++ b/src/ActionModal/components/ActionModal.vue
@@ -18,6 +18,11 @@
           <i class="material-icons notranslate">close</i>
         </div>
         <span class="action-modal-title">{{ title }}</span>
+        <span
+          >Currently you are logged in with a {{ session.addressRole }} account.
+          Only send action is allowed. To perform other actions, please create
+          and sign in with a Lunie account</span
+        >
         <Steps
           v-if="
             [defaultStep, feeStep, signStep].includes(step) &&
@@ -563,6 +568,12 @@ export default {
       // some API responses don't have gasPrices set
       if (!balance.gasPrice) balance.gasPrice = defaultBalance.gasPrice
       return balance
+    },
+    isRestrictedAddressRole() {
+      return (
+        this.session.addressRole === "stash" ||
+        this.session.addressRole === "controller"
+      )
     }
   },
   watch: {

--- a/src/ActionModal/components/ActionModal.vue
+++ b/src/ActionModal/components/ActionModal.vue
@@ -18,11 +18,16 @@
           <i class="material-icons notranslate">close</i>
         </div>
         <span class="action-modal-title">{{ title }}</span>
-        <span
-          >Currently you are logged in with a {{ session.addressRole }} account.
+        <TmFormMsg
+          v-if="isRestrictedAddressRole"
+          :msg="
+            `Currently you are logged in with a ${session.addressRole} account.
           Only send action is allowed. To perform other actions, please create
-          and sign in with a Lunie account</span
-        >
+          and sign in with a Lunie account`
+          "
+          type="custom"
+          class="tm-form-msg--desc"
+        />
         <Steps
           v-if="
             [defaultStep, feeStep, signStep].includes(step) &&

--- a/src/components/common/TmBalance.vue
+++ b/src/components/common/TmBalance.vue
@@ -12,11 +12,16 @@
     <div v-else>
       <div class="header-container">
         <h1>Your Portfolio</h1>
-        <span v-if="isRestrictedAddressRole"
-          >Currently you are logged in with a {{ session.addressRole }} account.
+        <TmFormMsg
+          v-if="isRestrictedAddressRole"
+          :msg="
+            `Currently you are logged in with a ${session.addressRole} account.
           If you want to stake and see your delegations, create and sing in with
-          a Lunie account.</span
-        >
+          a Lunie account.`
+          "
+          type="custom"
+          class="tm-form-msg--desc"
+        />
         <div class="buttons">
           <TmBtn
             class="send-button"
@@ -219,6 +224,7 @@ import { bigFigureOrShortDecimals } from "scripts/num"
 import { noBlanks } from "src/filters"
 import TmBtn from "common/TmBtn"
 import SendModal from "src/ActionModal/components/SendModal"
+import TmFormMsg from "common/TmFormMsg"
 import ModalWithdrawRewards from "src/ActionModal/components/ModalWithdrawRewards"
 import ModalTutorial from "common/ModalTutorial"
 import { mapGetters, mapState } from "vuex"
@@ -231,6 +237,7 @@ export default {
   components: {
     TmBtn,
     SendModal,
+    TmFormMsg,
     ModalWithdrawRewards,
     ModalTutorial
   },

--- a/src/components/common/TmBalance.vue
+++ b/src/components/common/TmBalance.vue
@@ -355,8 +355,8 @@ export default {
     },
     isRestrictedAddressRole() {
       return (
-        this.session.addressRole === "stash" ||
-        this.session.addressRole === "controller"
+        this.session.accountRole === "stash" ||
+        this.session.accountRole === "controller"
       )
     }
   },

--- a/src/components/common/TmBalance.vue
+++ b/src/components/common/TmBalance.vue
@@ -820,6 +820,11 @@ select option {
   .rewards {
     font-size: 12px;
   }
+
+  .tm-form-msg.tm-form-msg--desc {
+    padding-bottom: 1rem;
+    text-align: center;
+  }
 }
 
 @media screen and (min-width: 1254px) {

--- a/src/components/common/TmBalance.vue
+++ b/src/components/common/TmBalance.vue
@@ -12,6 +12,11 @@
     <div v-else>
       <div class="header-container">
         <h1>Your Portfolio</h1>
+        <span v-if="isRestrictedAddressRole"
+          >Currently you are logged in with a {{ session.addressRole }} account.
+          If you want to stake and see your delegations, create and sing in with
+          a Lunie account.</span
+        >
         <div class="buttons">
           <TmBtn
             class="send-button"
@@ -21,7 +26,7 @@
           />
           <TmBtn
             id="withdraw-btn"
-            :disabled="!readyToWithdraw"
+            :disabled="!readyToWithdraw || isRestrictedAddressRole"
             class="withdraw-rewards"
             value="Claim Rewards"
             @click.native="readyToWithdraw && onWithdrawal()"
@@ -340,6 +345,12 @@ export default {
     },
     isTestnet() {
       return this.networks.find(network => network.id === this.network).testnet
+    },
+    isRestrictedAddressRole() {
+      return (
+        this.session.addressRole === "stash" ||
+        this.session.addressRole === "controller"
+      )
     }
   },
   watch: {

--- a/src/components/common/TmSessionExtension.vue
+++ b/src/components/common/TmSessionExtension.vue
@@ -92,7 +92,7 @@ export default {
     }
   },
   apollo: {
-    polkadotSignIn: {
+    addressRole: {
       query: gql`
         query polkadotSignIn($address: String!) {
           polkadotSignIn(address: $address) {

--- a/src/components/common/TmSessionExtension.vue
+++ b/src/components/common/TmSessionExtension.vue
@@ -44,7 +44,6 @@
 import AccountList from "common/AccountList"
 import SessionFrame from "common/SessionFrame"
 import { mapState, mapGetters } from "vuex"
-import gql from "graphql-tag"
 export default {
   name: `session-extension`,
   components: {
@@ -53,12 +52,11 @@ export default {
   },
   data: () => ({
     connectionError: null,
-    address: null,
-    addressRole: null
+    address: null
   }),
   computed: {
     ...mapState([`extension`]),
-    ...mapGetters([`networks`, `currentNetwork`]),
+    ...mapGetters([`networks`]),
     accounts() {
       return this.extension.accounts
     }
@@ -74,8 +72,7 @@ export default {
       this.$store.dispatch(`signIn`, {
         sessionType: `extension`,
         address: account.address,
-        networkId: account.network ? account.network : "cosmos-hub-mainnet", // defaulting to cosmos-hub-mainnet
-        addressRole: this.addressRole
+        networkId: account.network ? account.network : "cosmos-hub-mainnet" // defaulting to cosmos-hub-mainnet
       })
     },
     async signInAndRedirect(account) {
@@ -89,30 +86,6 @@ export default {
           networkId: accountNetwork.slug
         }
       })
-    }
-  },
-  apollo: {
-    addressRole: {
-      query: gql`
-        query accountRole($networkId: String!, $address: String!) {
-          accountRole(networkId: $networkId, address: $address)
-        }
-      `,
-      /* istanbul ignore next */
-      variables() {
-        return {
-          address: this.address,
-          networkId: this.currentNetwork.id
-        }
-      },
-      /* istanbul ignore next */
-      update(data) {
-        return data.accountRole
-      },
-      /* istanbul ignore next */
-      skip() {
-        return this.currentNetwork.network_type !== "polkadot" || !this.address
-      }
     }
   }
 }

--- a/src/components/common/TmSessionExtension.vue
+++ b/src/components/common/TmSessionExtension.vue
@@ -94,25 +94,24 @@ export default {
   apollo: {
     addressRole: {
       query: gql`
-        query polkadotSignIn($address: String!) {
-          polkadotSignIn(address: $address) {
-            role
-          }
+        query accountRole($networkId: String!, $address: String!) {
+          accountRole(networkId: $networkId, address: $address)
         }
       `,
       /* istanbul ignore next */
       variables() {
         return {
-          address: this.address
+          address: this.address,
+          networkId: this.currentNetwork.id
         }
       },
       /* istanbul ignore next */
       update(data) {
-        return data.polkadotSignIn.role
+        return data.accountRole
       },
       /* istanbul ignore next */
       skip() {
-        return this.currentNetwork.network_type !== "polkadot"
+        return this.currentNetwork.network_type !== "polkadot" || !this.address
       }
     }
   }

--- a/src/components/common/TmSessionHardware.vue
+++ b/src/components/common/TmSessionHardware.vue
@@ -172,25 +172,24 @@ export default {
   apollo: {
     addressRole: {
       query: gql`
-        query polkadotSignIn($address: String!) {
-          polkadotSignIn(address: $address) {
-            role
-          }
+        query accountRole($networkId: String!, $address: String!) {
+          accountRole(networkId: $networkId, address: $address)
         }
       `,
       /* istanbul ignore next */
       variables() {
         return {
-          address: this.address
+          address: this.address,
+          networkId: this.currentNetwork.id
         }
       },
       /* istanbul ignore next */
       update(data) {
-        return data.polkadotSignIn.role
+        return data.accountRole
       },
       /* istanbul ignore next */
       skip() {
-        return this.currentNetwork.network_type !== "polkadot"
+        return this.currentNetwork.network_type !== "polkadot" || !this.address
       }
     }
   }

--- a/src/components/common/TmSessionHardware.vue
+++ b/src/components/common/TmSessionHardware.vue
@@ -170,7 +170,7 @@ export default {
     }
   },
   apollo: {
-    polkadotSignIn: {
+    addressRole: {
       query: gql`
         query polkadotSignIn($address: String!) {
           polkadotSignIn(address: $address) {

--- a/src/components/common/TmSessionHardware.vue
+++ b/src/components/common/TmSessionHardware.vue
@@ -93,8 +93,6 @@ import HardwareState from "common/TmHardwareState"
 import SessionFrame from "common/SessionFrame"
 import { getAddressFromLedger } from "scripts/ledger"
 import * as Sentry from "@sentry/browser"
-import gql from "graphql-tag"
-
 export default {
   name: `session-hardware`,
   components: {
@@ -106,7 +104,6 @@ export default {
     status: `connect`,
     connectionError: null,
     address: null,
-    addressRole: null,
     copySuccess: false,
     hidFeatureLink: `chrome://flags/#enable-experimental-web-platform-features`,
     linuxLedgerConnectionLink: `https://support.ledger.com/hc/en-us/articles/360019301813-Fix-USB-issues`,
@@ -114,7 +111,7 @@ export default {
   }),
   computed: {
     ...mapState([`session`]),
-    ...mapGetters([`networkSlug`, `currentNetwork`]),
+    ...mapGetters([`networkSlug`]),
     ...mapGetters({ networkId: `network` }),
     submitCaption() {
       return {
@@ -155,11 +152,9 @@ export default {
         Sentry.captureException(error)
         return
       }
-
       await this.$store.dispatch(`signIn`, {
         sessionType: `ledger`,
-        address: this.address,
-        addressRole: this.addressRole
+        address: this.address
       })
     },
     onCopy() {
@@ -167,30 +162,6 @@ export default {
       setTimeout(() => {
         this.copySuccess = false
       }, 2500)
-    }
-  },
-  apollo: {
-    addressRole: {
-      query: gql`
-        query accountRole($networkId: String!, $address: String!) {
-          accountRole(networkId: $networkId, address: $address)
-        }
-      `,
-      /* istanbul ignore next */
-      variables() {
-        return {
-          address: this.address,
-          networkId: this.currentNetwork.id
-        }
-      },
-      /* istanbul ignore next */
-      update(data) {
-        return data.accountRole
-      },
-      /* istanbul ignore next */
-      skip() {
-        return this.currentNetwork.network_type !== "polkadot" || !this.address
-      }
     }
   }
 }
@@ -203,23 +174,19 @@ export default {
   margin-bottom: 0;
   padding-top: 1rem;
 }
-
 .install-notes {
   flex-direction: column;
 }
-
 .ledger-install {
   font-size: var(--sm);
   margin-bottom: 0;
 }
-
 .address {
   color: var(--link);
   font-weight: 500;
   font-size: 14px;
   white-space: nowrap;
 }
-
 .form-message {
   font-size: var(--sm);
   font-weight: 500;
@@ -227,7 +194,6 @@ export default {
   color: var(--dim);
   display: inline-block;
 }
-
 .form-message.notice {
   border-radius: 0.25rem;
   border: 1px solid var(--bc-dim);
@@ -239,7 +205,6 @@ export default {
   font-style: normal;
   width: 100%;
 }
-
 .copy-feature-link {
   display: initial;
   font-size: 0.8rem;
@@ -247,11 +212,9 @@ export default {
   margin-bottom: 0.2rem;
   color: var(--link);
 }
-
 .copy-feature-link .material-icons {
   font-size: 12px;
 }
-
 .copy-feature-link .copied {
   padding-bottom: 2px;
   padding-right: 0;
@@ -259,11 +222,9 @@ export default {
   color: var(--success);
   opacity: 0;
 }
-
 .copy-feature-link .copied.active {
   opacity: 1;
 }
-
 .session-main .button {
   margin: 2rem auto 0;
 }

--- a/src/components/common/TmSessionSignIn.vue
+++ b/src/components/common/TmSessionSignIn.vue
@@ -93,8 +93,7 @@ export default {
     signInPassword: ``,
     error: ``,
     testnet: false,
-    addressRole: null,
-    isAddressRoleSet: false
+    addressRole: null
   }),
   computed: {
     ...mapState([`keystore`, `session`]),
@@ -146,7 +145,7 @@ export default {
         password: this.signInPassword,
         address: this.signInAddress
       })
-      if (sessionCorrect && this.isAddressRoleSet) {
+      if (sessionCorrect && this.addressRole) {
         this.selectNetworkByAddress(this.signInAddress)
 
         this.$store.dispatch(`signIn`, {
@@ -232,11 +231,6 @@ export default {
       },
       /* istanbul ignore next */
       update(data) {
-        this.$store.dispatch(`setAddressRole`, {
-          role: data.polkadotSignIn.role
-        })
-        this.isAddressRoleSet = true
-        this.addressRole = data.polkadotSignIn.role
         return data.polkadotSignIn.role
       },
       /* istanbul ignore next */

--- a/src/components/common/TmSessionSignIn.vue
+++ b/src/components/common/TmSessionSignIn.vue
@@ -93,7 +93,8 @@ export default {
     signInPassword: ``,
     error: ``,
     testnet: false,
-    addressRole: null
+    addressRole: null,
+    isAddressRoleSet: false
   }),
   computed: {
     ...mapState([`keystore`, `session`]),
@@ -145,7 +146,7 @@ export default {
         password: this.signInPassword,
         address: this.signInAddress
       })
-      if (sessionCorrect) {
+      if (sessionCorrect && this.isAddressRoleSet) {
         this.selectNetworkByAddress(this.signInAddress)
 
         this.$store.dispatch(`signIn`, {
@@ -226,16 +227,23 @@ export default {
       /* istanbul ignore next */
       variables() {
         return {
-          address: this.address
+          address: this.signInAddress
         }
       },
       /* istanbul ignore next */
       update(data) {
+        this.$store.dispatch(`setAddressRole`, {
+          role: data.polkadotSignIn.role
+        })
+        this.isAddressRoleSet = true
+        this.addressRole = data.polkadotSignIn.role
         return data.polkadotSignIn.role
       },
       /* istanbul ignore next */
       skip() {
-        return this.currentNetwork.network_type !== "polkadot"
+        return (
+          !this.signInAddress || this.currentNetwork.network_type !== "polkadot"
+        )
       }
     }
   }

--- a/src/components/common/TmSessionSignIn.vue
+++ b/src/components/common/TmSessionSignIn.vue
@@ -215,7 +215,7 @@ export default {
     }
   },
   apollo: {
-    polkadotSignIn: {
+    addressRole: {
       query: gql`
         query polkadotSignIn($address: String!) {
           polkadotSignIn(address: $address) {

--- a/src/components/common/TmSessionSignIn.vue
+++ b/src/components/common/TmSessionSignIn.vue
@@ -217,26 +217,25 @@ export default {
   apollo: {
     addressRole: {
       query: gql`
-        query polkadotSignIn($address: String!) {
-          polkadotSignIn(address: $address) {
-            role
-          }
+        query accountRole($networkId: String!, $address: String!) {
+          accountRole(networkId: $networkId, address: $address)
         }
       `,
       /* istanbul ignore next */
       variables() {
         return {
-          address: this.signInAddress
+          address: this.signInAddress,
+          networkId: this.currentNetwork.id
         }
       },
       /* istanbul ignore next */
       update(data) {
-        return data.polkadotSignIn.role
+        return data.accountRole
       },
       /* istanbul ignore next */
       skip() {
         return (
-          !this.signInAddress || this.currentNetwork.network_type !== "polkadot"
+          this.currentNetwork.network_type !== "polkadot" || !this.signInAddress
         )
       }
     }

--- a/src/components/staking/PageValidator.vue
+++ b/src/components/staking/PageValidator.vue
@@ -315,8 +315,8 @@ export default {
     ...mapGetters({ userAddress: `address` }),
     isRestrictedAddressRole() {
       return (
-        this.session.addressRole === "stash" ||
-        this.session.addressRole === "controller"
+        this.session.accountRole === "stash" ||
+        this.session.accountRole === "controller"
       )
     }
   },

--- a/src/components/staking/PageValidator.vue
+++ b/src/components/staking/PageValidator.vue
@@ -10,10 +10,7 @@
   >
     <template v-if="validator.operatorAddress" slot="managed-body">
       <div class="button-container">
-        <button
-          class="back-button"
-          @click="$router.go(-1)"
-        >
+        <button class="back-button" @click="$router.go(-1)">
           <i class="material-icons notranslate arrow">arrow_back</i>
           Back
         </button>
@@ -81,11 +78,16 @@
       </tr>
 
       <div class="action-button-container">
-        <TmBtn id="delegation-btn" value="Stake" @click.native="onDelegation" />
+        <TmBtn
+          id="delegation-btn"
+          value="Stake"
+          :disabled="isRestrictedAddressRole"
+          @click.native="onDelegation"
+        />
         <TmBtn
           id="undelegation-btn"
           class="undelegation-btn"
-          :disabled="delegation.amount === 0"
+          :disabled="delegation.amount === 0 || isRestrictedAddressRole"
           value="Unstake"
           type="secondary"
           @click.native="onUndelegation"
@@ -308,9 +310,15 @@ export default {
     }
   }),
   computed: {
-    ...mapState([`connection`]),
+    ...mapState([`connection`, `session`]),
     ...mapGetters([`network`, `stakingDenom`]),
-    ...mapGetters({ userAddress: `address` })
+    ...mapGetters({ userAddress: `address` }),
+    isRestrictedAddressRole() {
+      return (
+        this.session.addressRole === "stash" ||
+        this.session.addressRole === "controller"
+      )
+    }
   },
   mounted() {
     this.$apollo.queries.rewards.refetch()

--- a/src/components/wallet/PagePortfolio.vue
+++ b/src/components/wallet/PagePortfolio.vue
@@ -23,9 +23,7 @@ export default {
   computed: {
     ...mapState([`session`]),
     isRestrictedAddressRole() {
-      return (
-        this.session.addressRole === "controller"
-      )
+      return this.session.accountRole === "controller"
     }
   }
 }

--- a/src/components/wallet/PagePortfolio.vue
+++ b/src/components/wallet/PagePortfolio.vue
@@ -1,6 +1,6 @@
 <template>
   <TmPage :sign-in-required="true" :managed="true" :dark-background="true">
-    <template slot="managed-body">
+    <template v-if="!isRestrictedAddressRole" slot="managed-body">
       <DelegationsOverview />
       <Undelegations />
     </template>
@@ -11,6 +11,7 @@
 import TmPage from "common/TmPage"
 import DelegationsOverview from "staking/DelegationsOverview"
 import Undelegations from "staking/Undelegations"
+import { mapState } from "vuex"
 
 export default {
   name: `page-portfolio`,
@@ -18,6 +19,15 @@ export default {
     TmPage,
     Undelegations,
     DelegationsOverview
+  },
+  computed: {
+    ...mapState([`session`]),
+    isRestrictedAddressRole() {
+      return (
+        this.session.addressRole === "stash" ||
+        this.session.addressRole === "controller"
+      )
+    }
   }
 }
 </script>

--- a/src/components/wallet/PagePortfolio.vue
+++ b/src/components/wallet/PagePortfolio.vue
@@ -24,7 +24,6 @@ export default {
     ...mapState([`session`]),
     isRestrictedAddressRole() {
       return (
-        this.session.addressRole === "stash" ||
         this.session.addressRole === "controller"
       )
     }

--- a/src/gql/index.js
+++ b/src/gql/index.js
@@ -219,3 +219,9 @@ export const UserTransactionAdded = gql`
     }
   }
 `
+
+export const AccountRole = gql`
+  query accountRole($networkId: String!, $address: String!) {
+    accountRole(networkId: $networkId, address: $address)
+  }
+`

--- a/src/vuex/modules/session.js
+++ b/src/vuex/modules/session.js
@@ -1,7 +1,6 @@
 import { track, deanonymize, anonymize } from "scripts/google-analytics"
 // import pushNotifications from "./pushNotifications.js"
 import config from "src/../config"
-import { getAPI } from "../../signing/networkMessages/polkadot-transactions"
 
 export default () =>
   // { apollo }
@@ -134,7 +133,7 @@ export default () =>
       },
       async signIn(
         { state, getters: { currentNetwork }, commit, dispatch },
-        { address, sessionType = `ledger`, networkId }
+        { address, sessionType = `ledger`, networkId, role }
       ) {
         if (networkId && currentNetwork.id !== networkId) {
           await commit(`setNetworkId`, networkId)
@@ -157,10 +156,7 @@ export default () =>
         })
 
         if (currentNetwork.network_type === "polkadot") {
-          await dispatch(`checkAddressRole`, {
-            address,
-            currentNetwork
-          })
+          await dispatch(`setAddressRole`, { role })
         }
 
         // Register device for push registrations
@@ -245,19 +241,9 @@ export default () =>
         dispatch(`storeLocalPreferences`)
       },
       /* istanbul ignore next */
-      async checkAddressRole({ commit }, { address }) {
-        const api = await getAPI()
-        const bonded = await api.query.staking.bonded(address)
-        if (!bonded) {
-          // Set address role (stash | controller), useful for Polkadot networks so we can limit actions based on it
-          commit(`setUserAddressRole`, {
-            addressRole: `controller`
-          })
-          return
-        }
-        commit(`setUserAddressRole`, {
-          addressRole: `stash`
-        })
+      async setAddressRole({ commit }, { role }) {
+        // Set address role (stash | controller), useful for Polkadot networks so we can limit actions based on it
+        commit(`setUserAddressRole`, role)
       }
     }
 

--- a/src/vuex/modules/session.js
+++ b/src/vuex/modules/session.js
@@ -1,263 +1,256 @@
 import { track, deanonymize, anonymize } from "scripts/google-analytics"
 // import pushNotifications from "./pushNotifications.js"
+import { AccountRole } from "../../gql"
 import config from "src/../config"
 
-export default () =>
-  // { apollo }
-  {
-    const USER_PREFERENCES_KEY = `lunie_user_preferences`
+export default ({ apollo }) => {
+  const USER_PREFERENCES_KEY = `lunie_user_preferences`
 
-    const state = {
-      developmentMode: config.development, // can't be set in browser
-      experimentalMode: config.development, // development mode, can be set from browser
-      insecureMode: config.development || config.e2e || false, // show the local signer
-      mobile: config.mobileApp || false,
-      signedIn: false,
-      sessionType: null, // local, explore, ledger, extension
-      pauseHistory: false,
-      history: [],
-      address: null, // Current address
-      addresses: [], // Array of previously used addresses
-      addressRole: undefined, // For Polkadot: stash, controller
-      errorCollection: false,
-      analyticsCollection: false,
-      cookiesAccepted: undefined,
-      preferredCurrency: undefined,
-      stateLoaded: false, // shows if the persisted state is already loaded. used to prevent overwriting the persisted state before it is loaded
-      error: null,
-      currrentModalOpen: false,
-      modals: {
-        error: { active: false },
-        help: { active: false }
-      },
-      browserWithLedgerSupport:
-        navigator.userAgent.includes(`Chrome`) ||
-        navigator.userAgent.includes(`Opera`),
+  const state = {
+    developmentMode: config.development, // can't be set in browser
+    experimentalMode: config.development, // development mode, can be set from browser
+    insecureMode: config.development || config.e2e || false, // show the local signer
+    mobile: config.mobileApp || false,
+    signedIn: false,
+    sessionType: null, // local, explore, ledger, extension
+    pauseHistory: false,
+    history: [],
+    address: null, // Current address
+    addresses: [], // Array of previously used addresses
+    accountRole: undefined, // For Polkadot: stash, controller
+    errorCollection: false,
+    analyticsCollection: false,
+    cookiesAccepted: undefined,
+    preferredCurrency: undefined,
+    stateLoaded: false, // shows if the persisted state is already loaded. used to prevent overwriting the persisted state before it is loaded
+    error: null,
+    currrentModalOpen: false,
+    modals: {
+      error: { active: false },
+      help: { active: false }
+    },
+    browserWithLedgerSupport:
+      navigator.userAgent.includes(`Chrome`) ||
+      navigator.userAgent.includes(`Opera`),
 
-      // import into state to be able to test easier
-      externals: {
-        config,
-        track,
-        anonymize,
-        deanonymize
-      }
-    }
-
-    const mutations = {
-      setSignIn(state, hasSignedIn) {
-        state.signedIn = hasSignedIn
-      },
-      setSessionType(state, sessionType) {
-        state.sessionType = sessionType
-      },
-      setUserAddress(state, address) {
-        state.address = address
-      },
-      setUserAddresses(state, addresses) {
-        state.addresses = addresses
-      },
-      setExperimentalMode(state) {
-        state.experimentalMode = true
-      },
-      setInsecureMode(state) {
-        state.insecureMode = true
-      },
-      addHistory(state, path) {
-        state.history.push(path)
-        state.externals.track(`pageview`, {
-          dl: path
-        })
-      },
-      popHistory(state) {
-        state.history.pop()
-      },
-      pauseHistory(state, paused) {
-        state.pauseHistory = paused
-      },
-      setCurrrentModalOpen(state, modal) {
-        state.currrentModalOpen = modal
-      },
-      setUserAddressRole(state, addressRole) {
-        state.addressRole = addressRole
-      }
-    }
-
-    const actions = {
-      async checkForPersistedSession({
-        dispatch,
-        commit,
-        rootState: {
-          connection: { network }
-        }
-      }) {
-        const session = localStorage.getItem(sessionKey(network))
-        if (session) {
-          const { address, sessionType } = JSON.parse(session)
-          await dispatch(`signIn`, { address, sessionType, networkId: network })
-        } else {
-          commit(`setSignIn`, false)
-        }
-      },
-      async checkForPersistedAddresses({ commit }) {
-        const addresses = localStorage.getItem(`addresses`)
-        if (addresses) {
-          await commit(`setUserAddresses`, JSON.parse(addresses))
-        }
-      },
-      async checkForPersistedAddressRole({ commit }) {
-        const addressRole = localStorage.getItem(`addressRole`)
-        if (addressRole) {
-          await commit(`setUserAddressRole`, addressRole)
-        }
-      },
-      async persistSession(store, { address, sessionType, networkId }) {
-        localStorage.setItem(
-          sessionKey(networkId),
-          JSON.stringify({ address, sessionType })
-        )
-      },
-      async persistAddresses(store, { addresses }) {
-        localStorage.setItem(`addresses`, JSON.stringify(addresses))
-      },
-      async persistUserAddressRole(store, { addressRole }) {
-        localStorage.setItem(`addressRole`, addressRole)
-      },
-      async rememberAddress(
-        { state, commit },
-        { address, sessionType, networkId }
-      ) {
-        // Check if signin address was previously used
-        const sessionExist = state.addresses.find(
-          usedAddress => address === usedAddress.address
-        )
-        // Add signin address to addresses array if was not used previously
-        if (!sessionExist) {
-          state.addresses.push({
-            address,
-            type: sessionType,
-            networkId
-          })
-          commit(`setUserAddresses`, state.addresses)
-        }
-      },
-      async signIn(
-        { state, getters: { currentNetwork }, commit, dispatch },
-        { address, sessionType = `ledger`, networkId, addressRole }
-      ) {
-        if (networkId && currentNetwork.id !== networkId) {
-          await commit(`setNetworkId`, networkId)
-          await dispatch(`persistNetwork`, { id: networkId })
-          currentNetwork.id = networkId
-        }
-        commit(`setSignIn`, true)
-        commit(`setSessionType`, sessionType)
-        commit(`setUserAddress`, address)
-        await dispatch(`rememberAddress`, { address, sessionType, networkId })
-
-        dispatch(`persistSession`, {
-          address,
-          sessionType,
-          networkId: currentNetwork.id
-        })
-        const addresses = state.addresses
-        dispatch(`persistAddresses`, {
-          addresses
-        })
-
-        dispatch(`persistUserAddressRole`, { addressRole })
-        // Set address role (stash | controller), useful for Polkadot networks so we can limit actions based on it
-        // if role is null (all non-polkadot accounts) we allow all actions
-        dispatch(`checkForPersistedAddressRole`)
-
-        // Register device for push registrations
-        // const activeNetworks = getActiveNetworks(networks)
-        /* istanbul ignore next */
-        // await pushNotifications.askPermissionAndRegister(activeNetworks, apollo)
-
-        state.externals.track(`event`, `session`, `sign-in`, sessionType)
-      },
-      signOut({ state, commit, dispatch }, networkId) {
-        state.externals.track(`event`, `session`, `sign-out`)
-
-        dispatch(`resetSessionData`, networkId)
-        commit(`setSignIn`, false)
-      },
-      resetSessionData({ commit, state }, networkId) {
-        state.history = ["/"]
-        commit(`setUserAddress`, null)
-        localStorage.removeItem(sessionKey(networkId))
-      },
-      loadLocalPreferences({ state, dispatch }) {
-        const localPreferences = localStorage.getItem(USER_PREFERENCES_KEY)
-
-        if (!localPreferences) {
-          state.cookiesAccepted = false
-          return
-        }
-
-        const {
-          cookiesAccepted,
-          errorCollection,
-          analyticsCollection,
-          preferredCurrency
-        } = JSON.parse(localPreferences)
-
-        if (cookiesAccepted) {
-          state.cookiesAccepted = true
-        }
-        if (state.errorCollection !== errorCollection)
-          dispatch(`setErrorCollection`, errorCollection)
-        if (state.analyticsCollection !== analyticsCollection)
-          dispatch(`setAnalyticsCollection`, analyticsCollection)
-        if (state.preferredCurrency !== preferredCurrency)
-          dispatch(`setPreferredCurrency`, preferredCurrency)
-      },
-      storeLocalPreferences({ state }) {
-        state.cookiesAccepted = true
-        localStorage.setItem(
-          USER_PREFERENCES_KEY,
-          JSON.stringify({
-            cookiesAccepted: state.cookiesAccepted,
-            errorCollection: state.errorCollection,
-            analyticsCollection: state.analyticsCollection,
-            preferredCurrency: state.preferredCurrency
-          })
-        )
-      },
-      setErrorCollection({ state, dispatch }, enabled) {
-        // don't track in development
-        if (state.developmentMode) return
-
-        state.errorCollection = enabled
-        dispatch(`storeLocalPreferences`)
-      },
-      setAnalyticsCollection({ state, dispatch }, enabled) {
-        // don't track in development
-        if (state.developmentMode) return
-
-        state.analyticsCollection = enabled
-        dispatch(`storeLocalPreferences`)
-
-        if (state.analyticsCollection) {
-          state.externals.deanonymize()
-          console.log(`Analytics collection has been enabled`)
-        } else {
-          state.externals.anonymize()
-          console.log(`Analytics collection has been disabled`)
-        }
-      },
-      setPreferredCurrency({ state, dispatch }, currency) {
-        state.preferredCurrency = currency
-        dispatch(`storeLocalPreferences`)
-      }
-    }
-
-    return {
-      state,
-      mutations,
-      actions
+    // import into state to be able to test easier
+    externals: {
+      config,
+      track,
+      anonymize,
+      deanonymize
     }
   }
+
+  const mutations = {
+    setSignIn(state, hasSignedIn) {
+      state.signedIn = hasSignedIn
+    },
+    setSessionType(state, sessionType) {
+      state.sessionType = sessionType
+    },
+    setUserAddress(state, address) {
+      state.address = address
+    },
+    setUserAddresses(state, addresses) {
+      state.addresses = addresses
+    },
+    setExperimentalMode(state) {
+      state.experimentalMode = true
+    },
+    setInsecureMode(state) {
+      state.insecureMode = true
+    },
+    addHistory(state, path) {
+      state.history.push(path)
+      state.externals.track(`pageview`, {
+        dl: path
+      })
+    },
+    popHistory(state) {
+      state.history.pop()
+    },
+    pauseHistory(state, paused) {
+      state.pauseHistory = paused
+    },
+    setCurrrentModalOpen(state, modal) {
+      state.currrentModalOpen = modal
+    }
+  }
+
+  const actions = {
+    async checkForPersistedSession({
+      dispatch,
+      commit,
+      rootState: {
+        connection: { network }
+      }
+    }) {
+      const session = localStorage.getItem(sessionKey(network))
+      if (session) {
+        const { address, sessionType } = JSON.parse(session)
+        dispatch(`getPolkadotAccountRole`, { address, networkId: network })
+        await dispatch(`signIn`, { address, sessionType, networkId: network })
+      } else {
+        commit(`setSignIn`, false)
+      }
+    },
+    async checkForPersistedAddresses({ commit }) {
+      const addresses = localStorage.getItem(`addresses`)
+      if (addresses) {
+        await commit(`setUserAddresses`, JSON.parse(addresses))
+      }
+    },
+    async persistSession(store, { address, sessionType, networkId }) {
+      localStorage.setItem(
+        sessionKey(networkId),
+        JSON.stringify({ address, sessionType })
+      )
+    },
+    async persistAddresses(store, { addresses }) {
+      localStorage.setItem(`addresses`, JSON.stringify(addresses))
+    },
+    async rememberAddress(
+      { state, commit },
+      { address, sessionType, networkId }
+    ) {
+      // Check if signin address was previously used
+      const sessionExist = state.addresses.find(
+        usedAddress => address === usedAddress.address
+      )
+      // Add signin address to addresses array if was not used previously
+      if (!sessionExist) {
+        state.addresses.push({
+          address,
+          type: sessionType,
+          networkId
+        })
+        commit(`setUserAddresses`, state.addresses)
+      }
+    },
+    async signIn(
+      { state, getters: { currentNetwork }, commit, dispatch },
+      { address, sessionType = `ledger`, networkId }
+    ) {
+      if (networkId && currentNetwork.id !== networkId) {
+        await commit(`setNetworkId`, networkId)
+        await dispatch(`persistNetwork`, { id: networkId })
+        currentNetwork.id = networkId
+      }
+      commit(`setSignIn`, true)
+      commit(`setSessionType`, sessionType)
+      commit(`setUserAddress`, address)
+      await dispatch(`rememberAddress`, { address, sessionType, networkId })
+
+      dispatch(`persistSession`, {
+        address,
+        sessionType,
+        networkId: currentNetwork.id
+      })
+      const addresses = state.addresses
+      dispatch(`persistAddresses`, {
+        addresses
+      })
+      dispatch(`getPolkadotAccountRole`, { address, networkId })
+
+      // Register device for push registrations
+      // const activeNetworks = getActiveNetworks(networks)
+      /* istanbul ignore next */
+      // await pushNotifications.askPermissionAndRegister(activeNetworks, apollo)
+
+      state.externals.track(`event`, `session`, `sign-in`, sessionType)
+    },
+    signOut({ state, commit, dispatch }, networkId) {
+      state.externals.track(`event`, `session`, `sign-out`)
+
+      dispatch(`resetSessionData`, networkId)
+      commit(`setSignIn`, false)
+    },
+    resetSessionData({ commit, state }, networkId) {
+      state.history = ["/"]
+      commit(`setUserAddress`, null)
+      localStorage.removeItem(sessionKey(networkId))
+    },
+    loadLocalPreferences({ state, dispatch }) {
+      const localPreferences = localStorage.getItem(USER_PREFERENCES_KEY)
+
+      if (!localPreferences) {
+        state.cookiesAccepted = false
+        return
+      }
+
+      const {
+        cookiesAccepted,
+        errorCollection,
+        analyticsCollection,
+        preferredCurrency
+      } = JSON.parse(localPreferences)
+
+      if (cookiesAccepted) {
+        state.cookiesAccepted = true
+      }
+      if (state.errorCollection !== errorCollection)
+        dispatch(`setErrorCollection`, errorCollection)
+      if (state.analyticsCollection !== analyticsCollection)
+        dispatch(`setAnalyticsCollection`, analyticsCollection)
+      if (state.preferredCurrency !== preferredCurrency)
+        dispatch(`setPreferredCurrency`, preferredCurrency)
+    },
+    storeLocalPreferences({ state }) {
+      state.cookiesAccepted = true
+      localStorage.setItem(
+        USER_PREFERENCES_KEY,
+        JSON.stringify({
+          cookiesAccepted: state.cookiesAccepted,
+          errorCollection: state.errorCollection,
+          analyticsCollection: state.analyticsCollection,
+          preferredCurrency: state.preferredCurrency
+        })
+      )
+    },
+    setErrorCollection({ state, dispatch }, enabled) {
+      // don't track in development
+      if (state.developmentMode) return
+
+      state.errorCollection = enabled
+      dispatch(`storeLocalPreferences`)
+    },
+    setAnalyticsCollection({ state, dispatch }, enabled) {
+      // don't track in development
+      if (state.developmentMode) return
+
+      state.analyticsCollection = enabled
+      dispatch(`storeLocalPreferences`)
+
+      if (state.analyticsCollection) {
+        state.externals.deanonymize()
+        console.log(`Analytics collection has been enabled`)
+      } else {
+        state.externals.anonymize()
+        console.log(`Analytics collection has been disabled`)
+      }
+    },
+    setPreferredCurrency({ state, dispatch }, currency) {
+      state.preferredCurrency = currency
+      dispatch(`storeLocalPreferences`)
+    },
+    async getPolkadotAccountRole(store, { address, networkId }) {
+      const accountRole = await apollo.query({
+        query: AccountRole,
+        variables: { address, networkId }
+      })
+      // Set address role (stash | controller), useful for Polkadot networks so we can limit actions based on it
+      // if role is null (all non-polkadot accounts) we allow all actions
+      state.accountRole = accountRole.data.accountRole
+    }
+  }
+
+  return {
+    state,
+    mutations,
+    actions
+  }
+}
 
 /**
  * Retrieve active networks from localstorage via session keys

--- a/src/vuex/modules/session.js
+++ b/src/vuex/modules/session.js
@@ -155,9 +155,7 @@ export default () =>
           addresses
         })
 
-        if (currentNetwork.network_type === "polkadot") {
-          await dispatch(`setAddressRole`, { role })
-        }
+        await dispatch(`setAddressRole`, { role })
 
         // Register device for push registrations
         // const activeNetworks = getActiveNetworks(networks)
@@ -243,6 +241,7 @@ export default () =>
       /* istanbul ignore next */
       async setAddressRole({ commit }, { role }) {
         // Set address role (stash | controller), useful for Polkadot networks so we can limit actions based on it
+        // if role is null (all non-polkadot accounts) we allow all actions
         commit(`setUserAddressRole`, role)
       }
     }

--- a/tests/unit/specs/components/ActionModal/components/__snapshots__/ActionModal.spec.js.snap
+++ b/tests/unit/specs/components/ActionModal/components/__snapshots__/ActionModal.spec.js.snap
@@ -37,6 +37,12 @@ exports[`ActionModal back button renders and functions 1`] = `
       Send
     </span>
      
+    <span>
+      Currently you are logged in with a  account.
+        Only send action is allowed. To perform other actions, please create
+        and sign in with a Lunie account
+    </span>
+     
     <steps-stub
       activestep="sign"
       steps="Details,Fees,Sign"
@@ -129,6 +135,12 @@ exports[`ActionModal runs validation and changes step on sign step should displa
       Send
     </span>
      
+    <span>
+      Currently you are logged in with a  account.
+        Only send action is allowed. To perform other actions, please create
+        and sign in with a Lunie account
+    </span>
+     
     <steps-stub
       activestep="sign"
       steps="Details,Fees,Sign"
@@ -218,6 +230,12 @@ exports[`ActionModal should show the action modal on success 1`] = `
       Send
     </span>
      
+    <span>
+      Currently you are logged in with a  account.
+        Only send action is allowed. To perform other actions, please create
+        and sign in with a Lunie account
+    </span>
+     
     <!---->
      
     <!---->
@@ -292,6 +310,12 @@ exports[`ActionModal should show the action modal waiting on inclusion 1`] = `
       Send
     </span>
      
+    <span>
+      Currently you are logged in with a  account.
+        Only send action is allowed. To perform other actions, please create
+        and sign in with a Lunie account
+    </span>
+     
     <!---->
      
     <!---->
@@ -346,6 +370,12 @@ exports[`ActionModal should show the action modal when user has logged in with e
       class="action-modal-title"
     >
       Send
+    </span>
+     
+    <span>
+      Currently you are logged in with a  account.
+        Only send action is allowed. To perform other actions, please create
+        and sign in with a Lunie account
     </span>
      
     <steps-stub
@@ -431,6 +461,12 @@ exports[`ActionModal should show the action modal when user has logged in with e
       Send
     </span>
      
+    <span>
+      Currently you are logged in with a  account.
+        Only send action is allowed. To perform other actions, please create
+        and sign in with a Lunie account
+    </span>
+     
     <steps-stub
       activestep="sign"
       steps="Details,Fees,Sign"
@@ -503,6 +539,12 @@ exports[`ActionModal should show the action modal when user has logged in with e
       class="action-modal-title"
     >
       Send
+    </span>
+     
+    <span>
+      Currently you are logged in with a  account.
+        Only send action is allowed. To perform other actions, please create
+        and sign in with a Lunie account
     </span>
      
     <steps-stub
@@ -588,6 +630,12 @@ exports[`ActionModal should show the action modal when user has logged in with e
       Send
     </span>
      
+    <span>
+      Currently you are logged in with a  account.
+        Only send action is allowed. To perform other actions, please create
+        and sign in with a Lunie account
+    </span>
+     
     <steps-stub
       activestep="fees"
       steps="Details,Fees,Sign"
@@ -670,6 +718,12 @@ exports[`ActionModal should show the action modal when user has logged in with e
       class="action-modal-title"
     >
       Send
+    </span>
+     
+    <span>
+      Currently you are logged in with a  account.
+        Only send action is allowed. To perform other actions, please create
+        and sign in with a Lunie account
     </span>
      
     <steps-stub
@@ -759,6 +813,12 @@ exports[`ActionModal should show the action modal when user has logged in with e
       class="action-modal-title"
     >
       Send
+    </span>
+     
+    <span>
+      Currently you are logged in with a  account.
+        Only send action is allowed. To perform other actions, please create
+        and sign in with a Lunie account
     </span>
      
     <steps-stub
@@ -861,6 +921,12 @@ exports[`ActionModal should show the action modal when user has logged in with l
       Send
     </span>
      
+    <span>
+      Currently you are logged in with a  account.
+        Only send action is allowed. To perform other actions, please create
+        and sign in with a Lunie account
+    </span>
+     
     <steps-stub
       activestep="fees"
       steps="Details,Fees,Sign"
@@ -945,6 +1011,12 @@ exports[`ActionModal should show the action modal when user has logged in with l
       Send
     </span>
      
+    <span>
+      Currently you are logged in with a  account.
+        Only send action is allowed. To perform other actions, please create
+        and sign in with a Lunie account
+    </span>
+     
     <steps-stub
       activestep="sign"
       steps="Details,Fees,Sign"
@@ -1021,6 +1093,12 @@ exports[`ActionModal should show the action modal when user has logged in with l
       class="action-modal-title"
     >
       Send
+    </span>
+     
+    <span>
+      Currently you are logged in with a  account.
+        Only send action is allowed. To perform other actions, please create
+        and sign in with a Lunie account
     </span>
      
     <steps-stub
@@ -1112,6 +1190,12 @@ exports[`ActionModal should show the action modal when user has logged in with l
       Send
     </span>
      
+    <span>
+      Currently you are logged in with a  account.
+        Only send action is allowed. To perform other actions, please create
+        and sign in with a Lunie account
+    </span>
+     
     <steps-stub
       activestep="fees"
       steps="Details,Fees,Sign"
@@ -1196,6 +1280,12 @@ exports[`ActionModal should show the action modal when user has logged in with l
       Send
     </span>
      
+    <span>
+      Currently you are logged in with a  account.
+        Only send action is allowed. To perform other actions, please create
+        and sign in with a Lunie account
+    </span>
+     
     <steps-stub
       activestep="sign"
       steps="Details,Fees,Sign"
@@ -1277,6 +1367,12 @@ exports[`ActionModal should show the action modal when user has logged in with l
       class="action-modal-title"
     >
       Send
+    </span>
+     
+    <span>
+      Currently you are logged in with a  account.
+        Only send action is allowed. To perform other actions, please create
+        and sign in with a Lunie account
     </span>
      
     <steps-stub
@@ -1363,6 +1459,12 @@ exports[`ActionModal should show the action modal when user hasn't logged in 1`]
       Send
     </span>
      
+    <span>
+      Currently you are logged in with a  account.
+        Only send action is allowed. To perform other actions, please create
+        and sign in with a Lunie account
+    </span>
+     
     <steps-stub
       activestep="details"
       steps="Details,Fees,Sign"
@@ -1435,6 +1537,12 @@ exports[`ActionModal shows a feature unavailable message 1`] = `
       class="action-modal-title"
     >
       Send
+    </span>
+     
+    <span>
+      Currently you are logged in with a  account.
+        Only send action is allowed. To perform other actions, please create
+        and sign in with a Lunie account
     </span>
      
     <steps-stub

--- a/tests/unit/specs/components/common/TmSessionExtension.spec.js
+++ b/tests/unit/specs/components/common/TmSessionExtension.spec.js
@@ -78,7 +78,8 @@ describe(`TmSessionExtension`, () => {
     expect($store.dispatch).toHaveBeenCalledWith("signIn", {
       sessionType: `extension`,
       address: "cosmos1",
-      networkId: "cosmos-hub-mainnet"
+      networkId: "cosmos-hub-mainnet",
+      addressRole: null
     })
   })
 

--- a/tests/unit/specs/components/common/TmSessionSignIn.spec.js
+++ b/tests/unit/specs/components/common/TmSessionSignIn.spec.js
@@ -123,7 +123,8 @@ describe(`TmSessionSignIn`, () => {
     expect($store.dispatch).toHaveBeenCalledWith(`signIn`, {
       password: `1234567890`,
       address: "cosmosdefault",
-      sessionType: `local`
+      sessionType: `local`,
+      addressRole: null
     })
   })
 

--- a/tests/unit/specs/components/common/__snapshots__/TmBalance.spec.js.snap
+++ b/tests/unit/specs/components/common/__snapshots__/TmBalance.spec.js.snap
@@ -12,6 +12,8 @@ exports[`TmBalance do not show available atoms when the user has none in the fir
         Your Portfolio
       </h1>
        
+      <!---->
+       
       <div
         class="buttons"
       >
@@ -283,6 +285,8 @@ exports[`TmBalance show the balance header when signed in 1`] = `
       <h1>
         Your Portfolio
       </h1>
+       
+      <!---->
        
       <div
         class="buttons"


### PR DESCRIPTION
Partially closes #4017

**Description:**

Limit actions based on address role in Polkadot:

- [ ] If Stash account, disable delegation to validators (keep bonding enabled, disable validator selection)
- [x] If Stash account, show a warning "For staking to validators you need to sign in with your controller account. You can still send tokens."
- [ ] Check batch message construction to not include the wrong tx

Thank you! 🚀

---

For contributor:

- [ ] Added changes entries. Run `yarn changelog` for a guided process.
- [ ] Reviewed `Files changed` in the github PR explorer
- [ ] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI
