### PR TITLE
Ana/try fix extension deploy flow

### DIFF
--- a/.github/workflows/extension_publish.yml
+++ b/.github/workflows/extension_publish.yml
@@ -25,7 +25,7 @@ jobs:
         run: yarn build-zip
         working-directory: ${{env.WORKING_DIRECTORY}}
       - name: Deploy
-        run: sh ./scripts/deploy.sh ./dist-zip/lunie-browser-extension.zip
+        run: sh ./extension/scripts/deploy.sh ./extension/dist-zip/extension.zip
         working-directory: ${{env.WORKING_DIRECTORY}}
         env:
           GAPI_CLIENT_ID: ${{ secrets.GAPI_CLIENT_ID }}

--- a/.github/workflows/extension_publish.yml
+++ b/.github/workflows/extension_publish.yml
@@ -25,7 +25,7 @@ jobs:
         run: yarn build-zip
         working-directory: ${{env.WORKING_DIRECTORY}}
       - name: Deploy
-        run: sh ./extension/scripts/deploy.sh ./extension/dist-zip/extension.zip
+        run: sh ./scripts/deploy.sh ./dist-zip/extension.zip
         working-directory: ${{env.WORKING_DIRECTORY}}
         env:
           GAPI_CLIENT_ID: ${{ secrets.GAPI_CLIENT_ID }}

--- a/extension/changes/ana_fix-extension-deploy-flow
+++ b/extension/changes/ana_fix-extension-deploy-flow
@@ -1,0 +1,1 @@
+[Fixed] [#4467](https://github.com/cosmos/lunie/pull/4467) Fix extension deploy flow @Bitcoinera


### PR DESCRIPTION
Closes #ISSUE

**Description:**

<!-- Briefly describe what you're adding or fixing with this PR -->

Extension deploy flow seems broken. Version in Chrome Webstore is still 1.0.21 (you can check [here](http://bit.ly/lunie-ext)), while we have released extension already once with an older versions (workflow file [here](https://github.com/luniehq/lunie/runs/832623408?check_suite_focus=true))

After checking the file, it seems it actually failed (`Deploy` step, this line: `curl: Can't open './dist-zip/lunie-browser-extension.zip'!`) but somehow it behaved as succesfull.

Hoping to fix it here

Thank you! 🚀

---

For contributor:

- [ ] Added changes entries. Run `yarn changelog` for a guided process.
- [ ] Reviewed `Files changed` in the github PR explorer
- [ ] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI
