### PR TITLE
Ana/fix statistics amount to numeric

### DIFF
--- a/api/changes/ana_fix-statistics-amount-to-numeric
+++ b/api/changes/ana_fix-statistics-amount-to-numeric
@@ -1,0 +1,1 @@
+[Fixed] [#4556](https://github.com/cosmos/lunie/pull/4556) Fix storing statistics due to invalid numeric type for amount @Bitcoinera

--- a/api/lib/controller/transaction/index.js
+++ b/api/lib/controller/transaction/index.js
@@ -57,9 +57,9 @@ async function broadcastWithPolkadot(tx, fingerprint, development) {
   const hash = result.toJSON()
   tx.hash = hash
   // store tx in db
-  // if (!development) {
-  storeTransactions([tx], tx.networkId, tx.senderAddress, fingerprint)
-  // }
+  if (!development) {
+    storeTransactions([tx], tx.networkId, tx.senderAddress, fingerprint)
+  }
   return {
     hash,
     success: true

--- a/api/lib/statistics.js
+++ b/api/lib/statistics.js
@@ -38,7 +38,7 @@ const storeTransactions = (
     amounts.forEach(({ amount, denom }) => {
       store({
         ...baseRow,
-        value: amount,
+        value: Number(amount),
         denom
       })
     })


### PR DESCRIPTION
Closes #ISSUE

**Description:**

<!-- Briefly describe what you're adding or fixing with this PR -->

Fixes this:

```
invalid input syntax for type numeric: ""0.01""
```

The problem were amounts were Bignumbers instead of plain numeric, that is why the parsing was failing here.

Fixed by converting Bignumber to Number

Thank you! 🚀

---

For contributor:

- [ ] Added changes entries. Run `yarn changelog` for a guided process.
- [ ] Reviewed `Files changed` in the github PR explorer
- [ ] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI
