### PR TITLE
Ana/add loadMore logic to ParticipantList

### DIFF
--- a/app/changes/ana_4903-add-pagination-for-voters
+++ b/app/changes/ana_4903-add-pagination-for-voters
@@ -1,0 +1,1 @@
+[Changed] [#4903](https://github.com/cosmos/lunie/issues/4903) Use loadMore logic to load participants in batches in ParticipantList if the user clicks a button @Bitcoinera

--- a/app/src/components/governance/ParticipantList.vue
+++ b/app/src/components/governance/ParticipantList.vue
@@ -1,6 +1,7 @@
 <template>
   <div
     v-infinite-scroll="loadMore"
+    infinite-scroll-disabled="doNotLoad"
     infinite-scroll-distance="80"
     class="participant-container"
   >
@@ -29,15 +30,25 @@
         </div>
       </li>
     </ul>
+    <TmBtn
+      id="loadMoreBtn"
+      value="Load More"
+      type="secondary"
+      @click.native="loadABit"
+    />
   </div>
 </template>
 
 <script>
 import { mapGetters } from "vuex"
 import { formatAddress } from "src/filters"
+import TmBtn from "src/components/common/TmBtn"
 
 export default {
   name: `participant-list`,
+  components: {
+    TmBtn,
+  },
   filters: {
     formatAddress,
   },
@@ -52,8 +63,9 @@ export default {
     },
   },
   data: () => ({
-    showing: 30,
+    showing: 5,
     maxReached: false,
+    doNotLoad: true,
   }),
   computed: {
     ...mapGetters([`currentNetwork`]),
@@ -76,7 +88,7 @@ export default {
     },
     loadMore() {
       if (!this.maxReached) {
-        this.showing += 30
+        this.showing += 5
 
         if (
           this.showing > this.participants.length - 100 &&
@@ -93,6 +105,10 @@ export default {
           this.$emit("loadMore")
         }
       }
+    },
+    loadABit() {
+      this.doNotLoad = false
+      setTimeout(() => (this.doNotLoad = true), 10)
     },
   },
 }

--- a/app/src/components/governance/ParticipantList.vue
+++ b/app/src/components/governance/ParticipantList.vue
@@ -1,10 +1,5 @@
 <template>
-  <div
-    v-infinite-scroll="loadMore"
-    infinite-scroll-disabled="doNotLoad"
-    infinite-scroll-distance="80"
-    class="participant-container"
-  >
+  <div class="participant-container">
     <h4>{{ title }}</h4>
     <ul>
       <li
@@ -35,7 +30,7 @@
         id="loadMoreBtn"
         value="Load More"
         type="secondary"
-        @click.native="loadABit"
+        @click.native="loadMore"
       />
     </div>
   </div>
@@ -67,7 +62,6 @@ export default {
   data: () => ({
     showing: 5,
     maxReached: false,
-    doNotLoad: true,
   }),
   computed: {
     ...mapGetters([`currentNetwork`]),
@@ -98,19 +92,7 @@ export default {
         ) {
           this.maxReached = true
         }
-
-        // preload next transactions before scroll end and check if last loading loads new records
-        if (
-          this.showing > this.participants.length - 100 &&
-          this.moreAvailable
-        ) {
-          this.$emit("loadMore")
-        }
       }
-    },
-    loadABit() {
-      this.doNotLoad = false
-      setTimeout(() => (this.doNotLoad = true), 10)
     },
   },
 }

--- a/app/src/components/governance/ParticipantList.vue
+++ b/app/src/components/governance/ParticipantList.vue
@@ -30,12 +30,14 @@
         </div>
       </li>
     </ul>
-    <TmBtn
-      id="loadMoreBtn"
-      value="Load More"
-      type="secondary"
-      @click.native="loadABit"
-    />
+    <div v-if="moreAvailable" class="loadmore-button-container">
+      <TmBtn
+        id="loadMoreBtn"
+        value="Load More"
+        type="secondary"
+        @click.native="loadABit"
+      />
+    </div>
   </div>
 </template>
 
@@ -174,5 +176,10 @@ h4 {
 .icon,
 .option {
   margin-right: 1rem;
+}
+
+.loadmore-button-container {
+  display: flex;
+  justify-content: center;
 }
 </style>

--- a/app/src/components/governance/ParticipantList.vue
+++ b/app/src/components/governance/ParticipantList.vue
@@ -163,5 +163,6 @@ h4 {
 .loadmore-button-container {
   display: flex;
   justify-content: center;
+  margin: 2rem 0 0;
 }
 </style>


### PR DESCRIPTION
Closes #4903 

**Description:**

<!-- Briefly describe what you're adding or fixing with this PR -->

I see it loads the voters in batches, but I think it should be the user clicking on a `Load More` thing who activates this. Otherwise we have the same issue than before, too many voters. Do you agree?

Thank you! 🚀

---

For contributor:

- [ ] Added changes entries. Run `yarn changelog` for a guided process.
- [ ] Reviewed `Files changed` in the github PR explorer
- [ ] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI
