### PR TITLE
Ana/use code to determine if transaction failed

### DIFF
--- a/changes/ana_891-tx-polling-returning-success-false
+++ b/changes/ana_891-tx-polling-returning-success-false
@@ -1,0 +1,1 @@
+[Changed] [#4203](https://github.com/cosmos/lunie/pull/4203) Uses code in userTransactionAddedV2 to determine if a transaction failed or not @Bitcoinera

--- a/src/ActionModal/components/ActionModal.vue
+++ b/src/ActionModal/components/ActionModal.vue
@@ -874,13 +874,13 @@ export default {
         query: UserTransactionAdded,
         /* istanbul ignore next */
         result({ data }) {
-          const { hash, height, success, log } = data.userTransactionAddedV2
+          const { hash, height, code, log } = data.userTransactionAddedV2
           if (hash === this.txHash) {
             this.includedHeight = height
-            if (success) {
-              this.onTxIncluded()
-            } else {
+            if (code) {
               this.onSendingFailed(new Error(log))
+            } else {
+              this.onTxIncluded()
             }
           }
           this.txHash = null

--- a/src/gql/index.js
+++ b/src/gql/index.js
@@ -215,6 +215,7 @@ export const UserTransactionAdded = gql`
       hash
       height
       success
+      code
       log
     }
   }

--- a/tests/unit/specs/components/ActionModal/components/ActionModal.spec.js
+++ b/tests/unit/specs/components/ActionModal/components/ActionModal.spec.js
@@ -825,7 +825,7 @@ describe(`ActionModal`, () => {
       data: {
         userTransactionAddedV2: {
           hash,
-          success: false,
+          code: 12,
           log: "error",
         },
       },


### PR DESCRIPTION
Closes 50% luniehq/lunie-api/#891

**Description:**

<!-- Briefly describe what you're adding or fixing with this PR -->
⚠️ Needs luniehq/lunie-api#895 to work

As Anil pointed out, newer versions of the Cosmos-SDK lack of the success field. So now we only have code to determine if a transaction failed.

I will make some tests with out of gas error, the only error after broadcasting a transaction I know how to reproduce for Tendermint networks.

EDIT: just checked. It works great 👍 

Thank you! 🚀

---

For contributor:

- [ ] Added changes entries. Run `yarn changelog` for a guided process.
- [ ] Reviewed `Files changed` in the github PR explorer
- [ ] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI
