### PR TITLE
Fix confusing message in stake using a stash account in polkadot

### DIFF
--- a/changes/mario_4108-fix-confusing-stake-stash-polkadot
+++ b/changes/mario_4108-fix-confusing-stake-stash-polkadot
@@ -1,0 +1,1 @@
+[Fixed] [#4108](https://github.com/cosmos/lunie/issues/4108) Fix confusing behaviour in stake using stash account in polkadot @mariopino

--- a/src/ActionModal/components/ActionModal.vue
+++ b/src/ActionModal/components/ActionModal.vue
@@ -941,13 +941,13 @@ export default {
         if (message.amount) {
           message.amount = {
             amount: String(message.amount.amount),
-            denom: message.amount.denom
+            denom: message.amount.denom,
           }
         }
         if (message.amounts) {
-          message.amounts = message.amounts.map(({amount, denom}) => ({
+          message.amounts = message.amounts.map(({ amount, denom }) => ({
             amount: String(amount),
-            denom
+            denom,
           }))
         }
         return {

--- a/src/ActionModal/components/DelegationModal.vue
+++ b/src/ActionModal/components/DelegationModal.vue
@@ -64,28 +64,15 @@
         type="text"
         readonly
       />
-      <template
-        v-if="
-          network.type !== `polkadot` ||
-          (addressRole && addressRole !== `stash`)
-        "
-      >
+      <template v-if="session.addressRole !== `stash`">
         <TmFormMsg
-          v-if="
-            targetValidator.status === 'INACTIVE' &&
-            !isRedelegation &&
-            addressRole !== `stash`
-          "
+          v-if="targetValidator.status === 'INACTIVE' && !isRedelegation"
           :msg="`You are about to stake to an inactive validator (${targetValidator.statusDetailed})`"
           type="custom"
           class="tm-form-msg--desc"
         />
         <TmFormMsg
-          v-if="
-            targetValidator.status === 'INACTIVE' &&
-            isRedelegation &&
-            addressRole !== `stash`
-          "
+          v-if="targetValidator.status === 'INACTIVE' && isRedelegation"
           :msg="`You are about to restake to an inactive validator (${targetValidator.statusDetailed})`"
           type="custom"
           class="tm-form-msg--desc"

--- a/src/ActionModal/components/DelegationModal.vue
+++ b/src/ActionModal/components/DelegationModal.vue
@@ -71,13 +71,13 @@
         "
       >
         <TmFormMsg
-          v-if="targetValidator.status === 'INACTIVE' && !isRedelegation"
+          v-if="targetValidator.status === 'INACTIVE' && !isRedelegation && !(addressRole && addressRole !== `stash`)"
           :msg="`You are about to stake to an inactive validator (${targetValidator.statusDetailed})`"
           type="custom"
           class="tm-form-msg--desc"
         />
         <TmFormMsg
-          v-if="targetValidator.status === 'INACTIVE' && isRedelegation"
+          v-if="targetValidator.status === 'INACTIVE' && isRedelegation && !(addressRole && addressRole !== `stash`)"
           :msg="`You are about to restake to an inactive validator (${targetValidator.statusDetailed})`"
           type="custom"
           class="tm-form-msg--desc"

--- a/src/ActionModal/components/DelegationModal.vue
+++ b/src/ActionModal/components/DelegationModal.vue
@@ -71,13 +71,21 @@
         "
       >
         <TmFormMsg
-          v-if="targetValidator.status === 'INACTIVE' && !isRedelegation && !(addressRole && addressRole !== `stash`)"
+          v-if="
+            targetValidator.status === 'INACTIVE' &&
+            !isRedelegation &&
+            addressRole !== `stash`
+          "
           :msg="`You are about to stake to an inactive validator (${targetValidator.statusDetailed})`"
           type="custom"
           class="tm-form-msg--desc"
         />
         <TmFormMsg
-          v-if="targetValidator.status === 'INACTIVE' && isRedelegation && !(addressRole && addressRole !== `stash`)"
+          v-if="
+            targetValidator.status === 'INACTIVE' &&
+            isRedelegation &&
+            addressRole !== `stash`
+          "
           :msg="`You are about to restake to an inactive validator (${targetValidator.statusDetailed})`"
           type="custom"
           class="tm-form-msg--desc"

--- a/tests/e2e/browserstack.conf.js
+++ b/tests/e2e/browserstack.conf.js
@@ -26,10 +26,7 @@ const nightwatch_config = {
       browser: "INFO",
     },
     chromeOptions: {
-      args: [
-        "disable-web-security",
-        "ignore-certificate-errors"
-      ],
+      args: ["disable-web-security", "ignore-certificate-errors"],
       prefs: {
         "intl.accept_languages": "en-US,en",
       },

--- a/tests/e2e/delegation.spec.js
+++ b/tests/e2e/delegation.spec.js
@@ -3,7 +3,7 @@ const {
   waitForText,
   getAccountBalance,
   getLastActivityItemHash,
-  waitForHashUpdate
+  waitForHashUpdate,
 } = require("./helpers.js")
 
 async function setSelect(browser, selector, option) {
@@ -64,7 +64,7 @@ module.exports = {
       ".tx:nth-of-type(1) .tx__content .tx__content__right .amount",
       `${value} ${browser.globals.denom}`
     )
-    
+
     await waitForHashUpdate(browser, lastHash)
   },
   "Redelegate Action": async function (browser) {
@@ -110,7 +110,7 @@ module.exports = {
       ".tx:nth-of-type(1) .tx__content .tx__content__right .amount",
       `${value} ${browser.globals.denom}`
     )
-    
+
     await waitForHashUpdate(browser, lastHash)
   },
   "Undelegate Action": async function (browser) {
@@ -158,7 +158,7 @@ module.exports = {
       ".tx:nth-of-type(1) .tx__content .tx__content__right .amount",
       `${value} ${browser.globals.denom}`
     )
-    
+
     await waitForHashUpdate(browser, lastHash)
   },
 }

--- a/tests/e2e/helpers.js
+++ b/tests/e2e/helpers.js
@@ -65,7 +65,7 @@ async function waitForText(
   while (iterations--) {
     try {
       const { value: text } = await browser.getText(selector)
-      console.log(text.replace(/ /g, '_'))
+      console.log(text.replace(/ /g, "_"))
       if (text && text.trim() === expectedCaption) return
     } catch (error) {
       console.error(error)


### PR DESCRIPTION
Closes #4108 

**Description:**

<!-- Briefly describe what you're adding or fixing with this PR -->

Don't show `to` field validation messages if user address is a stash in Stake action.

Thank you! 🚀

---

For contributor:

- [x] Added changes entries. Run `yarn changelog` for a guided process.
- [x] Reviewed `Files changed` in the github PR explorer
- [x] Attach screenshots of the UI components on the PR description (if applicable)
- [x] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI
