### PR TITLE
Ana/fix stake for none address

### DIFF
--- a/changes/ana_fix-property-stash-of-null
+++ b/changes/ana_fix-property-stash-of-null
@@ -1,0 +1,1 @@
+[Fixed] [#4160](https://github.com/cosmos/lunie/issues/4160) Fixes staking for 'none' accounts in Polkadot @Bitcoinera

--- a/src/signing/networkMessages/kusama.js
+++ b/src/signing/networkMessages/kusama.js
@@ -22,7 +22,7 @@ export async function StakeTx(
   // stake with all existing plus the selected
   const api = await getAPI()
   const transactions = []
-
+  // delegation amount
   if (amount.amount > 0) {
     const chainAmount = toChainAmount(amount, network.coinLookup)
     const payee = 0
@@ -39,19 +39,25 @@ export async function StakeTx(
     }
     // controllers can't bond stake
   }
-
+  // validator you are delegating to
   if (to.length > 0) {
     // only controller addresses can nominate (for not set controllers, we set the controller above)
     if (["controller", "stash/controller", "none"].includes(addressRole)) {
       const stakingLedger = await api.query.staking.ledger(senderAddress)
-      const stashId = stakingLedger.toJSON().stash
-      const response = await api.query.staking.nominators(stashId)
-      const { targets: delegatedValidators = [] } = response.toJSON() || {}
-      const validatorAddresses = uniqBy(
-        delegatedValidators.concat(to[0]),
-        (x) => x
-      )
-      transactions.push(await api.tx.staking.nominate(validatorAddresses))
+      console.log(stakingLedger.toJSON())
+      const stashId = stakingLedger.toJSON() ? stakingLedger.toJSON().stash : null
+      if (stashId) {
+        const response = await api.query.staking.nominators(stashId)
+        const { targets: delegatedValidators = [] } = response.toJSON() || {}
+        const validatorAddresses = uniqBy(
+          delegatedValidators.concat(to[0]),
+          (x) => x
+        )
+        transactions.push(await api.tx.staking.nominate(validatorAddresses))
+      } else {
+        // if there are no bonds it is the first account's delegation. We nominate 'to'
+        transactions.push(await api.tx.staking.nominate(to))
+      }
     }
   }
 
@@ -68,12 +74,12 @@ export async function UnstakeTx(
   // stake with all existing plus the selected
   const api = await getAPI()
   const transactions = []
-
+  // undelegation amount
   if (amount.amount > 0) {
     const chainAmount = toChainAmount(amount, network.coinLookup)
     transactions.push(await api.tx.staking.unbond(chainAmount))
   }
-
+  // validator you are undelegating from
   // Disable if address is a controller account
   if (
     from.length > 0 &&


### PR DESCRIPTION
Closes #4160 4160

**Description:**

<!-- Briefly describe what you're adding or fixing with this PR -->
Fixes stake for none accounts (that is, Polkadot accounts that have no bonds/nominations yet)

<img width="440px" src="https://user-images.githubusercontent.com/40721795/83138248-cbc99a80-a0ea-11ea-8d0d-834f0dbb3f58.png">



Thank you! 🚀

---

For contributor:

- [ ] Added changes entries. Run `yarn changelog` for a guided process.
- [ ] Reviewed `Files changed` in the github PR explorer
- [ ] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI
