### PR TITLE
Ana/add dataloading to pagenotifications

### DIFF
--- a/api/lib/fiatvalues-api.js
+++ b/api/lib/fiatvalues-api.js
@@ -166,11 +166,11 @@ class fiatValueAPI {
               symbol: this.fiatCurrenciesSymbolsDictionary[fiatCurrency]
             }
           : {
-            coinDenom: coin.denom, // only used to identify values
-            amount: 0,
-            denom: fiatCurrency,
-            symbol: this.fiatCurrenciesSymbolsDictionary[fiatCurrency]
-          }
+              coinDenom: coin.denom, // only used to identify values
+              amount: 0,
+              denom: fiatCurrency,
+              symbol: this.fiatCurrenciesSymbolsDictionary[fiatCurrency]
+            }
       )
     )
     return keyBy(fiatValuesArray, 'coinDenom')

--- a/api/lib/fiatvalues-api.js
+++ b/api/lib/fiatvalues-api.js
@@ -165,7 +165,12 @@ class fiatValueAPI {
               denom: fiatCurrency,
               symbol: this.fiatCurrenciesSymbolsDictionary[fiatCurrency]
             }
-          : null
+          : {
+            coinDenom: coin.denom, // only used to identify values
+            amount: 0,
+            denom: fiatCurrency,
+            symbol: this.fiatCurrenciesSymbolsDictionary[fiatCurrency]
+          }
       )
     )
     return keyBy(fiatValuesArray, 'coinDenom')

--- a/app/changes/ana_add-dataloading-to-pagenotifications
+++ b/app/changes/ana_add-dataloading-to-pagenotifications
@@ -1,1 +1,2 @@
 [Changed] [#4372](https://github.com/cosmos/lunie/pull/4372) Add TmDataLoading to PageNotifications and a spinner for the dynamic notifications loading @Bitcoinera
+[Changed] [#4372](https://github.com/cosmos/lunie/pull/4372) Hide 0 fiat values in TmBalance @Bitcoinera

--- a/app/changes/ana_add-dataloading-to-pagenotifications
+++ b/app/changes/ana_add-dataloading-to-pagenotifications
@@ -1,0 +1,1 @@
+[Changed] [#4372](https://github.com/cosmos/lunie/pull/4372) Add TmDataLoading to PageNotifications and a spinner for the dynamic notifications loading @Bitcoinera

--- a/app/src/components/common/TmBalance.vue
+++ b/app/src/components/common/TmBalance.vue
@@ -95,7 +95,14 @@
                 {{ balance.total | bigFigureOrShortDecimals }}
                 {{ balance.denom }}
               </span>
-              <span v-if="balance.fiatValue && !isTestnet" class="fiat">
+              <span
+                v-if="
+                  balance.fiatValue &&
+                  !isTestnet &&
+                  balance.fiatValue.amount > 0
+                "
+                class="fiat"
+              >
                 {{ bigFigureOrShortDecimals(balance.fiatValue.amount) }}
                 {{ balance.fiatValue.denom }}</span
               >

--- a/app/src/components/notifications/PageNotifications.vue
+++ b/app/src/components/notifications/PageNotifications.vue
@@ -13,24 +13,31 @@
       <div slot="subtitle">Don't worry, they are on their way!</div>
     </TmDataMsg>
 
-    <EventList
-      v-else
-      :events="notifications"
-      :more-available="moreAvailable"
-      @loadMore="loadMore"
-    >
-      <template slot-scope="event">
-        <router-link :key="event.id" class="notification" :to="event.link">
-          <div class="content">
-            <img :src="event.icon" />
-            <div>
-              <h3 class="title">{{ event.title }}</h3>
+    <div v-else>
+      <EventList
+        :events="notifications"
+        :more-available="moreAvailable"
+        @loadMore="loadMore"
+      >
+        <template slot-scope="event">
+          <router-link :key="event.id" class="notification" :to="event.link">
+            <div class="content">
+              <img :src="event.icon" />
+              <div>
+                <h3 class="title">{{ event.title }}</h3>
+              </div>
             </div>
-          </div>
-          <i class="material-icons notranslate">chevron_right</i>
-        </router-link>
-      </template>
-    </EventList>
+            <i class="material-icons notranslate">chevron_right</i>
+          </router-link>
+        </template>
+      </EventList>
+      <div
+        v-if="$apollo.loading && !dataLoaded && moreAvailable"
+        class="spinner-container"
+      >
+        <img src="/img/spinner_blue@256.gif" class="spinner" />
+      </div>
+    </div>
   </TmPage>
 </template>
 
@@ -125,6 +132,7 @@ export default {
         this.dataLoaded = true
         // assume that when the full page got loaded, that there is more
         this.moreAvailable = result.notifications.length % 20 === 0
+        this.notifications = result.notifications
         return result.notifications
       },
       /* istanbul ignore next */
@@ -212,5 +220,15 @@ img {
 .title {
   font-weight: 400;
   overflow-wrap: anywhere; /** Important. Otherwise awful style bug */
+}
+
+.spinner-container {
+  display: flex;
+  justify-content: center;
+}
+
+.spinner {
+  height: 45px;
+  width: 45px;
 }
 </style>

--- a/app/src/components/notifications/PageNotifications.vue
+++ b/app/src/components/notifications/PageNotifications.vue
@@ -132,7 +132,6 @@ export default {
         this.dataLoaded = true
         // assume that when the full page got loaded, that there is more
         this.moreAvailable = result.notifications.length % 20 === 0
-        this.notifications = result.notifications
         return result.notifications
       },
       /* istanbul ignore next */

--- a/app/src/components/notifications/PageNotifications.vue
+++ b/app/src/components/notifications/PageNotifications.vue
@@ -1,7 +1,8 @@
 <template>
   <TmPage data-title="My alerts" hide-header>
+    <TmDataLoading v-if="$apollo.loading && notifications.length === 0" />
     <TmDataMsg
-      v-if="notifications.length === 0"
+      v-else-if="!$apollo.loading && notifications.length === 0"
       icon="error"
       icon-color="var(--dark-grey-blue)"
     >
@@ -37,6 +38,7 @@
 import TmPage from "common/TmPage"
 import TmDataMsg from "common/TmDataMsg"
 import EventList from "common/EventList"
+import TmDataLoading from "common/TmDataLoading"
 import { mapState, mapGetters } from "vuex"
 import gql from "graphql-tag"
 
@@ -46,6 +48,7 @@ export default {
     TmPage,
     TmDataMsg,
     EventList,
+    TmDataLoading,
   },
   data: () => ({
     notifications: [],

--- a/app/src/components/staking/PageValidators.vue
+++ b/app/src/components/staking/PageValidators.vue
@@ -242,7 +242,6 @@ export default {
 .show-mobile-sorting {
   display: none;
   cursor: pointer;
-  display: none;
 }
 
 .show-mobile-sorting.active {

--- a/app/tests/unit/specs/components/common/__snapshots__/TmBalance.spec.js.snap
+++ b/app/tests/unit/specs/components/common/__snapshots__/TmBalance.spec.js.snap
@@ -156,13 +156,7 @@ exports[`TmBalance do not show available atoms when the user has none in the fir
             
           </span>
            
-          <span
-            class="fiat"
-          >
-            
-              0
-              USD
-          </span>
+          <!---->
         </div>
       </div>
        


### PR DESCRIPTION
Closes #ISSUE

**Description:**

<!-- Briefly describe what you're adding or fixing with this PR -->

Adds TmDataLoading to PageNotifications as well as a spinner for the dynamic load from subscribeToMore.

<img width="740px" src="https://user-images.githubusercontent.com/40721795/85804544-3867a180-b74a-11ea-855d-d5944cba53f6.png">


Also fixes my mistake in #4361 of deleting an important second option in `fiatvalues-api.js`, and adds a better solution v-ifing 0 fiatValues in `TmBalance`

Thank you! 🚀

---

For contributor:

- [ ] Added changes entries. Run `yarn changelog` for a guided process.
- [ ] Reviewed `Files changed` in the github PR explorer
- [ ] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI
