### PR TITLE
Ana/fix voter cache all voters the same

### DIFF
--- a/api/changes/ana_cache-polkadot-identities-2.Versuch
+++ b/api/changes/ana_cache-polkadot-identities-2.Versuch
@@ -1,0 +1,1 @@
+[Changed] [#4861](https://github.com/cosmos/lunie/pull/4861) Cache Substrate identities in blockStore to make AllProposals query faster @Bitcoinera

--- a/api/changes/ana_fix-voter-cache-all-voters-the-same
+++ b/api/changes/ana_fix-voter-cache-all-voters-the-same
@@ -1,0 +1,1 @@
+[Fixed] [#4812](https://github.com/cosmos/lunie/issues/4812) Fix voter cache in proposal -> detailedVotes query for FE by adding a distinct ID @Bitcoinera

--- a/api/lib/reducers/cosmosV0-reducers.js
+++ b/api/lib/reducers/cosmosV0-reducers.js
@@ -141,7 +141,7 @@ function depositReducer(deposit, network) {
 
 function voteReducer(vote) {
   return {
-    id: vote.proposal_id,
+    id: String(vote.proposal_id),
     voter: networkAccountReducer(vote.voter),
     option: vote.option
   }

--- a/api/lib/reducers/polkadotV0-reducers.js
+++ b/api/lib/reducers/polkadotV0-reducers.js
@@ -542,12 +542,12 @@ function democracyReferendumReducer(
   proposal,
   totalIssuance,
   blockHeight,
-  detailedVotes,
-  proposerInfo
+  detailedVotes
 ) {
   return {
     id: `referendum-`.concat(proposal.index),
     proposalId: proposal.index,
+    proposer: proposal.proposer,
     networkId: network.id,
     type: proposalTypeEnum.PARAMETER_CHANGE,
     title: `Proposal #${proposal.index}`,
@@ -558,7 +558,6 @@ function democracyReferendumReducer(
     statusEndTime: getStatusEndTime(blockHeight, proposal.status.end),
     tally: tallyReducer(network, proposal.status.tally, totalIssuance),
     deposit: toViewDenom(network, proposal.status.tally.turnout),
-    proposer: networkAccountReducer(proposerInfo),
     detailedVotes
   }
 }

--- a/api/lib/reducers/polkadotV0-reducers.js
+++ b/api/lib/reducers/polkadotV0-reducers.js
@@ -45,12 +45,12 @@ function validatorReducer(network, validator) {
     networkId: network.id,
     chainId: network.chain_id,
     operatorAddress: validator.accountId,
-    website:
-      validator.identity.web && validator.identity.web !== ``
-        ? validator.identity.web
-        : ``,
+    website: validator.identity.web ? validator.identity.web : ``,
     identity: validator.identity.twitter,
-    name: identityReducer(validator.accountId, validator.identity),
+    name:
+      validator.identity && validator.accountId
+        ? identityReducer(validator.accountId, validator.identity)
+        : undefined,
     votingPower: validator.votingPower.toFixed(6),
     startHeight: undefined,
     uptimePercentage: undefined,
@@ -489,7 +489,7 @@ function rewardReducer(network, validators, reward, reducers) {
   return parsedRewards
 }
 
-function depositReducer(deposit, depositerInfo, network) {
+function depositReducer(deposit, depositer, network) {
   return {
     amount: [
       {
@@ -497,7 +497,7 @@ function depositReducer(deposit, depositerInfo, network) {
         denom: network.stakingDenom
       }
     ],
-    depositer: networkAccountReducer(depositerInfo)
+    depositer
   }
 }
 
@@ -518,7 +518,7 @@ function democracyProposalReducer(
   totalIssuance,
   blockHeight,
   detailedVotes,
-  proposerInfo
+  proposer
 ) {
   return {
     id: `democracy-`.concat(proposal.index),
@@ -532,7 +532,7 @@ function democracyProposalReducer(
     statusBeginTime: proposal.creationTime,
     tally: democracyTallyReducer(proposal),
     deposit: toViewDenom(network, proposal.balance),
-    proposer: networkAccountReducer(proposerInfo),
+    proposer,
     detailedVotes
   }
 }
@@ -569,7 +569,7 @@ function treasuryProposalReducer(
   blockHeight,
   electionInfo,
   detailedVotes,
-  proposerInfo
+  proposer
 ) {
   return {
     id: `treasury-`.concat(proposal.index || proposal.votes.index),
@@ -587,7 +587,7 @@ function treasuryProposalReducer(
       ? councilTallyReducer(proposal.votes, councilMembers, electionInfo)
       : {},
     deposit: toViewDenom(network, Number(proposal.deposit)),
-    proposer: networkAccountReducer(proposerInfo),
+    proposer,
     beneficiary: proposal.beneficiary, // the account getting the tip
     detailedVotes
   }

--- a/api/lib/schema.js
+++ b/api/lib/schema.js
@@ -68,7 +68,7 @@ const typeDefs = gql`
   }
 
   type Vote {
-    id: Int
+    id: String
     voter: NetworkAccount
     option: String
   }

--- a/api/lib/source/polkadotV0-source.js
+++ b/api/lib/source/polkadotV0-source.js
@@ -44,7 +44,7 @@ class polkadotAPI {
     this.store.identities[address] = this.reducers.networkAccountReducer(
       accountInfo
     )
-    return this.reducers.networkAccountReducer(accountInfo)
+    return this.store.identities[address]
   }
 
   async getBlockHeight() {

--- a/api/lib/source/polkadotV0-source.js
+++ b/api/lib/source/polkadotV0-source.js
@@ -781,6 +781,7 @@ class polkadotAPI {
       proposal.seconds.map(async (secondAddress) => {
         const voter = await this.getNetworkAccountInfo(secondAddress, api)
         return {
+          id: voter.address,
           voter,
           option: `Yes`
         }
@@ -888,6 +889,7 @@ class polkadotAPI {
         .map(async (aye) => {
           const voter = await this.getNetworkAccountInfo(aye.accountId, api)
           return {
+            id: voter.address,
             voter,
             option: `Yes`
           }
@@ -896,6 +898,7 @@ class polkadotAPI {
           proposal.allNay.map(async (nay) => {
             const voter = await this.getNetworkAccountInfo(nay.accountId, api)
             return {
+              id: voter.address,
               voter,
               option: `No`
             }
@@ -962,15 +965,23 @@ class polkadotAPI {
     if (proposal.votes) {
       votes = await Promise.all(
         proposal.votes.ayes
-          .map(async (aye) => ({
-            voter: await this.getNetworkAccountInfo(aye, api),
-            option: `Yes`
-          }))
+          .map(async (aye) => {
+            const voter = await this.getNetworkAccountInfo(aye, api)
+            return {
+              id: voter.address,
+              voter,
+              option: `Yes`
+            }
+          })
           .concat(
-            proposal.votes.nays.map(async (nay) => ({
-              voter: await this.getNetworkAccountInfo(nay, api),
-              option: `No`
-            }))
+            proposal.votes.nays.map(async (nay) => {
+              const voter = await this.getNetworkAccountInfo(nay, api)
+              return {
+                id: voter.address,
+                voter,
+                option: `No`
+              }
+            })
           )
       )
     }
@@ -1191,7 +1202,7 @@ class polkadotAPI {
           )
         })
       ),
-      links: JSON.parse(links)
+      links
     }
   }
 }

--- a/api/lib/source/polkadotV0-source.js
+++ b/api/lib/source/polkadotV0-source.js
@@ -660,7 +660,7 @@ class polkadotAPI {
     const { meta, method } = api.registry.findMetaCall(
       proposal.image.proposal.callIndex
     )
-    proposer = proposal.image.proposer
+    proposer = await this.getNetworkAccountInfo(proposal.image.proposer, api)
     description = meta.documentation.toString()
     proposalMethod = method
 
@@ -677,7 +677,7 @@ class polkadotAPI {
     return {
       ...proposal,
       description,
-      proposer: proposal.proposer || proposer, // default to the already existing one if any
+      proposer: this.reducers.networkAccountReducer(proposer),
       method: proposalMethod,
       creationTime: proposal.creationTime || creationTime
     }
@@ -885,15 +885,20 @@ class polkadotAPI {
     const votes = await Promise.all(
       proposal.allAye
         .map(async (aye) => {
+          const voterInfo = await this.getNetworkAccountInfo(aye.accountId, api)
           return {
-            voter: this.reducers.networkAccountReducer(aye.accountId),
+            voter: this.reducers.networkAccountReducer(voterInfo),
             option: `Yes`
           }
         })
         .concat(
           proposal.allNay.map(async (nay) => {
+            const voterInfo = await this.getNetworkAccountInfo(
+              nay.accountId,
+              api
+            )
             return {
-              voter: this.reducers.networkAccountReducer(nay.accountId),
+              voter: this.reducers.networkAccountReducer(voterInfo),
               option: `No`
             }
           })

--- a/api/lib/source/polkadotV0-source.js
+++ b/api/lib/source/polkadotV0-source.js
@@ -1052,17 +1052,12 @@ class polkadotAPI {
               proposal,
               `referendum`
             )
-            const proposerInfo = await this.getNetworkAccountInfo(
-              proposal.proposer,
-              api
-            )
             return this.reducers.democracyReferendumReducer(
               this.network,
               proposalWithMetadata,
               totalIssuance,
               blockHeight,
-              await this.getDetailedVotes(proposalWithMetadata, `referendum`),
-              proposerInfo
+              await this.getDetailedVotes(proposalWithMetadata, `referendum`)
             )
           })
         )

--- a/api/lib/stores/block-store.js
+++ b/api/lib/stores/block-store.js
@@ -18,6 +18,7 @@ class BlockStore {
     this.annualProvision = 0
     this.signedBlocksWindow = 0
     this.validators = {}
+    this.identities = {}
     this.proposals = []
     this.newValidators = {}
     this.db = database


### PR DESCRIPTION
Related to #4812  

**Description:**

<!-- Briefly describe what you're adding or fixing with this PR -->

Fixes all the voters being exactly the same in FE. Apollo needed ID to catch votes correctly. Probably need to do the same for deposits too actually

Fixes this:

![image](https://user-images.githubusercontent.com/40721795/92640935-4e631800-f2de-11ea-8bb9-453614fb65c4.png)


Thank you! 🚀

---

For contributor:

- [ ] Added changes entries. Run `yarn changelog` for a guided process.
- [ ] Reviewed `Files changed` in the github PR explorer
- [ ] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI
