### PR TITLE
Jordan/after magic link

### DIFF
--- a/app/changes/jordan_after-magic-link
+++ b/app/changes/jordan_after-magic-link
@@ -1,0 +1,1 @@
+[Changed] after a user clicks the magic link they will now see a modal instead of a page - also updated the copy @jbibla

--- a/app/src/components/account/EmailAuthentication.vue
+++ b/app/src/components/account/EmailAuthentication.vue
@@ -1,26 +1,34 @@
 <template>
-  <TmPage data-title="email-authentication">
-    <div class="card">
-      <h1 v-if="account.userSignedIn" class="authentication-title">
-        You are now signed in! &#128640;
-      </h1>
-      <h1 v-else-if="account.signInError" class="authentication-title">
-        {{ account.signInError.message }} 🙀
-      </h1>
-      <h1 v-else class="authentication-title">
-        Good bye, see you soon! &#128075;
-      </h1>
+  <SessionFrame hide-back>
+    <h2 class="session-title">
+      Magic link success!
+    </h2>
+    <div class="session-main">
+      <p class="session-subtitle">
+        You're now signed in to Lunie with your email address. Head over to the
+        notifications page to see some of your recent events.
+      </p>
+      <TmBtn @click.native="goToNotifications" value="Let's Go!" centered />
     </div>
-  </TmPage>
+
+    <template v-if="account.signInError || account.signInEmailError">
+      <h2 class="session-title">Magic link error! 🙀</h2>
+      <div class="session-main">
+        <p class="session-subtitle">{{ account.signInError.message }}</p>
+      </div>
+    </template>
+  </SessionFrame>
 </template>
 
 <script>
-import TmPage from "common/TmPage"
+import SessionFrame from "common/SessionFrame"
+import TmBtn from "common/TmBtn"
 import { mapState } from "vuex"
 export default {
   name: `email-authentication`,
   components: {
-    TmPage,
+    SessionFrame,
+    TmBtn,
   },
   computed: {
     ...mapState([`account`]),
@@ -28,15 +36,11 @@ export default {
   mounted() {
     this.$store.dispatch(`signInUser`, window.location.href)
   },
+  methods: {
+    goToNotifications() {
+      this.$router.push({ name: "notifications" }).catch(err => {
+      })
+    }
+  }
 }
 </script>
-<style scoped>
-.card {
-  padding: 1rem 1.5rem;
-  margin: 1.5rem auto;
-}
-
-.authentication-title {
-  font-size: 2em;
-}
-</style>

--- a/app/src/components/common/SessionFrame.vue
+++ b/app/src/components/common/SessionFrame.vue
@@ -24,7 +24,7 @@
         >
         <div class="session">
           <div class="session-header">
-            <a v-if="!hideBack" @click="goBack">
+            <a :class="{ invisible: hideBack }" @click="goBack">
               <i class="material-icons notranslate circle back">arrow_back</i>
             </a>
             <div v-if="!isExtension" class="session-close">
@@ -102,6 +102,10 @@ export default {
 
 <style>
 @import "../../styles/session.css";
+
+.invisible {
+  visibility: hidden;
+}
 
 .component-fade-enter-active,
 .component-fade-leave-active {

--- a/app/src/components/common/TmBtn.vue
+++ b/app/src/components/common/TmBtn.vue
@@ -7,6 +7,7 @@
         small: size === `small`,
         active: type === `active`,
         sidebar: type === `sidebar`,
+        centered: centered,
         loading: loading,
       }
     "
@@ -59,6 +60,10 @@ export default {
       default: null,
     },
     loading: {
+      type: Boolean,
+      default: false,
+    },
+    centered: {
       type: Boolean,
       default: false,
     },
@@ -139,6 +144,11 @@ export default {
 
 .button.small:hover {
   background: var(--app-nav-hover);
+}
+
+.button.centered {
+  text-align: center;
+  margin: 0 auto;
 }
 
 @media screen and (max-width: 1023px) {

--- a/app/src/components/common/TmBtn.vue
+++ b/app/src/components/common/TmBtn.vue
@@ -147,7 +147,6 @@ export default {
 }
 
 .button.centered {
-  text-align: center;
   margin: 0 auto;
 }
 

--- a/app/src/vuex/modules/account.js
+++ b/app/src/vuex/modules/account.js
@@ -2,6 +2,7 @@ import getFirebase from "../../firebase.js"
 import * as Sentry from "@sentry/browser"
 import gql from "graphql-tag"
 import { Plugins } from "@capacitor/core"
+import config from "src/../config"
 const { App: CapacitorApp } = Plugins
 
 export default ({ apollo }) => {

--- a/app/tests/unit/specs/components/account/__snapshots__/EmailAuthentication.spec.js.snap
+++ b/app/tests/unit/specs/components/account/__snapshots__/EmailAuthentication.spec.js.snap
@@ -1,22 +1,37 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`EmailAuthentication should show the EmailAuthentication page 1`] = `
-<tmpage-stub
-  data-title="email-authentication"
-  emptysubtitle=""
-  emptytitle="No data"
-  loaderpath=""
+<sessionframe-stub
+  hideback="true"
+  icon=""
 >
-  <div
-    class="card"
+  <h2
+    class="session-title"
   >
-    <h1
-      class="authentication-title"
+    
+    Magic link success!
+  
+  </h2>
+   
+  <div
+    class="session-main"
+  >
+    <p
+      class="session-subtitle"
     >
       
-      You are now signed in! 🚀
+      You're now signed in to Lunie with your email address. Head over to the
+      notifications page to see some of your recent events.
     
-    </h1>
+    </p>
+     
+    <tmbtn-stub
+      centered="true"
+      customclass=""
+      value="Let's Go!"
+    />
   </div>
-</tmpage-stub>
+   
+  <!---->
+</sessionframe-stub>
 `;

--- a/app/tests/unit/specs/components/common/__snapshots__/SessionFrame.spec.js.snap
+++ b/app/tests/unit/specs/components/common/__snapshots__/SessionFrame.spec.js.snap
@@ -18,7 +18,9 @@ exports[`SessionFrame shows an overview of all wallets to sign in with from the 
       <div
         class="session-header"
       >
-        <a>
+        <a
+          class=""
+        >
           <i
             class="material-icons notranslate circle back"
           >

--- a/app/tests/unit/specs/components/common/__snapshots__/TmSessionHardware.spec.js.snap
+++ b/app/tests/unit/specs/components/common/__snapshots__/TmSessionHardware.spec.js.snap
@@ -4,7 +4,7 @@ exports[`TmSessionHardware should show a state indicator for different states of
 <div tabindex="0" class="session-frame" name="component-fade" mode="out-in">
   <div class="session-outer-container"><i class="material-icons notranslate circle modal-icon">vpn_key</i>
     <div class="session">
-      <div class="session-header"><a><i class="material-icons notranslate circle back">arrow_back</i></a>
+      <div class="session-header"><a class=""><i class="material-icons notranslate circle back">arrow_back</i></a>
         <div class="session-close"><a><i class="material-icons notranslate circle back">close</i></a></div>
       </div>
       <h2 class="session-title">
@@ -35,7 +35,7 @@ exports[`TmSessionHardware should show a state indicator for different states of
 <div tabindex="0" class="session-frame" name="component-fade" mode="out-in">
   <div class="session-outer-container"><i class="material-icons notranslate circle modal-icon">vpn_key</i>
     <div class="session">
-      <div class="session-header"><a><i class="material-icons notranslate circle back">arrow_back</i></a>
+      <div class="session-header"><a class=""><i class="material-icons notranslate circle back">arrow_back</i></a>
         <div class="session-close"><a><i class="material-icons notranslate circle back">close</i></a></div>
       </div>
       <h2 class="session-title">
@@ -65,7 +65,7 @@ exports[`TmSessionHardware should show a state indicator for different states of
 <div tabindex="0" class="session-frame" name="component-fade" mode="out-in">
   <div class="session-outer-container"><i class="material-icons notranslate circle modal-icon">vpn_key</i>
     <div class="session">
-      <div class="session-header"><a><i class="material-icons notranslate circle back">arrow_back</i></a>
+      <div class="session-header"><a class=""><i class="material-icons notranslate circle back">arrow_back</i></a>
         <div class="session-close"><a><i class="material-icons notranslate circle back">close</i></a></div>
       </div>
       <h2 class="session-title">
@@ -109,7 +109,9 @@ exports[`TmSessionHardware shows the ledger conection view when there're errors 
       <div
         class="session-header"
       >
-        <a>
+        <a
+          class=""
+        >
           <i
             class="material-icons notranslate circle back"
           >
@@ -205,7 +207,9 @@ exports[`TmSessionHardware shows the ledger conection view with no errors 1`] = 
       <div
         class="session-header"
       >
-        <a>
+        <a
+          class=""
+        >
           <i
             class="material-icons notranslate circle back"
           >
@@ -277,7 +281,7 @@ exports[`TmSessionHardware sign in does show the instructions to enable HID on W
 <div tabindex="0" class="session-frame" name="component-fade" mode="out-in">
   <div class="session-outer-container"><i class="material-icons notranslate circle modal-icon">vpn_key</i>
     <div class="session">
-      <div class="session-header"><a><i class="material-icons notranslate circle back">arrow_back</i></a>
+      <div class="session-header"><a class=""><i class="material-icons notranslate circle back">arrow_back</i></a>
         <div class="session-close"><a><i class="material-icons notranslate circle back">close</i></a></div>
       </div>
       <h2 class="session-title">
@@ -306,7 +310,7 @@ exports[`TmSessionHardware sign in does show the instructions to fix connection 
 <div tabindex="0" class="session-frame" name="component-fade" mode="out-in">
   <div class="session-outer-container"><i class="material-icons notranslate circle modal-icon">vpn_key</i>
     <div class="session">
-      <div class="session-header"><a><i class="material-icons notranslate circle back">arrow_back</i></a>
+      <div class="session-header"><a class=""><i class="material-icons notranslate circle back">arrow_back</i></a>
         <div class="session-close"><a><i class="material-icons notranslate circle back">close</i></a></div>
       </div>
       <h2 class="session-title">


### PR DESCRIPTION
Closes #4525

**Description:**
- email auth is now a modal with updated copy
- visibility hidden won't break styling for close button on modals
- added centered prop for buttons
- config needed to be imported in account.js

<img width="680" alt="Screen Shot 2020-07-28 at 10 47 57 PM" src="https://user-images.githubusercontent.com/6021933/88750859-6c0c6180-d124-11ea-9395-d1acdf44f0a7.png">


Thank you! 🚀

---

For contributor:

- [ ] Added changes entries. Run `yarn changelog` for a guided process.
- [ ] Reviewed `Files changed` in the github PR explorer
- [ ] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI
