### PR TITLE
Fabo/fix session having wrong network

### DIFF
--- a/app/changes/fabo_fix-session-having-wrong-network
+++ b/app/changes/fabo_fix-session-having-wrong-network
@@ -1,0 +1,1 @@
+[Fixed] Stored sessions had old network not the new one from the desired target network @faboweb

--- a/app/src/vuex/modules/account.js
+++ b/app/src/vuex/modules/account.js
@@ -1,4 +1,5 @@
 import getFirebase from "../../firebase.js"
+import config from "../../../config"
 import * as Sentry from "@sentry/browser"
 import gql from "graphql-tag"
 

--- a/app/src/vuex/modules/session.js
+++ b/app/src/vuex/modules/session.js
@@ -150,7 +150,7 @@ export default ({ apollo }) => {
       dispatch(`persistSession`, {
         address,
         sessionType,
-        networkId: currentNetwork.id,
+        networkId,
       })
       const addresses = state.addresses
       dispatch(`persistAddresses`, {

--- a/app/tests/unit/specs/store/session.spec.js
+++ b/app/tests/unit/specs/store/session.spec.js
@@ -281,7 +281,7 @@ describe(`Module: Session`, () => {
           commit,
           dispatch,
         },
-        { sessionType: `explore`, address, networkId: "fabo-net" }
+        { sessionType: `explore`, address, networkId: "happy-net" }
       )
       expect(dispatch).toHaveBeenCalledWith(`persistAddresses`, {
         addresses: [
@@ -298,12 +298,12 @@ describe(`Module: Session`, () => {
       expect(dispatch).toHaveBeenCalledWith(`persistSession`, {
         address: `cosmos1z8mzakma7vnaajysmtkwt4wgjqr2m84tzvyfkz`,
         sessionType: `explore`,
-        networkId: "fabo-net",
+        networkId: "happy-net",
       })
       expect(dispatch).toHaveBeenCalledWith(`rememberAddress`, {
         address: `cosmos1z8mzakma7vnaajysmtkwt4wgjqr2m84tzvyfkz`,
         sessionType: `explore`,
-        networkId: "fabo-net",
+        networkId: `happy-net`
       })
     })
 
@@ -535,12 +535,13 @@ describe(`Module: Session`, () => {
         {
           address: `cosmos15ky9du8a2wlstz6fpx3p4mqpjyrm5ctpesxxn9`,
           sessionType: `local`,
+          networkId: `happy-net`
         }
       )
       expect(dispatch).toHaveBeenCalledWith(`persistSession`, {
         address: `cosmos15ky9du8a2wlstz6fpx3p4mqpjyrm5ctpesxxn9`,
         sessionType: `local`,
-        networkId: "fabo-net",
+        networkId: `happy-net`
       })
 
       dispatch.mockClear()
@@ -559,12 +560,13 @@ describe(`Module: Session`, () => {
         {
           address: `cosmos15ky9du8a2wlstz6fpx3p4mqpjyrm5ctpesxxn9`,
           sessionType: `ledger`,
+          networkId: `happy-net`
         }
       )
       expect(dispatch).toHaveBeenCalledWith(`persistSession`, {
         address: `cosmos15ky9du8a2wlstz6fpx3p4mqpjyrm5ctpesxxn9`,
         sessionType: `ledger`,
-        networkId: "fabo-net",
+        networkId: `happy-net`
       })
     })
 


### PR DESCRIPTION
Closes https://github.com/luniehq/lunie/issues/4435

Session had a wrong network id s the current not the target network was used