### PR TITLE
Ana/4422 fix validators activeOnly filter

### DIFF
--- a/app/changes/ana_4422-fix-polkadot-validators-filters
+++ b/app/changes/ana_4422-fix-polkadot-validators-filters
@@ -1,0 +1,1 @@
+[Fixed] [#4422](https://github.com/cosmos/lunie/issues/4422) Fix missing active validators in Westend when filtering for "Active" @Bitcoinera

--- a/app/src/components/staking/PageValidators.vue
+++ b/app/src/components/staking/PageValidators.vue
@@ -160,9 +160,7 @@ export default {
         this.loaded = true
         /* istanbul ignore next */
         return this.activeOnly
-          ? result.validators.filter(
-              ({ status }) => status === `ACTIVE`
-            )
+          ? result.validators.filter(({ status }) => status === `ACTIVE`)
           : result.validators
       },
     },

--- a/app/src/components/staking/PageValidators.vue
+++ b/app/src/components/staking/PageValidators.vue
@@ -161,7 +161,7 @@ export default {
         /* istanbul ignore next */
         return this.activeOnly
           ? result.validators.filter(
-              ({ name, operatorAddress }) => name !== operatorAddress
+              ({ status }) => status === `ACTIVE`
             )
           : result.validators
       },


### PR DESCRIPTION
Closes #4422 

**Description:**

<!-- Briefly describe what you're adding or fixing with this PR -->

The `activeOnly` filter was filtering in a very strange way. I also looked into the missing inactive validators and turns out there are none in Westend (checked both in polkadot.js and subscan)

Thank you! 🚀

---

For contributor:

- [ ] Added changes entries. Run `yarn changelog` for a guided process.
- [ ] Reviewed `Files changed` in the github PR explorer
- [ ] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI
