### PR TITLE
Ana/fix session frame close

### DIFF
--- a/app/changes/ana_fix-session-frame-close
+++ b/app/changes/ana_fix-session-frame-close
@@ -1,0 +1,1 @@
+[Changed] [#4562](https://github.com/cosmos/lunie/pull/4562) Change close action in SessionFrame to make sense @Bitcoinera

--- a/app/src/App.vue
+++ b/app/src/App.vue
@@ -45,7 +45,9 @@ export default {
       return this.session.mobile
     },
     themeClass() {
-      return !this.$route.meta.networkSpecificRoute ? `lunie-light` : this.network
+      return !this.$route.meta.networkSpecificRoute
+        ? `lunie-light`
+        : this.network
     },
   },
   store,

--- a/app/src/components/common/AppHeader.vue
+++ b/app/src/components/common/AppHeader.vue
@@ -92,10 +92,7 @@ export default {
       return this.session.developmentMode
     },
     hideSidebarMenu() {
-      return (
-        !this.$route.meta.networkSpecificRoute &&
-        this.desktop
-      )
+      return !this.$route.meta.networkSpecificRoute && this.desktop
     },
   },
   mounted: async function () {

--- a/app/src/components/common/SessionFrame.vue
+++ b/app/src/components/common/SessionFrame.vue
@@ -86,12 +86,12 @@ export default {
         // if user is signed in with address
         if (this.session.address) {
           this.$router.push({
-            name: `portfolio`
+            name: `portfolio`,
           })
-        // if user is not signed in with address
+          // if user is not signed in with address
         } else {
           this.$router.push({
-            name: `validators`
+            name: `validators`,
           })
         }
       }

--- a/app/src/components/common/SessionFrame.vue
+++ b/app/src/components/common/SessionFrame.vue
@@ -42,7 +42,7 @@
 
 <script>
 import config from "src/../config"
-import { mapGetters } from "vuex"
+import { mapState, mapGetters } from "vuex"
 
 export default {
   name: `session-frame`,
@@ -61,6 +61,7 @@ export default {
     isExtension: config.isExtension,
   }),
   computed: {
+    ...mapState([`session`]),
     ...mapGetters([`networkSlug`]),
   },
   methods: {
@@ -82,7 +83,17 @@ export default {
           },
         })
       } else {
-        this.goBack()
+        // if user is signed in with address
+        if (this.session.address) {
+          this.$router.push({
+            name: `portfolio`
+          })
+        // if user is not signed in with address
+        } else {
+          this.$router.push({
+            name: `validators`
+          })
+        }
       }
     },
   },

--- a/app/src/routes.js
+++ b/app/src/routes.js
@@ -269,7 +269,7 @@ export default (store) => {
           name: `Proposals`,
           meta: {
             feature: "proposals",
-            networkSpecificRoute: true
+            networkSpecificRoute: true,
           },
           component: () => import(`./components/governance/PageProposals`),
         },
@@ -283,7 +283,7 @@ export default (store) => {
           name: `Proposal`,
           meta: {
             feature: "proposals",
-            networkSpecificRoute: true
+            networkSpecificRoute: true,
           },
           component: () => import(`./components/governance/PageProposal`),
           props: true,
@@ -298,7 +298,7 @@ export default (store) => {
           name: `Validators`,
           meta: {
             feature: "validators",
-            networkSpecificRoute: true
+            networkSpecificRoute: true,
           },
           component: () => import(`./components/staking/PageValidators`),
         },
@@ -312,7 +312,7 @@ export default (store) => {
           name: `validator`,
           meta: {
             feature: "validators",
-            networkSpecificRoute: true
+            networkSpecificRoute: true,
           },
           component: () => import(`./components/staking/PageValidator`),
         },
@@ -327,7 +327,7 @@ export default (store) => {
           meta: {
             requiresAuth: true,
             feature: "portfolio",
-            networkSpecificRoute: true
+            networkSpecificRoute: true,
           },
         },
         {
@@ -337,7 +337,7 @@ export default (store) => {
           meta: {
             requiresAuth: true,
             feature: "activity",
-            networkSpecificRoute: true
+            networkSpecificRoute: true,
           },
         },
         {
@@ -346,7 +346,7 @@ export default (store) => {
           component: () => import(`./components/network/PageBlock`),
           meta: {
             feature: "blocks",
-            networkSpecificRoute: true
+            networkSpecificRoute: true,
           },
         },
         { path: `*`, component: () => import(`./components/common/Page404`) },

--- a/app/src/styles/session.css
+++ b/app/src/styles/session.css
@@ -229,7 +229,7 @@
     width: 100%;
   }
 
-  .form-main>div {
+  .form-main > div {
     display: flex;
     flex-direction: column;
     align-items: space-between;

--- a/app/tests/e2e/signin.spec.js
+++ b/app/tests/e2e/signin.spec.js
@@ -80,8 +80,8 @@ async function openMenu(browser) {
 async function prepare(browser) {
   await browser.url(
     browser.launch_url +
-    browser.globals.slug +
-    "?insecure=true&experimental=true"
+      browser.globals.slug +
+      "?insecure=true&experimental=true"
   )
   browser.waitForElementVisible(`body`, 20000, true)
   browser.waitForElementVisible(`#app-content`, 20000, true)
@@ -114,8 +114,8 @@ async function prepare(browser) {
 
   await browser.url(
     browser.launch_url +
-    browser.globals.slug +
-    "?insecure=true&experimental=true"
+      browser.globals.slug +
+      "?insecure=true&experimental=true"
   )
 
   // check if we are already signed in

--- a/app/tests/unit/specs/components/common/AppHeader.spec.js
+++ b/app/tests/unit/specs/components/common/AppHeader.spec.js
@@ -31,7 +31,7 @@ describe(`AppHeader`, () => {
         $route: { meta: true },
       },
       methods: {
-        watchWindowSize: () => { }, // overwriting to not cause side effects when setting the data in tests
+        watchWindowSize: () => {}, // overwriting to not cause side effects when setting the data in tests
       },
       stubs: [`router-link`],
     })

--- a/app/tests/unit/specs/components/common/SessionFrame.spec.js
+++ b/app/tests/unit/specs/components/common/SessionFrame.spec.js
@@ -23,9 +23,9 @@ describe(`SessionFrame`, () => {
         },
         $route: {
           meta: {
-            requiresAuth: true
+            requiresAuth: true,
           },
-        }
+        },
       },
       stubs: [`router-link`],
     })


### PR DESCRIPTION
Closes #ISSUE

**Description:**

<!-- Briefly describe what you're adding or fixing with this PR -->

The close from SessionFrame was just returning to the previous modal, which is specially weird in the sign in flow (click 'close' from MagicLinkSent and you are taken to the previous, SignInModal, asking again for your email)

Thank you! 🚀

---

For contributor:

- [ ] Added changes entries. Run `yarn changelog` for a guided process.
- [ ] Reviewed `Files changed` in the github PR explorer
- [ ] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI
