### PR TITLE
Ana/prevent unhandled coingecko timeouts

### DIFF
--- a/api/changes/ana_prevent-unhandled-coingecko-timeouts
+++ b/api/changes/ana_prevent-unhandled-coingecko-timeouts
@@ -1,0 +1,1 @@
+[Code Improvements] [#4360](https://github.com/cosmos/lunie/pull/4360) Handle CoinGecko timeouts @Bitcoinera

--- a/api/lib/fiatvalues-api.js
+++ b/api/lib/fiatvalues-api.js
@@ -112,7 +112,7 @@ class fiatValueAPI {
     const fiatCurrenciesUppercase = allFiatCurrencies.map((fiatCurrency) =>
       fiatCurrency.toUpperCase()
     )
-    let allFiatValues
+    let allFiatValues = {}
     if (Object.keys(this.priceFeed).length > 0) {
       allFiatValues = geckoCoinIDs.reduce((allFiatValues, coinID) => {
         const coinDenom = this.fiatValuesAPIReverseDictionary[coinID] // the actual denom of the coin
@@ -127,8 +127,6 @@ class fiatValueAPI {
         })
         return allFiatValues
       }, {})
-    } else {
-      allFiatValues = {}
     }
     // add e-Money exchange rates
     allFiatValues = {


### PR DESCRIPTION
Closes #ISSUE

**Description:**

<!-- Briefly describe what you're adding or fixing with this PR -->

Goal is to fix this annoying error (very often seen running API locally):

```
(node:3141) UnhandledPromiseRejectionWarning: Error: CoinGecko API request timed out. Current timeout is: 30000 milliseconds
    at ClientRequest.req.on (/mnt/c/Users/usuario/lunie/lunie/node_modules/coingecko-api/lib/CoinGecko.js:888:16)
    at ClientRequest.emit (events.js:189:13)
    at ClientRequest.EventEmitter.emit (domain.js:441:20)
    at TLSSocket.emitRequestTimeout (_http_client.js:662:40)
    at Object.onceWrapper (events.js:277:13)
    at TLSSocket.emit (events.js:189:13)
    at TLSSocket.EventEmitter.emit (domain.js:441:20)
    at TLSSocket.Socket._onTimeout (net.js:440:8)
    at ontimeout (timers.js:436:11)
    at tryOnTimeout (timers.js:300:5)
```

Minor thing but cleaner this way

Thank you! 🚀

---

For contributor:

- [ ] Added changes entries. Run `yarn changelog` for a guided process.
- [ ] Reviewed `Files changed` in the github PR explorer
- [ ] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI
