### PR TITLE
Jordan/notificationzzz

### DIFF
--- a/app/changes/jordan_notificationzzz
+++ b/app/changes/jordan_notificationzzz
@@ -1,0 +1,1 @@
+[Changed] adjusted session frame click handler @jbibla

--- a/app/src/components/account/Paywall.vue
+++ b/app/src/components/account/Paywall.vue
@@ -60,11 +60,10 @@
             <li class="table-cell check">Github Alerts</li>
           </ul>
         </div>
-        <div class="table-span" @click="handleIntercom()">
-          <span>
-            Have any ideas? Share them with us
-            <i class="material-icons notranslate">launch</i>
-          </span>
+        <div class="table-span">
+          <a @click="handleIntercom()">
+            Have any ideas? Share them with us!
+          </a>
         </div>
       </div>
     </div>

--- a/app/src/components/account/UserMenu.vue
+++ b/app/src/components/account/UserMenu.vue
@@ -1,6 +1,9 @@
 <template>
   <div class="user-menu">
-    <UserMenuAddress v-if="address" :address="address" />
+    <UserMenuAddress
+      v-if="address && $route.name !== `notifications`"
+      :address="address"
+    />
     <router-link
       v-tooltip="`Notifications`"
       :to="{ name: 'notifications' }"

--- a/app/src/components/common/SessionFrame.vue
+++ b/app/src/components/common/SessionFrame.vue
@@ -5,7 +5,6 @@
       class="session-frame"
       tabindex="0"
       @keyup.esc="closeModal()"
-      @click.self="closeModal()"
     >
       <div class="session-outer-container">
         <div

--- a/app/src/components/notifications/PageNotifications.vue
+++ b/app/src/components/notifications/PageNotifications.vue
@@ -199,6 +199,7 @@ export default {
 .notifications-container {
   padding: 0 2rem 2rem;
   max-width: 900px;
+  width: 100%;
   margin: 0 auto;
 }
 

--- a/app/src/components/notifications/PageNotifications.vue
+++ b/app/src/components/notifications/PageNotifications.vue
@@ -1,7 +1,9 @@
 <template>
   <div class="notifications-container">
-    <h2>Notifications</h2>
-
+    <div class="notifications-header">
+      <h2>Notifications</h2>
+      <a @click="$store.dispatch(`displayMessenger`)">Questions or feedback?</a>
+    </div>
     <TmPage
       data-title="My alerts"
       :loading="$apollo.queries.notifications.loading && !firstLoaded"
@@ -203,6 +205,12 @@ export default {
   margin: 0 auto;
 }
 
+.notifications-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
 h2 {
   font-size: 36px;
   font-weight: 400;
@@ -241,5 +249,22 @@ img {
 .title {
   font-weight: 400;
   overflow-wrap: anywhere; /** Important. Otherwise awful style bug */
+}
+
+.end {
+  color: var(--txt);
+  text-align: center;
+  padding: 4rem 0 2rem;
+}
+
+@media screen and (max-width: 667px) {
+  .notifications-container {
+    padding: 0 1rem;
+  }
+
+  .notifications-header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
 }
 </style>

--- a/app/src/components/wallet/PageTransactions.vue
+++ b/app/src/components/wallet/PageTransactions.vue
@@ -193,9 +193,6 @@ export default {
         })
       }
     },
-    handleIntercom() {
-      this.$store.dispatch(`displayMessenger`)
-    },
   },
   apollo: {
     transactions: {

--- a/app/tests/unit/specs/components/account/__snapshots__/Paywall.spec.js.snap
+++ b/app/tests/unit/specs/components/account/__snapshots__/Paywall.spec.js.snap
@@ -170,16 +170,11 @@ exports[`Paywall should show the Paywall page 1`] = `
       <div
         class="table-span"
       >
-        <span>
+        <a>
           
-          Have any ideas? Share them with us
-          
-          <i
-            class="material-icons notranslate"
-          >
-            launch
-          </i>
-        </span>
+          Have any ideas? Share them with us!
+        
+        </a>
       </div>
     </div>
   </div>

--- a/app/tests/unit/specs/components/wallet/PageTransactions.spec.js
+++ b/app/tests/unit/specs/components/wallet/PageTransactions.spec.js
@@ -3,7 +3,7 @@ import { createLocalVue, shallowMount } from "@vue/test-utils"
 
 describe(`PageTransactions`, () => {
   const localVue = createLocalVue()
-  localVue.directive(`tooltip`, () => {})
+  localVue.directive(`tooltip`, () => { })
 
   const addresses = [
     `cosmos15ky9du8a2wlstz6fpx3p4mqpjyrm5ctpesxxn9`,
@@ -147,7 +147,7 @@ describe(`PageTransactions`, () => {
           $apollo,
         },
         directives: {
-          infiniteScroll: () => {},
+          infiniteScroll: () => { },
         },
       })
       wrapper.setProps({ transactions, validators })
@@ -166,7 +166,7 @@ describe(`PageTransactions`, () => {
         $apollo,
       },
       directives: {
-        infiniteScroll: () => {},
+        infiniteScroll: () => { },
       },
     })
     $store.state.session.signedIn = true
@@ -250,7 +250,7 @@ describe(`PageTransactions`, () => {
         $apollo,
       },
       directives: {
-        infiniteScroll: () => {},
+        infiniteScroll: () => { },
       },
     })
     wrapper.setData({
@@ -269,7 +269,7 @@ describe(`PageTransactions`, () => {
         $apollo,
       },
       directives: {
-        infiniteScroll: () => {},
+        infiniteScroll: () => { },
       },
     })
     wrapper.setData({ validators })
@@ -278,15 +278,5 @@ describe(`PageTransactions`, () => {
       "cosmos1b",
       "cosmos1c",
     ])
-  })
-
-  it(`should trigger intercom opening`, () => {
-    const self = {
-      $store: {
-        dispatch: jest.fn(),
-      },
-    }
-    PageTransactions.methods.handleIntercom.call(self)
-    expect(self.$store.dispatch).toHaveBeenCalledWith("displayMessenger")
   })
 })


### PR DESCRIPTION
- session frame click handler was too easy to set off by accident 
- the notifications page should always be 100% to avoid the title from moving
- paywall link was broken
- user menu addresses shouldn't display on notifications page
- add an intercom link on notifications page to encourage feedback