### PR TITLE
disable vote button for treasury proposals

### DIFF
--- a/app/changes/ana_disable-vote-button-for-treasury-proposals
+++ b/app/changes/ana_disable-vote-button-for-treasury-proposals
@@ -1,0 +1,1 @@
+[Changed] [#4826](https://github.com/cosmos/lunie/pull/4826) Disable Vote button for treasury proposals @Bitcoinera

--- a/app/src/components/governance/PageProposal.vue
+++ b/app/src/components/governance/PageProposal.vue
@@ -44,7 +44,6 @@
               value="Vote"
               :disabled="
                 proposal.status !== 'VotingPeriod' ||
-                proposal.type === 'COUNCIL' ||
                 proposal.type === 'TREASURY'
               "
               color="primary"

--- a/app/src/components/governance/PageProposal.vue
+++ b/app/src/components/governance/PageProposal.vue
@@ -44,7 +44,8 @@
               value="Vote"
               :disabled="
                 proposal.status !== 'VotingPeriod' ||
-                proposal.type === 'COUNCIL'
+                proposal.type === 'COUNCIL' ||
+                proposal.type === 'TREASURY'
               "
               color="primary"
               @click.native="() => onVote()"


### PR DESCRIPTION
Closes #ISSUE

**Description:**

<!-- Briefly describe what you're adding or fixing with this PR -->

I guess first we need to make sure that only councellors can vote on Treasuries... Going to check asap on some tip proposal

EDIT: OK, confirmed, we need to disable `Vote` button for Treasury proposals, since they are actually motions:

![image](https://user-images.githubusercontent.com/40721795/92235318-c0d59180-eeb3-11ea-9466-250c99579ab1.png)


Thank you! 🚀

---

For contributor:

- [ ] Added changes entries. Run `yarn changelog` for a guided process.
- [ ] Reviewed `Files changed` in the github PR explorer
- [ ] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI
