### PR TITLE
Ana/fix polkadot expected rewards are NaN

### DIFF
--- a/api/lib/database/methods.js
+++ b/api/lib/database/methods.js
@@ -125,6 +125,7 @@ const getNetworks = ({ hasura_url, hasura_admin_key }) => () => async () => {
         slug
         lockUpPeriod
         powered
+        erasPerDay
       }
       networksCapabilities: networksCapabilities {
         id

--- a/app/changes/ana_4426-fix-polkadot-expected-rewards-are-NaN
+++ b/app/changes/ana_4426-fix-polkadot-expected-rewards-are-NaN
@@ -1,0 +1,1 @@
+[Fixed] [#4426](https://github.com/cosmos/lunie/issues/4426) Fix Polkadot expectedRewards being shown as NaN @Bitcoinera


### PR DESCRIPTION
Closes #4426
**Description:**

<!-- Briefly describe what you're adding or fixing with this PR -->

I also added the new field to the production DB. Is there any way we could automate changes in staging DB being reflected in production? That would be amazing

Thank you! 🚀

---

For contributor:

- [ ] Added changes entries. Run `yarn changelog` for a guided process.
- [ ] Reviewed `Files changed` in the github PR explorer
- [ ] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI
