### PR TITLE
Ana/fix multi denom rewards not showing correctly

### DIFF
--- a/api/changes/ana_4590-multi-denom-rewards-not-showing-correctly
+++ b/api/changes/ana_4590-multi-denom-rewards-not-showing-correctly
@@ -1,0 +1,1 @@
+[Fixed] [#4592](https://github.com/cosmos/lunie/issues/4592) Fix multi denom rewards not displaying correctly by taking rewards into account when querying for balances @Bitcoinera

--- a/api/lib/source/cosmosV0-source.js
+++ b/api/lib/source/cosmosV0-source.js
@@ -356,10 +356,23 @@ class CosmosV0API extends RESTDataSource {
       this.getDelegationsForDelegatorAddress(address)
     ])
     const balances = balancesResponse || []
-    const coins = balances.map((coin) => {
+    let coins = balances.map((coin) => {
       const coinLookup = network.getCoinLookup(network, coin.denom)
       return this.reducers.coinReducer(coin, coinLookup)
     })
+    // also check if there are any balances as rewards
+    const rewards = await this.getRewards(address, fiatCurrency, network)
+    const rewardsBalances = rewards.reduce((coinsAggregator, reward) => {
+      if (!coins.find((coin) => coin.denom === reward.denom)) {
+        coinsAggregator.push({
+          amount: 0,
+          denom: reward.denom
+        })
+      }
+      return coinsAggregator
+    }, [])
+    // join regular balances and rewards balances
+    coins.push(...rewardsBalances)
     const hasStakingDenom = coins.find(
       ({ denom }) => denom === this.network.stakingDenom
     )
@@ -476,25 +489,22 @@ class CosmosV0API extends RESTDataSource {
     return expectedReturns
   }
 
-  async getRewards(delegatorAddress) {
+  async getRewards(delegatorAddress, fiatCurrency, network) {
     this.checkAddress(delegatorAddress)
-    const delegations = await this.getDelegationsForDelegatorAddress(
-      delegatorAddress
+    const result = await this.query(
+      `distribution/delegators/${delegatorAddress}/rewards`
     )
-    const rewards = await Promise.all(
-      delegations.map(async ({ validatorAddress, validator }) => ({
-        validator,
-        rewards:
-          (await this.query(
-            `distribution/delegators/${delegatorAddress}/rewards/${validatorAddress}`
-          )) || []
-      }))
+    const rewards = (result.rewards || []).filter(
+      ({ reward }) => reward && reward.length > 0
     )
-    return rewards
-      .filter(({ rewards }) => rewards.length > 0)
-      .map(({ rewards, validator }) =>
-        this.reducers.rewardReducer(rewards[0], validator)
-      )
+    return this.reducers.rewardReducer(
+      rewards,
+      this.store.validators,
+      fiatCurrency,
+      this.calculateFiatValue && this.calculateFiatValue.bind(this),
+      this.reducers,
+      network
+    )
   }
 
   async getAllDelegators() {

--- a/api/lib/source/cosmosV0-source.js
+++ b/api/lib/source/cosmosV0-source.js
@@ -356,7 +356,7 @@ class CosmosV0API extends RESTDataSource {
       this.getDelegationsForDelegatorAddress(address)
     ])
     const balances = balancesResponse || []
-    let coins = balances.map((coin) => {
+    const coins = balances.map((coin) => {
       const coinLookup = network.getCoinLookup(network, coin.denom)
       return this.reducers.coinReducer(coin, coinLookup)
     })


### PR DESCRIPTION
Closes #4590 

**Description:**

<!-- Briefly describe what you're adding or fixing with this PR -->

Fixed!

This is how balances for the terra1mpf4eflxsduv05kh29zkh8y6ch4kgee8h3sfr2 address looks like now:

![image](https://user-images.githubusercontent.com/40721795/88486967-c1f4d400-cf81-11ea-891b-64efcba24935.png)

Like @faboweb said, as easy as making `balancesV2` also take into account the empty balances that correspond to existing rewards :v:

Thank you! 🚀

---

For contributor:

- [ ] Added changes entries. Run `yarn changelog` for a guided process.
- [ ] Reviewed `Files changed` in the github PR explorer
- [ ] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI
