### PR TITLE
Ana/fix sending BNB transactions failing because of fees in Kava

### DIFF
--- a/api/changes/ana_4641-sending-bnb-failing-because-fees
+++ b/api/changes/ana_4641-sending-bnb-failing-because-fees
@@ -1,0 +1,1 @@
+[Fixed] [#4641](https://github.com/cosmos/lunie/issues/4641) Fix sending BNB transactions in Kava failing due to fees @Bitcoinera

--- a/api/data/network-fees.js
+++ b/api/data/network-fees.js
@@ -262,6 +262,11 @@ const maxDecimals = (value, decimals) => {
 }
 
 const getFeeDenomFromMessage = (message, network) => {
+  // kava is an exception within Tendermint networks and all fees must be paid in KAVA
+  if (network.id.includes(`kava`)) {
+    return `KAVA`
+  }
+
   // check if there is a fee field (polkadot)
   if (message.fee) {
     return message.fee.denom

--- a/api/data/network-fees.js
+++ b/api/data/network-fees.js
@@ -263,7 +263,7 @@ const maxDecimals = (value, decimals) => {
 
 const getFeeDenomFromMessage = (message, network) => {
   // kava is an exception within Tendermint networks and all fees must be paid in KAVA
-  if (network.id.includes(`kava`)) {
+  if (network.id === "kava-mainnet" || network.id === "kava-testnet") {
     return `KAVA`
   }
 


### PR DESCRIPTION
Closes #4641 

**Description:**

<!-- Briefly describe what you're adding or fixing with this PR -->
Simple fix. Hardcoding feeDenom as `KAVA` for the Kava network

Thank you! 🚀

---

For contributor:

- [ ] Added changes entries. Run `yarn changelog` for a guided process.
- [ ] Reviewed `Files changed` in the github PR explorer
- [ ] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI
