### PR TITLE
Ana/add github templates and other gh docs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,8 @@
+# This is a comment.
+# Each line is a file pattern followed by one or more owners.
+
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# @global-owner1 and @global-owner2 will be requested for
+# review when someone opens a pull request.
+*       @faboweb @jbibla

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,4 +5,4 @@
 # the repo. Unless a later match takes precedence,
 # @global-owner1 and @global-owner2 will be requested for
 # review when someone opens a pull request.
-*       @faboweb @jbibla
+*       @faboweb @jbibla @Bitcoinera 

--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,0 +1,76 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, sex characteristics, gender identity and expression,
+level of experience, education, socio-economic status, nationality, personal
+appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+ advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+ address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+ professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at hello@lunie.io. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see
+https://www.contributor-covenant.org/faq

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,24 @@
+# Contributing to Lunie
+
+Thank you for your interest in contributing to Lunie. We've written up some guidelines to help you get your issues looked into faster, and pull requests merged in a timely manner.
+
+## Issue Guidelines
+
+- Before you file an issue, make sure to have read the [README](https://github.com/cosmos/voyager/blob/develop/README.md) and followed the instructions correctly.
+- Please label the issue either bug or proposal according to its purpose.
+- Please state the version (or commit) of the UI.
+- Please describe the bug or your proposed change to the software in as much detail as possible. The faster we can reproduce the bug, the faster we can fix it.
+- When screenshots can be used to describe the bug/proposal, please include them.
+- If you report a bug, please provide the log content and the steps required to reproduce the bug. The logs can be found at `%USER_HOME%/.cosmos-voyager[-dev]/{network}/main.log`.
+
+## Pull Request Guidelines
+
+- Please confirm that your pull request will pass our linting and unit tests.
+- Please make sure your code is properly tested, so that the code coverage is not decreasing.
+- Please write `closes #123` somewhere in the pull request. #123 is the issue number you are attempting to fix with this PR. This string will automatically close the issue when the PR is merged.
+- If this PR produces a visible change, please provide screenshots showing these changes.
+- If the change is difficult to understand, please provide a description on why and how the change helps Lunie.
+
+## Release
+
+- To make an official release, follow the instructions in [docs/release.md](https://github.com/cosmos/voyager/blob/develop/docs/release.md).

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,38 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Describe the bug**
+<!-- A clear and concise description of what the bug is. -->
+
+**To Reproduce**
+<!-- Steps to reproduce the behavior: -->
+<!-- 1. Go to '...' -->
+<!-- 2. Click on '....' -->
+<!-- 3. Scroll down to '....' -->
+<!-- 4. See error -->
+
+**Expected behavior**
+<!-- A clear and concise description of what you expected to happen. -->
+
+**Screenshots**
+<!-- If applicable, add screenshots to help explain your problem. -->
+
+**Desktop (please complete the following information):**
+ - OS: <!-- [e.g. iOS] -->
+ - Browser: <!-- [e.g. chrome, safari] -->
+ - Version: <!-- [e.g. 22] -->
+
+**Smartphone (please complete the following information):**
+ - Device: <!-- [e.g. iPhone6] -->
+ - OS: <!-- [e.g. iOS] -->
+ - Browser: <!-- [e.g. chrome, safari] -->
+ - Version: <!-- [e.g. 22] -->
+
+**Additional context**
+<!-- Add any other context about the problem here. -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+<!-- A clear and concise description of what the problem is. Ex. I'm always frustrated when [...] -->
+
+**Describe the solution you'd like**
+<!-- A clear and concise description of what you want to happen. -->
+
+**Describe alternatives you've considered**
+<!-- A clear and concise description of any alternative solutions or features you've considered. -->
+
+**Additional context**
+<!-- Add any other context or screenshots about the feature request here. -->

--- a/.github/ISSUE_TEMPLATE/network_integration.md
+++ b/.github/ISSUE_TEMPLATE/network_integration.md
@@ -1,0 +1,58 @@
+---
+name: Network Integration
+about: Details for new network integration
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+### What is the network's name?
+
+
+### Is there a description for the network?
+
+
+#### Network Phase?
+- [ ] Mainnet
+- [ ] Testnet
+
+### Please share a link to this project's website.
+
+
+### Please share a link to this project's Github.
+
+
+### Please share the full node endpoints we can use.
+
+
+### What features need to be implemented?
+All functionality listed below will work with the appropriate combination of Lunie web, Lunie iOS and Android, Lunie browser extension, and Ledger Nano S and X with a cable (no bluetooth yet) and theCosmos Ledger app.
+
+**Wallet functionality**
+- [ ] Create address
+- [ ] Restore from seed phrase
+- [ ] Send tokens
+- [ ] Check balance and rewards
+- [ ] View transaction history
+
+**Staking functionality**
+- [ ] View validator list in Lunie
+- [ ] Ability to view network portfolio
+- [ ] Ability to stake tokens
+- [ ] Ability to unstake, restake tokens
+- [ ] Ability to claim rewards
+
+**Governance functionality**
+- [ ] Create a proposal
+- [ ] Deposit on a proposal
+- [ ] Vote on a proposal
+- [ ] View current and past proposals
+
+**Block explorer**
+- [ ] View user generated transactions per block
+
+### Additional context
+Add any other context or screenshots about the network integration here.
+
+### Delivery Date

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,20 @@
+Closes #ISSUE
+
+**Description:**
+
+<!-- Briefly describe what you're adding or fixing with this PR -->
+
+Thank you! 🚀
+
+---
+
+For contributor:
+
+- [ ] Added changes entries. Run `yarn changelog` for a guided process.
+- [ ] Reviewed `Files changed` in the github PR explorer
+- [ ] Attach screenshots of the UI components on the PR description (if applicable)
+- [ ] Scope of work approved for big PRs
+
+For reviewer:
+
+- [ ] Manually tested the changes on the UI

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,21 @@
+# Configuration for probot-stale - https://github.com/probot/stale
+
+# Set to true to ignore issues in a project (defaults to false)
+exemptProjects: false
+
+# Set to true to ignore issues in a milestone (defaults to false)
+exemptMilestones: false
+
+# Set to true to ignore issues with an assignee (defaults to false)
+exemptAssignees: false
+
+# Label to use when marking as stale
+staleLabel: stale
+
+pulls:
+  daysUntilStale: 6
+  daysUntilClose: 3
+
+issues:
+  daysUntilStale: 28
+  daysUntilClose: 3


### PR DESCRIPTION
Closes #4271 

Adds the missing templates to our `.github` folder in the monorepo root directory, as well as some other docs like `CONTRIBUTING.md`, `pull_request_template.md` and so on...

I also added the `CODEOWNERS` file, which means @faboweb and @jbibla will be now automatically assigned as reviewers for each PR, but I can remove it if it is too much noise. What should I do?

Thank you 🚀 ! (this one was manually added)