### PR TITLE
Ana/navigate to network portfolio when selecting

### DIFF
--- a/app/changes/ana_fix-networks-page-navigation
+++ b/app/changes/ana_fix-networks-page-navigation
@@ -1,0 +1,1 @@
+[Changed] [#4570](https://github.com/cosmos/lunie/pull/4570) When selecting a network in PageNetworks user is taken to that network's porfolio @Bitcoinera

--- a/app/src/components/network/NetworkItem.vue
+++ b/app/src/components/network/NetworkItem.vue
@@ -38,7 +38,7 @@
 </template>
 
 <script>
-import { mapGetters } from "vuex"
+import { mapGetters, mapState } from "vuex"
 import PoweredBy from "./PoweredBy"
 
 export default {
@@ -57,6 +57,7 @@ export default {
     },
   },
   computed: {
+    ...mapState([`session`]),
     ...mapGetters([`network`]),
     isCurrentNetwork() {
       return this.networkItem.id === this.network
@@ -64,10 +65,23 @@ export default {
   },
   methods: {
     goToNetwork() {
-      this.$router.push({
-        name: "portfolio",
-        params: { networkId: this.networkItem.slug },
-      })
+      // search for an active session in the network we are switching to
+      if (
+        this.session.allSessionAddresses.find(
+          ({ networkId }) => networkId === this.networkItem.id
+        )
+      ) {
+        this.$router.push({
+          name: `portfolio`,
+          params: { networkId: this.networkItem.slug },
+        })
+        // if no active session found then take to the validators table
+      } else {
+        this.$router.push({
+          name: `validators`,
+          params: { networkId: this.networkItem.slug },
+        })
+      }
     },
   },
 }

--- a/app/src/components/network/NetworkItem.vue
+++ b/app/src/components/network/NetworkItem.vue
@@ -1,5 +1,9 @@
 <template>
-  <div class="network-item" :class="{ disabled: disabled }">
+  <div
+    class="network-item"
+    :class="{ disabled: disabled }"
+    @click="goToNetwork()"
+  >
     <div class="network-icon">
       <img
         :src="`${networkItem.icon}`"
@@ -56,6 +60,14 @@ export default {
     ...mapGetters([`network`]),
     isCurrentNetwork() {
       return this.networkItem.id === this.network
+    },
+  },
+  methods: {
+    goToNetwork() {
+      this.$router.push({
+        name: "portfolio",
+        params: { networkId: this.networkItem.slug },
+      })
     },
   },
 }


### PR DESCRIPTION
Closes #ISSUE

**Description:**

<!-- Briefly describe what you're adding or fixing with this PR -->

Fixes getting stuck in the NetworksPage, since there are no navigation elements there available. But getting NavigationDuplicated error for some reason. Tried debugging `setNetwork` but that doesn't seem to be the problem:

![image](https://user-images.githubusercontent.com/40721795/88274766-85547e80-ccdc-11ea-8a33-f4e301f79ab8.png)


Thank you! 🚀

---

For contributor:

- [ ] Added changes entries. Run `yarn changelog` for a guided process.
- [ ] Reviewed `Files changed` in the github PR explorer
- [ ] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI
