### PR TITLE
redeploy scriptRunner when we redeploy API

### DIFF
--- a/.github/workflows/scriptRunner_deploy_development.yml
+++ b/.github/workflows/scriptRunner_deploy_development.yml
@@ -6,6 +6,7 @@ on:
       - 'develop'
     paths:
       - 'scriptRunner/**'
+      - 'api/**'
 env:
   WORKING_DIRECTORY: ./scriptRunner
 jobs:

--- a/.github/workflows/scriptRunner_deploy_production.yml
+++ b/.github/workflows/scriptRunner_deploy_production.yml
@@ -6,6 +6,7 @@ on:
       - 'master'
     paths:
       - 'scriptRunner/CHANGELOG.md'
+      - 'api/CHANGELOG.md'
 env:
   WORKING_DIRECTORY: ./scriptRunner
   HASURA_URL: "https://production-db.lunie.io/v1/graphql"


### PR DESCRIPTION
Closes #ISSUE

**Description:**

<!-- Briefly describe what you're adding or fixing with this PR -->

Apparently scriptRunner stopped working because it couldn't sync with the API after one of its last deployments.

This change in the workflow here is to make sure we redeploy scriptRunner also every time we deploy a new API.

We will check if it works the next time we merge something to develop for the `api` submodule (`scriptRunner_deploy_development`)

Thank you! 🚀

---

For contributor:

- [ ] Added changes entries. Run `yarn changelog` for a guided process.
- [ ] Reviewed `Files changed` in the github PR explorer
- [ ] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI
