### PR TITLE
fix my mess with validator images in scriptRunner

### DIFF
--- a/scriptRunner/src/keybase.js
+++ b/scriptRunner/src/keybase.js
@@ -28,7 +28,7 @@ module.exports.getKeybaseImages = async () => {
             return {
               name,
               operator_address,
-              picture: result.list[0].keybase.picture_url.replace('http', 'https')
+              picture: result.list[0].keybase.picture_url.replace('http://', 'https://')
             }
           }
           return {

--- a/scriptRunner/src/twitterImages.js
+++ b/scriptRunner/src/twitterImages.js
@@ -34,7 +34,7 @@ module.exports.getTwitterImages = async () => {
           return {
             name,
             operator_address,
-            picture: result.profile_image_url.replace('http', 'https')
+            picture: result.profile_image_url.replace('http://', 'https://')
           }
         } else {
           console.log(JSON.stringify(result.errors, null, 2))


### PR DESCRIPTION
Closes #ISSUE

**Description:**

<!-- Briefly describe what you're adding or fixing with this PR -->

Doing `result.profile_image_url.replace('http', 'https')` was logically making the protocol be `httpss` and thus break the image link.

My bad :shrug: 

Thank you! 🚀

---

For contributor:

- [ ] Added changes entries. Run `yarn changelog` for a guided process.
- [ ] Reviewed `Files changed` in the github PR explorer
- [ ] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI
