### PR TITLE
Disable "Set Max" button in stake for controller accounts in polkadot

### DIFF
--- a/changes/mario_4067-staking-controller-polkadot
+++ b/changes/mario_4067-staking-controller-polkadot
@@ -1,0 +1,1 @@
+[Fixed] [#4067](https://github.com/cosmos/lunie/issues/4067) Disable "Set Max" button in stake for controller accounts in polkadot @mariopino

--- a/src/ActionModal/components/DelegationModal.vue
+++ b/src/ActionModal/components/DelegationModal.vue
@@ -108,6 +108,7 @@
           class="secondary addon-max"
           value="Set Max"
           @click.native="setMaxAmount()"
+          :disabled="session.addressRole === `controller`"
         />
       </TmFieldGroup>
       <span class="form-message">


### PR DESCRIPTION
Closes #4067 

**Description:**

Disable "Set Max" button in stake for controller accounts in polkadot

Thank you! 🚀

---

For contributor:

- [ ] Added changes entries. Run `yarn changelog` for a guided process.
- [ ] Reviewed `Files changed` in the github PR explorer
- [ ] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI
