### PR TITLE
Ana/use mobile codeblocks only for mobile

### DIFF
--- a/app/changes/ana_use-mobile-codeblocks-only-for-mobile
+++ b/app/changes/ana_use-mobile-codeblocks-only-for-mobile
@@ -1,0 +1,1 @@
+[Changed] [#4692](https://github.com/cosmos/lunie/pull/4692) Include the firebase mobile options in actionCodeSettings only when on mobile @Bitcoinera

--- a/app/src/vuex/modules/account.js
+++ b/app/src/vuex/modules/account.js
@@ -5,6 +5,19 @@ import { Plugins } from "@capacitor/core"
 import config from "src/../config"
 const { App: CapacitorApp } = Plugins
 
+const mobileCodeBlocks = config.mobileApp
+  ? {
+      android: {
+        packageName: `org.lunie.lunie`,
+        installApp: true,
+        minimumVersion: `1.0.221`, // the first version with deep linking enabled
+      },
+      iOS: {
+        bundleId: `org.lunie.lunie`,
+      },
+    }
+  : null
+
 export default ({ apollo }) => {
   const state = {
     userSignedIn: false,
@@ -109,14 +122,7 @@ export default ({ apollo }) => {
           ? `https://app.lunie.io/email-authentication`
           : `${window.location.protocol}//${window.location.host}/email-authentication`,
         handleCodeInApp: true,
-        android: {
-          packageName: `org.lunie.lunie`,
-          installApp: true,
-          minimumVersion: `1.0.221`, // the first version with deep linking enabled
-        },
-        iOS: {
-          bundleId: `org.lunie.lunie`,
-        },
+        ...mobileCodeBlocks,
       }
       try {
         await Auth.sendSignInLinkToEmail(user.email, actionCodeSettings)

--- a/app/src/vuex/modules/account.js
+++ b/app/src/vuex/modules/account.js
@@ -5,7 +5,7 @@ import { Plugins } from "@capacitor/core"
 import config from "src/../config"
 const { App: CapacitorApp } = Plugins
 
-const mobileCodeBlocks = config.mobileApp
+const firebaseMobileCodeBlocks = config.mobileApp
   ? {
       android: {
         packageName: `org.lunie.lunie`,
@@ -16,7 +16,7 @@ const mobileCodeBlocks = config.mobileApp
         bundleId: `org.lunie.lunie`,
       },
     }
-  : null
+  : {}
 
 export default ({ apollo }) => {
   const state = {
@@ -122,7 +122,7 @@ export default ({ apollo }) => {
           ? `https://app.lunie.io/email-authentication`
           : `${window.location.protocol}//${window.location.host}/email-authentication`,
         handleCodeInApp: true,
-        ...mobileCodeBlocks,
+        ...firebaseMobileCodeBlocks,
       }
       try {
         await Auth.sendSignInLinkToEmail(user.email, actionCodeSettings)


### PR DESCRIPTION
Closes #ISSUE

**Description:**

<!-- Briefly describe what you're adding or fixing with this PR -->

Only have the mobile code blocks in `actionCodeSettings` when we are on mobile 

Thank you! 🚀

---

For contributor:

- [ ] Added changes entries. Run `yarn changelog` for a guided process.
- [ ] Reviewed `Files changed` in the github PR explorer
- [ ] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI
