### PR TITLE
Ana/fix extension images paths

### DIFF
--- a/app/changes/ana_fix-extension-images-paths
+++ b/app/changes/ana_fix-extension-images-paths
@@ -1,0 +1,1 @@
+[Changed] [#4466](https://github.com/cosmos/lunie/pull/4466) Adapt AccountMenu styles to extension @Bitcoinera

--- a/app/src/components/account/AccountList.vue
+++ b/app/src/components/account/AccountList.vue
@@ -95,7 +95,7 @@ export default {
 }
 
 .account.open {
-  transform: translate(-3rem);
+  transform: translate(-4rem);
 }
 
 .account h3 {

--- a/app/src/components/account/AccountMenu.vue
+++ b/app/src/components/account/AccountMenu.vue
@@ -6,7 +6,7 @@
           class="account-menu-button account-menu-show-seed"
           :to="{ name: 'reveal', params: { address } }"
         >
-          <i class="material-icons notranslate">visibility</i>
+          <i class="material-icons notranslate show-seed">visibility</i>
         </router-link>
         <span class="account-menu-button-span">Show Seed</span>
       </div>

--- a/app/src/components/common/SessionFrame.vue
+++ b/app/src/components/common/SessionFrame.vue
@@ -9,7 +9,10 @@
     >
       <div class="session-outer-container">
         <div
-          v-if="(icon.startsWith(`/img`) || icon.startsWith(`https`)) && !isExtension"
+          v-if="
+            (icon.startsWith(`/img`) || icon.startsWith(`https`)) &&
+            !isExtension
+          "
           class="icon-circle"
         >
           <img class="icon-image" :src="icon" />

--- a/app/src/components/common/SessionFrame.vue
+++ b/app/src/components/common/SessionFrame.vue
@@ -9,17 +9,17 @@
     >
       <div class="session-outer-container">
         <div
-          v-if="icon.startsWith(`/img`) || icon.startsWith(`https`)"
+          v-if="(icon.startsWith(`/img`) || icon.startsWith(`https`)) && !isExtension"
           class="icon-circle"
         >
           <img class="icon-image" :src="icon" />
         </div>
         <i
-          v-else-if="icon.length > 0"
+          v-else-if="icon.length > 0 && !isExtension"
           class="material-icons notranslate circle modal-icon"
           >{{ icon }}</i
         >
-        <div class="session">
+        <div class="session" :class="{ evenly: !isExtension }">
           <div class="session-header">
             <a v-if="!hideBack" @click="goBack">
               <i class="material-icons notranslate circle back">arrow_back</i>
@@ -111,5 +111,9 @@ export default {
   transform: scaleX(-1);
   filter: invert(85%) sepia(9%) saturate(18%) hue-rotate(6deg) brightness(85%)
     contrast(87%); /* converts to same than var(--dim) */
+}
+
+.evenly {
+  justify-content: space-evenly;
 }
 </style>

--- a/app/src/gql/apollo.js
+++ b/app/src/gql/apollo.js
@@ -115,7 +115,7 @@ const createApolloClient = async () => {
 
   const cache = new InMemoryCache({
     fragmentMatcher,
-    dataIdFromObject: object => defaultDataIdFromObject(object),
+    dataIdFromObject: (object) => defaultDataIdFromObject(object),
   })
 
   // await before instantiating ApolloClient, else queries might run before the cache is persisted

--- a/app/src/styles/session.css
+++ b/app/src/styles/session.css
@@ -143,6 +143,10 @@
   color: var(--txt);
 }
 
+.session .material-icons.show-seed {
+  color: inherit;
+}
+
 .material-icons.circle.modal-icon {
   background: var(--app-fg);
   color: var(--dim);

--- a/app/src/styles/session.css
+++ b/app/src/styles/session.css
@@ -30,7 +30,6 @@
 .session {
   display: flex;
   flex-direction: column;
-  justify-content: space-evenly;
   background: var(--app-bg);
   max-width: 560px;
   border-radius: 2px;

--- a/app/tests/unit/specs/components/account/__snapshots__/AccountMenu.spec.js.snap
+++ b/app/tests/unit/specs/components/account/__snapshots__/AccountMenu.spec.js.snap
@@ -15,7 +15,7 @@ exports[`AccountMenu should show the AccountMenu page 1`] = `
         to="[object Object]"
       >
         <i
-          class="material-icons notranslate"
+          class="material-icons notranslate show-seed"
         >
           visibility
         </i>

--- a/app/tests/unit/specs/components/common/__snapshots__/SessionFrame.spec.js.snap
+++ b/app/tests/unit/specs/components/common/__snapshots__/SessionFrame.spec.js.snap
@@ -13,7 +13,7 @@ exports[`SessionFrame shows an overview of all wallets to sign in with from the 
     <!---->
      
     <div
-      class="session"
+      class="session evenly"
     >
       <div
         class="session-header"

--- a/app/tests/unit/specs/components/common/__snapshots__/TmSessionHardware.spec.js.snap
+++ b/app/tests/unit/specs/components/common/__snapshots__/TmSessionHardware.spec.js.snap
@@ -3,7 +3,7 @@
 exports[`TmSessionHardware should show a state indicator for different states of the hardware connection 1`] = `
 <div tabindex="0" class="session-frame" name="component-fade" mode="out-in">
   <div class="session-outer-container"><i class="material-icons notranslate circle modal-icon">vpn_key</i>
-    <div class="session">
+    <div class="session evenly">
       <div class="session-header"><a><i class="material-icons notranslate circle back">arrow_back</i></a>
         <div class="session-close"><a><i class="material-icons notranslate circle back">close</i></a></div>
       </div>
@@ -34,7 +34,7 @@ exports[`TmSessionHardware should show a state indicator for different states of
 exports[`TmSessionHardware should show a state indicator for different states of the hardware connection 2`] = `
 <div tabindex="0" class="session-frame" name="component-fade" mode="out-in">
   <div class="session-outer-container"><i class="material-icons notranslate circle modal-icon">vpn_key</i>
-    <div class="session">
+    <div class="session evenly">
       <div class="session-header"><a><i class="material-icons notranslate circle back">arrow_back</i></a>
         <div class="session-close"><a><i class="material-icons notranslate circle back">close</i></a></div>
       </div>
@@ -64,7 +64,7 @@ exports[`TmSessionHardware should show a state indicator for different states of
 exports[`TmSessionHardware should show a state indicator for different states of the hardware connection 3`] = `
 <div tabindex="0" class="session-frame" name="component-fade" mode="out-in">
   <div class="session-outer-container"><i class="material-icons notranslate circle modal-icon">vpn_key</i>
-    <div class="session">
+    <div class="session evenly">
       <div class="session-header"><a><i class="material-icons notranslate circle back">arrow_back</i></a>
         <div class="session-close"><a><i class="material-icons notranslate circle back">close</i></a></div>
       </div>
@@ -104,7 +104,7 @@ exports[`TmSessionHardware shows the ledger conection view when there're errors 
     </i>
      
     <div
-      class="session"
+      class="session evenly"
     >
       <div
         class="session-header"
@@ -200,7 +200,7 @@ exports[`TmSessionHardware shows the ledger conection view with no errors 1`] = 
     </i>
      
     <div
-      class="session"
+      class="session evenly"
     >
       <div
         class="session-header"
@@ -276,7 +276,7 @@ exports[`TmSessionHardware shows the ledger conection view with no errors 1`] = 
 exports[`TmSessionHardware sign in does show the instructions to enable HID on Windows 1`] = `
 <div tabindex="0" class="session-frame" name="component-fade" mode="out-in">
   <div class="session-outer-container"><i class="material-icons notranslate circle modal-icon">vpn_key</i>
-    <div class="session">
+    <div class="session evenly">
       <div class="session-header"><a><i class="material-icons notranslate circle back">arrow_back</i></a>
         <div class="session-close"><a><i class="material-icons notranslate circle back">close</i></a></div>
       </div>
@@ -305,7 +305,7 @@ exports[`TmSessionHardware sign in does show the instructions to enable HID on W
 exports[`TmSessionHardware sign in does show the instructions to fix connection issues for Linux users 1`] = `
 <div tabindex="0" class="session-frame" name="component-fade" mode="out-in">
   <div class="session-outer-container"><i class="material-icons notranslate circle modal-icon">vpn_key</i>
-    <div class="session">
+    <div class="session evenly">
       <div class="session-header"><a><i class="material-icons notranslate circle back">arrow_back</i></a>
         <div class="session-close"><a><i class="material-icons notranslate circle back">close</i></a></div>
       </div>

--- a/extension/changes/ana_fix-extension-images-paths
+++ b/extension/changes/ana_fix-extension-images-paths
@@ -1,0 +1,1 @@
+[Fixed] [#4466](https://github.com/cosmos/lunie/pull/4466) Fix extension images paths @Bitcoinera

--- a/extension/webpack.config.js
+++ b/extension/webpack.config.js
@@ -40,8 +40,7 @@ const config = {
       src: resolve('../app/src'),
       lunie: resolve('../app'),
       app: resolve('../app'),
-      scripts: resolve('../app/src/scripts'),
-      images: resolve('./images/')
+      scripts: resolve('../app/src/scripts')
     },
     extensions: ['.js', '.vue', '.css']
   },

--- a/extension/webpack.config.js
+++ b/extension/webpack.config.js
@@ -29,6 +29,7 @@ const config = {
   resolve: {
     alias: {
       assets: resolve('../app/src/assets'),
+      '~assets': resolve('../app/src/assets'),
       'common/Avatar': resolve('./src/components/BlankAvatar'),
       common: resolve('../app/src/components/common'),
       account: resolve('../app/src/components/account'),
@@ -39,7 +40,8 @@ const config = {
       src: resolve('../app/src'),
       lunie: resolve('../app'),
       app: resolve('../app'),
-      scripts: resolve('../app/src/scripts')
+      scripts: resolve('../app/src/scripts'),
+      images: resolve('./images/')
     },
     extensions: ['.js', '.vue', '.css']
   },
@@ -72,10 +74,14 @@ const config = {
       },
       {
         test: /\.(png|jpg|gif|svg|ico)$/,
-        loader: 'file-loader',
-        query: {
-          name: `images/[name].[ext]`
-        }
+        use: [
+          {
+            loader: 'file-loader',
+            options: {
+              esModule: false,
+            },
+          }
+        ]
       },
       {
         test: /\.(woff2?|eot|ttf|otf)(\?.*)?$/,


### PR DESCRIPTION
Closes #ISSUE

**Description:**

<!-- Briefly describe what you're adding or fixing with this PR -->

Fixes this (header image and Show Seed eye):

![image](https://user-images.githubusercontent.com/40721795/86911505-bc8f3100-c11b-11ea-9cec-e43081f922e9.png)


Also the spinning circle while importing an account.

Looking into fixing the import of the @polkadot/api module as well (right now it seems impossible to import a Substrate account)


Thank you! 🚀

---

For contributor:

- [ ] Added changes entries. Run `yarn changelog` for a guided process.
- [ ] Reviewed `Files changed` in the github PR explorer
- [ ] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI
