### PR TITLE
Ana/3965 emoney limit fees

### DIFF
--- a/changes/ana_3965-emoney-limit-fees
+++ b/changes/ana_3965-emoney-limit-fees
@@ -1,0 +1,1 @@
+[Fixed] [#3965](https://github.com/cosmos/lunie/issues/3965) Fixes getting insufficient fees error in e-Money and Kava mainnet by not applying adjustFeesToMaxPayable in those @Bitcoinera

--- a/src/ActionModal/components/ActionModal.vue
+++ b/src/ActionModal/components/ActionModal.vue
@@ -504,14 +504,11 @@ export default {
     invoiceTotal() {
       // emoney-mainnet and kava-mainnet don't allow discounts on fees
       if (
-        this.networkId === "emoney-mainnet" ||
-        this.networkId === "kava-mainnet"
-      ) {
-        return Number(this.subTotal) + this.estimatedFee
-      }
-      if (
         this.gasEstimate &&
-        Number(this.subTotal) + this.estimatedFee > this.selectedBalance.amount
+        Number(this.subTotal) + this.estimatedFee >
+          this.selectedBalance.amount &&
+        !this.networkId === "emoney-mainnet" &&
+        !this.networkId === "kava-mainnet"
       ) {
         this.adjustFeesToMaxPayable()
       }

--- a/src/ActionModal/components/ActionModal.vue
+++ b/src/ActionModal/components/ActionModal.vue
@@ -502,7 +502,6 @@ export default {
       return this.featureFlag === "undelegate" ? 0 : this.amount
     },
     invoiceTotal() {
-      // emoney-mainnet and kava-mainnet don't allow discounts on fees
       if (
         this.gasEstimate &&
         Number(this.subTotal) + this.estimatedFee >

--- a/src/ActionModal/components/ActionModal.vue
+++ b/src/ActionModal/components/ActionModal.vue
@@ -507,8 +507,9 @@ export default {
         this.gasEstimate &&
         Number(this.subTotal) + this.estimatedFee >
           this.selectedBalance.amount &&
-        !this.networkId === "emoney-mainnet" &&
-        !this.networkId === "kava-mainnet"
+        // emoney-mainnet and kava-mainnet don't allow discounts on fees
+        this.networkId !== "emoney-mainnet" &&
+        this.networkId !== "kava-mainnet"
       ) {
         this.adjustFeesToMaxPayable()
       }

--- a/src/ActionModal/components/TableInvoice.vue
+++ b/src/ActionModal/components/TableInvoice.vue
@@ -8,7 +8,7 @@
       <li>
         <span>Network Fee</span>
         <span>
-          {{ estimatedFee | fullDecimals }}
+          {{ networkFee | fullDecimals }}
           {{ bondDenom }}
         </span>
       </li>
@@ -39,6 +39,10 @@ export default {
     bondDenom: {
       type: String,
       required: true
+    },
+    fixedFees: {
+      type: Number,
+      default: 0
     }
   },
   data: () => ({
@@ -48,8 +52,11 @@ export default {
     subTotal() {
       return this.amount
     },
+    networkFee() {
+      return this.fixedFees ? this.fixedFees : this.estimatedFee
+    },
     total() {
-      return this.estimatedFee + this.subTotal
+      return this.networkFee + this.subTotal
     }
   }
 }

--- a/src/ActionModal/components/TableInvoice.vue
+++ b/src/ActionModal/components/TableInvoice.vue
@@ -8,7 +8,7 @@
       <li>
         <span>Network Fee</span>
         <span>
-          {{ networkFee | fullDecimals }}
+          {{ estimatedFee | fullDecimals }}
           {{ bondDenom }}
         </span>
       </li>
@@ -39,10 +39,6 @@ export default {
     bondDenom: {
       type: String,
       required: true
-    },
-    fixedFees: {
-      type: Number,
-      default: 0
     }
   },
   data: () => ({
@@ -52,11 +48,8 @@ export default {
     subTotal() {
       return this.amount
     },
-    networkFee() {
-      return this.fixedFees ? this.fixedFees : this.estimatedFee
-    },
     total() {
-      return this.networkFee + this.subTotal
+      return this.estimatedFee + this.subTotal
     }
   }
 }

--- a/src/components/staking/PageValidator.vue
+++ b/src/components/staking/PageValidator.vue
@@ -10,10 +10,7 @@
   >
     <template v-if="validator.operatorAddress" slot="managed-body">
       <div class="button-container">
-        <button
-          class="back-button"
-          @click="$router.go(-1)"
-        >
+        <button class="back-button" @click="$router.go(-1)">
           <i class="material-icons notranslate arrow">arrow_back</i>
           Back
         </button>

--- a/tests/unit/specs/components/ActionModal/components/ActionModal.spec.js
+++ b/tests/unit/specs/components/ActionModal/components/ActionModal.spec.js
@@ -628,7 +628,8 @@ describe(`ActionModal`, () => {
       invoiceTotal: 1.001,
       selectedBalance: balances[0],
       subTotal: 0.999,
-      gasEstimate: 100000
+      gasEstimate: 100000,
+      chainAppliedFees: 0
     }
     ActionModal.methods.adjustFeesToMaxPayable.call(self)
     expect(self.gasPrice).toBe(1.0000000000000008e-8) // a bit lower then gasEstimate. feels right

--- a/tests/unit/specs/components/ActionModal/components/SendModal.spec.js
+++ b/tests/unit/specs/components/ActionModal/components/SendModal.spec.js
@@ -278,7 +278,11 @@ describe(`SendModal`, () => {
           denom: "STAKE"
         },
         getTerraTax: SendModal.methods.getTerraTax,
-        maxDecimals: SendModal.methods.maxDecimals
+        maxDecimals: SendModal.methods.maxDecimals,
+        chainAppliedFees: {
+          rate: 0.007,
+          cap: 1
+        }
       }
       const maxAmount = SendModal.computed.maxAmount.call(self)
       expect(maxAmount).toBe(0.993)


### PR DESCRIPTION
Closes #3965

**Description:**

<!-- Briefly describe what you're adding or fixing with this PR -->
OK, so as you can see I was here trying weird stuff with some fixed fees thing when at the end I realized the logic to fix this issue is quite simple...

simply, when the network we are on is e-Money or Kava mainnets, don't apply `adjustFeesToMaxPayable` and that's it.

I also took the chance to refactor SendModal to get `chainAppliedFees` from the API

Thank you! 🚀

---

For contributor:

- [ ] Added changes entries. Run `yarn changelog` for a guided process.
- [ ] Reviewed `Files changed` in the github PR explorer
- [ ] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI
