### PR TITLE
Ana/4822 negative staking balance in substrate

### DIFF
--- a/api/changes/ana_4822-negative-staking-balance-in-substrate
+++ b/api/changes/ana_4822-negative-staking-balance-in-substrate
@@ -1,0 +1,1 @@
+[Fixed] [#4822](https://github.com/cosmos/lunie/issues/4822) Fix negative staking balance in Substrate by filtering only active undelegations @Bitcoinera

--- a/api/lib/resolvers.js
+++ b/api/lib/resolvers.js
@@ -251,7 +251,10 @@ const resolvers = (networkList, notificationController) => ({
       let validators = Object.values(
         localStore(dataSources, networkId).validators
       )
-      return await remoteFetch(dataSources, networkId).getProposalById(id, validators)
+      return await remoteFetch(dataSources, networkId).getProposalById(
+        id,
+        validators
+      )
     },
     vote: (_, { networkId, proposalId, address }, { dataSources }) =>
       remoteFetch(dataSources, networkId).getDelegatorVote({


### PR DESCRIPTION
Closes #4822 

**Description:**

<!-- Briefly describe what you're adding or fixing with this PR -->

The problem we were counting past undelegations as active, and therefore substracting balance that was already among freeBalance

Thank you! 🚀

---

For contributor:

- [ ] Added changes entries. Run `yarn changelog` for a guided process.
- [ ] Reviewed `Files changed` in the github PR explorer
- [ ] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI
