### PR TITLE
Fabo/update bonding role

### DIFF
--- a/app/changes/fabo_update-bonding-role
+++ b/app/changes/fabo_update-bonding-role
@@ -1,0 +1,1 @@
+[Changed] Update the account role after bonding @faboweb

--- a/app/src/ActionModal/components/DelegationModal.vue
+++ b/app/src/ActionModal/components/DelegationModal.vue
@@ -355,6 +355,7 @@ export default {
 
       // update registered topics for emails as the validator set changed
       this.$store.dispatch("updateEmailRegistrations")
+      this.$store.dispatch("checkAddressRole")
     },
   },
   validations() {

--- a/app/src/ActionModal/components/DelegationModal.vue
+++ b/app/src/ActionModal/components/DelegationModal.vue
@@ -355,7 +355,10 @@ export default {
 
       // update registered topics for emails as the validator set changed
       this.$store.dispatch("updateEmailRegistrations")
-      this.$store.dispatch("checkAddressRole")
+      // update the role of the user as it might change after bonding the first time
+      if (this.currentNetwork.network_type === "polkadot") {
+        this.$store.dispatch("checkAddressRole")
+      }
     },
   },
   validations() {

--- a/app/tests/unit/specs/components/ActionModal/components/DelegationModal.spec.js
+++ b/app/tests/unit/specs/components/ActionModal/components/DelegationModal.spec.js
@@ -227,6 +227,9 @@ describe(`DelegationModal`, () => {
         $store: {
           dispatch: jest.fn(),
         },
+        currentNetwork: {
+          network_type: "polkadot"
+        }
       }
       DelegationModal.methods.onSuccess.call(self)
       expect(self.$emit).toHaveBeenCalledWith(
@@ -241,6 +244,9 @@ describe(`DelegationModal`, () => {
         $store: {
           dispatch: jest.fn(),
         },
+        currentNetwork: {
+          network_type: "polkadot"
+        }
       }
       DelegationModal.methods.onSuccess.call(self)
       expect(self.$store.dispatch).toHaveBeenCalledWith(


### PR DESCRIPTION
The bonding role would not update after the user bonded so consecutive staketx (the bonding part) would fail in polkadot as they need to send `bondMore` instead of `bond` extrinsics.

TODO: need to check if the role actually updates immediately or only after the era/session changes