### PR TITLE
Ana/fix monorepo yarn install and add and add README

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,12 +38,12 @@ $ yarn workspace extension --dev vue-jest
 
 - API:
 ```bash
-$ yarn workspace api dev
+$ yarn workspace api start
 ```
 
 - App:
 ```bash
-$ yarn workspace app serve:win
+$ yarn workspace app serve
 ```
 
 ## To build:

--- a/README.md
+++ b/README.md
@@ -1,0 +1,60 @@
+# Lunie Official Monorepo
+
+## Packages:
+
+- API: an API to interact with many different PoS blockchains
+
+- App: Lunie Core (webapp)
+
+- Extension: Lunie browser extension.
+
+## Preparation:
+
+To install the required modules for all packages run:
+
+```bash
+$ yarn workspace api
+$ yarn workspace app
+$ yarn workspace extension
+```
+
+Or just work on the directory you are interested in and simply run `yarn`
+
+#### To install a single package:
+
+Should follow this syntax:
+
+```bash
+$ yarn workspace <workspace-name> --dev <package-name>
+```
+
+As an example:
+
+```bash
+$ yarn workspace extension --dev vue-jest
+```
+
+## To run:
+
+- API:
+```bash
+$ yarn workspace api dev
+```
+
+- App:
+```bash
+$ yarn workspace app serve:win
+```
+
+## To build:
+
+- Extension:
+```bash
+$ yarn workspace extension build
+```
+
+## To build enabling localhost connection
+
+```bash
+$ yarn run build:dev
+```

--- a/api/package.json
+++ b/api/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "lunie-api",
+  "name": "api",
   "version": "1.0.23",
   "description": "GraphQL API for Lunie.io",
   "repository": {

--- a/app/package.json
+++ b/app/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "lunie",
+  "name": "app",
   "version": "1.0.211",
   "description": "Lunie is the staking and governance platform for proof-of-stake blockchains.",
   "author": "Lunie International Software Systems Inc. <hello@lunie.io>",

--- a/extension/package.json
+++ b/extension/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "lunie-browser-extension",
+  "name": "extension",
   "version": "1.0.22",
   "description": "A browser extension to securely manage accounts and addresses, for use with Lunie.io.",
   "author": "Lunie <hello@lunie.io> (https://lunie.io)",
@@ -131,7 +131,7 @@
     "simsala": "^0.0.21",
     "stylelint": "^10.1.0",
     "stylelint-config-standard": "^18.3.0",
-    "vue-jest": "^3.0.4",
+    "vue-jest": "^3.0.5",
     "vue-loader": "^15.4.2",
     "vue-template-compiler": "^2.6.10",
     "web-ext-types": "^3.2.1",


### PR DESCRIPTION
Packages names were still the old ones and that is why the `yarn workspace` command to switch between the subrepos wasn't working.

Now `yarn workspace app` is like `yarn` in the app directory and it is also possible to do `yarn workspace extension --dev vue-jest` to add this module to the extension only