### PR TITLE
Ana/fix url img import in extension webpack

### DIFF
--- a/app/changes/ana_fix-url-img-import-in-extension
+++ b/app/changes/ana_fix-url-img-import-in-extension
@@ -1,0 +1,1 @@
+[Fixed] [#4836](https://github.com/cosmos/lunie/issues/4836) Fix extension not building: can't resolve /img/tutorials/*** @Bitcoinera

--- a/app/src/components/common/ModalTutorial.vue
+++ b/app/src/components/common/ModalTutorial.vue
@@ -223,7 +223,7 @@ export default {
 
 .modal-tutorial .top-bg {
   margin-top: 0.6rem;
-  background-image: url("/img/tutorials/bg-red.png");
+  background-image: url("../../../public/img/tutorials/bg-red.png");
   background-size: cover;
   background-repeat: no-repeat;
   background-position: center center;
@@ -234,23 +234,23 @@ export default {
 }
 
 .modal-tutorial .top-bg.yellow {
-  background-image: url("/img/tutorials/bg-yellow.png");
+  background-image: url("../../../public/img/tutorials/bg-yellow.png");
 }
 
 .modal-tutorial .top-bg.green {
-  background-image: url("/img/tutorials/bg-green.png");
+  background-image: url("../../../public/img/tutorials/bg-green.png");
 }
 
 .modal-tutorial .top-bg.blue {
-  background-image: url("/img/tutorials/bg-blue.png");
+  background-image: url("../../../public/img/tutorials/bg-blue.png");
 }
 
 .modal-tutorial .top-bg.lightblue {
-  background-image: url("/img/tutorials/bg-lightblue.png");
+  background-image: url("../../../public/img/tutorials/bg-lightblue.png");
 }
 
 .modal-tutorial .top-bg.red {
-  background-image: url("/img/tutorials/bg-red.png");
+  background-image: url("../../../public/img/tutorials/bg-red.png");
 }
 
 .modal-tutorial .content {


### PR DESCRIPTION
Closes #ISSUE

**Description:**

<!-- Briefly describe what you're adding or fixing with this PR -->

I have been trying lots of other solutions like using the `url-loader` package, the `css-url-relative-plugin`, applying path to `         MiniCssExtractPlugin`, but so far only this simple solution has worked :shrug: Change the urls for images in `ModalTutorial` to be relative. So maybe better just stick with it


Thank you! 🚀

---

For contributor:

- [ ] Added changes entries. Run `yarn changelog` for a guided process.
- [ ] Reviewed `Files changed` in the github PR explorer
- [ ] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI
