### PR TITLE
Fabo/deploy master changes if there are any

### DIFF
--- a/.github/workflows/api_deploy_production.yml
+++ b/.github/workflows/api_deploy_production.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - 'master'
     paths:
-      - 'api/CHANGELOG.md'
+      - 'api/*'
 env:
   WORKING_DIRECTORY: ./api
   HASURA_URL: "https://production-db.lunie.io/v1/graphql"

--- a/.github/workflows/app_deploy.yml
+++ b/.github/workflows/app_deploy.yml
@@ -4,7 +4,7 @@ on:
     branches:
       - "master"
     paths:
-      - 'app/CHANGELOG.md'
+      - 'app/*'
 
 env:
   WORKING_DIRECTORY: ./app

--- a/.github/workflows/extension_publish.yml
+++ b/.github/workflows/extension_publish.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - "master"
     paths:
-      - 'extension/CHANGELOG.md'
+      - 'extension/*'
 env:
   WORKING_DIRECTORY: ./extension
 jobs:

--- a/.github/workflows/scriptRunner_deploy_production.yml
+++ b/.github/workflows/scriptRunner_deploy_production.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - 'master'
     paths:
-      - 'scriptRunner/CHANGELOG.md'
+      - 'scriptRunner/*'
 env:
   WORKING_DIRECTORY: ./scriptRunner
   HASURA_URL: "https://production-db.lunie.io/v1/graphql"


### PR DESCRIPTION
Instead of deploying only if changelog got edited, deploy always. This is needed to deploy hotfixes easier (without manually editing the changelog.md)