### PR TITLE
Ana/fix networks ordering using default

### DIFF
--- a/app/changes/ana_fix-network-ordering-using-default
+++ b/app/changes/ana_fix-network-ordering-using-default
@@ -1,0 +1,1 @@
+[Fixed] [#4428](https://github.com/cosmos/lunie/pull/4428) Fix the network ordering by using the default field @Bitcoinera

--- a/app/src/components/common/NetworkSelector.vue
+++ b/app/src/components/common/NetworkSelector.vue
@@ -34,7 +34,9 @@ export default {
     ...mapGetters([`networks`]),
     ...mapGetters({ networkId: `network` }),
     mainnets() {
-      return this.networks.filter((network) => network.testnet === false)
+      return this.networks
+        .filter((network) => network.testnet === false)
+        .sort((a, b) => b.default - a.default)
     },
   },
 }

--- a/app/src/components/network/PageNetworks.vue
+++ b/app/src/components/network/PageNetworks.vue
@@ -37,7 +37,9 @@ export default {
   computed: {
     ...mapGetters([`networks`]),
     mainNetworks() {
-      return this.networks.filter((network) => !network.testnet)
+      return this.networks
+        .filter((network) => !network.testnet)
+        .sort((a, b) => b.default - a.default)
     },
     testNetworks() {
       return this.networks.filter((network) => network.testnet)


### PR DESCRIPTION
Closes #ISSUE

**Description:**

<!-- Briefly describe what you're adding or fixing with this PR -->

It seems the ordering before had nothing to do with the `default` field (this, in fact, was not being used at all, as it seems) but with the ordering in the `networks.js` file.

Fixed here simply using the sort method.

Thank you! 🚀

---

For contributor:

- [ ] Added changes entries. Run `yarn changelog` for a guided process.
- [ ] Reviewed `Files changed` in the github PR explorer
- [ ] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI
