### PR TITLE
Ana/4094 account role detection on switching networks

### DIFF
--- a/changes/ana_4094-account-role-detection-on-switching-networks
+++ b/changes/ana_4094-account-role-detection-on-switching-networks
@@ -1,0 +1,1 @@
+[Fixed] [#4094](https://github.com/cosmos/lunie/issues/4094) Fixes account role detection on switching networks @Bitcoinera

--- a/src/ActionModal/components/ActionModal.vue
+++ b/src/ActionModal/components/ActionModal.vue
@@ -205,12 +205,6 @@
         >
           {{ submissionError }}
         </p>
-        <p
-          v-if="step === feeStep && !gasEstimateLoaded"
-          class="waiting-fees-message"
-        >
-          Fetching fees...
-        </p>
         <div class="action-modal-footer">
           <slot name="action-modal-footer">
             <TmFormGroup
@@ -248,6 +242,7 @@
                 ref="next"
                 type="primary"
                 value="Next"
+                :loading="step === feeStep && !gasEstimateLoaded"
                 :disabled="
                   disabled ||
                   (step === feeStep && $v.invoiceTotal.$invalid) ||
@@ -1053,14 +1048,6 @@ export default {
 
 .action-modal-footer .tm-form-group {
   padding: 0;
-}
-
-.waiting-fees-message {
-  color: var(--warning);
-  font-size: var(--sm);
-  font-style: italic;
-  margin-bottom: 0;
-  padding-top: 1rem;
 }
 
 .submission-error {

--- a/src/components/common/Avatar.vue
+++ b/src/components/common/Avatar.vue
@@ -4,23 +4,23 @@
 </template>
 
 <script>
-import Avatars from '@dicebear/avatars'
-import sprites from '@dicebear/avatars-jdenticon-sprites'
+import Avatars from "@dicebear/avatars"
+import sprites from "@dicebear/avatars-jdenticon-sprites"
 
 export default {
   name: `avatar`,
   props: {
     address: {
       type: String,
-      required: true
-    }
+      required: true,
+    },
   },
   computed: {
     svg() {
       const options = {}
       const avatars = new Avatars(sprites, options)
       return avatars.create(this.address)
-    }
-  }
+    },
+  },
 }
 </script>

--- a/src/vuex/modules/session.js
+++ b/src/vuex/modules/session.js
@@ -153,6 +153,8 @@ export default ({ apollo }) => {
         addresses,
       })
 
+      // In Polkadot there are different account types for staking. To be able to signal allowed interactions
+      // for the user in Lunie we need to query for the type of the account.
       await dispatch(`checkAddressRole`, {
         address,
         networkId: currentNetwork.id,

--- a/src/vuex/modules/session.js
+++ b/src/vuex/modules/session.js
@@ -155,10 +155,14 @@ export default ({ apollo }) => {
 
       // In Polkadot there are different account types for staking. To be able to signal allowed interactions
       // for the user in Lunie we need to query for the type of the account.
-      await dispatch(`checkAddressRole`, {
-        address,
-        networkId: currentNetwork.id,
-      })
+      if (currentNetwork.network_type === 'polkadot') {
+        await dispatch(`checkAddressRole`, {
+          address,
+          networkId: currentNetwork.id,
+        })
+      } else {
+        commit(`setUserAddressRole`, undefined)
+      }
 
       state.externals.track(`event`, `session`, `sign-in`, sessionType)
     },

--- a/src/vuex/modules/session.js
+++ b/src/vuex/modules/session.js
@@ -153,12 +153,10 @@ export default ({ apollo }) => {
         addresses,
       })
 
-      if (currentNetwork.network_type === "polkadot") {
-        await dispatch(`checkAddressRole`, {
-          address,
-          networkId: currentNetwork.id,
-        })
-      }
+      await dispatch(`checkAddressRole`, {
+        address,
+        networkId: currentNetwork.id,
+      })
 
       state.externals.track(`event`, `session`, `sign-in`, sessionType)
     },

--- a/tests/unit/specs/components/ActionModal/components/__snapshots__/ActionModal.spec.js.snap
+++ b/tests/unit/specs/components/ActionModal/components/__snapshots__/ActionModal.spec.js.snap
@@ -69,8 +69,6 @@ exports[`ActionModal back button renders and functions 1`] = `
    
   <!---->
    
-  <!---->
-   
   <div
     class="action-modal-footer"
   >
@@ -167,8 +165,6 @@ exports[`ActionModal runs validation and changes step on sign step should displa
    
   <!---->
    
-  <!---->
-   
   <div
     class="action-modal-footer"
   >
@@ -254,8 +250,6 @@ exports[`ActionModal should show the action modal on success 1`] = `
    
   <!---->
    
-  <!---->
-   
   <div
     class="action-modal-footer"
   >
@@ -296,8 +290,6 @@ exports[`ActionModal should show the action modal waiting on inclusion 1`] = `
      
     <!---->
   </div>
-   
-  <!---->
    
   <!---->
    
@@ -368,8 +360,6 @@ exports[`ActionModal should show the action modal when user has logged in with e
         
     </p>
   </div>
-   
-  <!---->
    
   <!---->
    
@@ -454,8 +444,6 @@ exports[`ActionModal should show the action modal when user has logged in with e
    
   <!---->
    
-  <!---->
-   
   <div
     class="action-modal-footer"
   >
@@ -525,8 +513,6 @@ exports[`ActionModal should show the action modal when user has logged in with e
         
     </p>
   </div>
-   
-  <!---->
    
   <!---->
    
@@ -609,8 +595,6 @@ exports[`ActionModal should show the action modal when user has logged in with e
      
     <!---->
   </div>
-   
-  <!---->
    
   <!---->
    
@@ -710,8 +694,6 @@ exports[`ActionModal should show the action modal when user has logged in with e
    
   <!---->
    
-  <!---->
-   
   <div
     class="action-modal-footer"
   >
@@ -800,8 +782,6 @@ exports[`ActionModal should show the action modal when user has logged in with e
    
   <!---->
    
-  <!---->
-   
   <div
     class="action-modal-footer"
   >
@@ -882,8 +862,6 @@ exports[`ActionModal should show the action modal when user has logged in with l
      
     <!---->
   </div>
-   
-  <!---->
    
   <!---->
    
@@ -972,8 +950,6 @@ exports[`ActionModal should show the action modal when user has logged in with l
    
   <!---->
    
-  <!---->
-   
   <div
     class="action-modal-footer"
   >
@@ -1048,8 +1024,6 @@ exports[`ActionModal should show the action modal when user has logged in with l
       </div>
     </hardwarestate-stub>
   </div>
-   
-  <!---->
    
   <!---->
    
@@ -1133,8 +1107,6 @@ exports[`ActionModal should show the action modal when user has logged in with l
      
     <!---->
   </div>
-   
-  <!---->
    
   <!---->
    
@@ -1228,8 +1200,6 @@ exports[`ActionModal should show the action modal when user has logged in with l
    
   <!---->
    
-  <!---->
-   
   <div
     class="action-modal-footer"
   >
@@ -1311,8 +1281,6 @@ exports[`ActionModal should show the action modal when user has logged in with l
    
   <!---->
    
-  <!---->
-   
   <div
     class="action-modal-footer"
   >
@@ -1386,8 +1354,6 @@ exports[`ActionModal should show the action modal when user hasn't logged in 1`]
    
   <!---->
    
-  <!---->
-   
   <div
     class="action-modal-footer"
   >
@@ -1448,8 +1414,6 @@ exports[`ActionModal shows a feature unavailable message 1`] = `
   <div
     class="action-modal-form"
   />
-   
-  <!---->
    
   <!---->
    


### PR DESCRIPTION
Closes #4094
Closes #4096 

**Description:**

<!-- Briefly describe what you're adding or fixing with this PR -->

Works better with luniehq/lunie-api#798.
Also works without it but better not throw any errors, just return `undefined`

Fixes the account role detection not working when switching networks.

Bonus extra. add loading state to button on ActionModal for `feeStep`

<img width="390px" src="https://user-images.githubusercontent.com/40721795/82552654-d4f2be80-9b62-11ea-9349-89a2c29ff8c9.png">


Thank you! 🚀

---

For contributor:

- [ ] Added changes entries. Run `yarn changelog` for a guided process.
- [ ] Reviewed `Files changed` in the github PR explorer
- [ ] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI
