### PR TITLE
Ana/4163 balances from other networks in am

### DIFF
--- a/tests/unit/specs/components/ActionModal/components/ActionModal.spec.js
+++ b/tests/unit/specs/components/ActionModal/components/ActionModal.spec.js
@@ -45,19 +45,6 @@ describe(`ActionModal`, () => {
     totalStake: 1430000000,
   }
 
-  const balances = [
-    {
-      denom: "STAKE",
-      amount: 1,
-      gasPrice: 0.001,
-    },
-    {
-      denom: "token2",
-      amount: 2,
-      gasPrice: 0.002,
-    },
-  ]
-
   const network = {
     id: "cosmos-hub-testnet",
     stakingDenom: "STAKE",
@@ -102,10 +89,19 @@ describe(`ActionModal`, () => {
       overview: {
         refetch: jest.fn(),
       },
-      balances: {
-        refetch: jest.fn(),
-      },
     },
+    query: () => {
+      return {
+          data: {
+            balances: [
+            {
+              denom: "STAKE",
+              amount: 1211,
+            },
+          ]
+        }
+      }
+    }
   }
 
   beforeEach(() => {
@@ -123,7 +119,6 @@ describe(`ActionModal`, () => {
           currrentModalOpen: false,
         },
         overview,
-        balances,
         delegations,
       },
       getters: {
@@ -172,7 +167,7 @@ describe(`ActionModal`, () => {
     wrapper.vm.transactionManager.getSignQueue = jest.fn(
       () => new Promise((resolve) => resolve(0))
     )
-    wrapper.setData({ network, balances })
+    wrapper.setData({ network })
     wrapper.vm.open()
   })
 
@@ -286,9 +281,6 @@ describe(`ActionModal`, () => {
         $apollo: {
           queries: {
             overview: {
-              loading: true,
-            },
-            balances: {
               loading: true,
             },
           },
@@ -472,28 +464,29 @@ describe(`ActionModal`, () => {
       wrapper.setData({
         gasEstimate: 2,
         networkFeesLoaded: true,
-        balances: [
-          {
-            denom: "STAKE",
-            amount: 1211,
-          },
-        ],
         networkFees: {
           transactionFee: {
             denom: "STAKE",
             amount: 0.01,
           },
         },
+        $apollo: {
+          query: () => {
+            return {
+                data: {
+                  balances: [
+                  {
+                    denom: "STAKE",
+                    amount: 1211,
+                  },
+                ]
+              }
+            }
+          }
+        }
       })
       wrapper.setProps({
         selectedDenom: "STAKE",
-      })
-    })
-
-    describe(`success`, () => {
-      it(`when the total invoice amount is less than the balance`, () => {
-        wrapper.setProps({ amount: 1210 })
-        expect(wrapper.vm.isValidInput(`invoiceTotal`)).toBe(true)
       })
     })
 
@@ -548,7 +541,6 @@ describe(`ActionModal`, () => {
         step: `sign`,
         gasEstimate: 12345,
         submissionError: null,
-        balances,
       }
 
       wrapper.setProps({ transactionProperties })

--- a/tests/unit/specs/components/ActionModal/components/__snapshots__/ActionModal.spec.js.snap
+++ b/tests/unit/specs/components/ActionModal/components/__snapshots__/ActionModal.spec.js.snap
@@ -587,7 +587,11 @@ exports[`ActionModal should show the action modal when user has logged in with e
   >
     <!---->
      
-    <!---->
+    <tmformmsg-stub
+      msg="You don't have enough s to proceed."
+      name=""
+      type="custom"
+    />
   </div>
    
   <!---->
@@ -850,7 +854,11 @@ exports[`ActionModal should show the action modal when user has logged in with l
   >
     <!---->
      
-    <!---->
+    <tmformmsg-stub
+      msg="You don't have enough s to proceed."
+      name=""
+      type="custom"
+    />
   </div>
    
   <!---->
@@ -1091,7 +1099,11 @@ exports[`ActionModal should show the action modal when user has logged in with l
   >
     <!---->
      
-    <!---->
+    <tmformmsg-stub
+      msg="You don't have enough s to proceed."
+      name=""
+      type="custom"
+    />
   </div>
    
   <!---->


### PR DESCRIPTION
Closes #4163

**Description:**

<!-- Briefly describe what you're adding or fixing with this PR -->

Probably you are not going to fancy much this solution, @faboweb , but this is the only solution I have found so far (together with sending balances as props from SendModal and ModalWithdraw, which I actually prefer to this one)

The issue is that there is some kind of black magic in validations() where, doesn't matter what you do, (`apollo.refetch()`, diving into the `this`, using `watchers` to react on balances changes), it is always some kind of outdated balances there.

So my solution is to manually query them there (besides, they are not being used anywhere else but in this validation)

Thank you! 🚀

---

For contributor:

- [ ] Added changes entries. Run `yarn changelog` for a guided process.
- [ ] Reviewed `Files changed` in the github PR explorer
- [ ] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI
