### PR TITLE
Jordan/skip proposal queries

### DIFF
--- a/app/changes/jordan_skip-proposal-queries
+++ b/app/changes/jordan_skip-proposal-queries
@@ -1,0 +1,1 @@
+[Code Improvements] skip querying proposals to avoid console errors when switching networks @jbibla

--- a/app/src/components/governance/PageProposal.vue
+++ b/app/src/components/governance/PageProposal.vue
@@ -204,6 +204,10 @@ export default {
         return data.proposal || {}
       },
       /* istanbul ignore next */
+      skip() {
+        return this.found
+      },
+      /* istanbul ignore next */
       variables() {
         return {
           id: this.proposalId,
@@ -227,7 +231,12 @@ export default {
       /* istanbul ignore next */
       skip() {
         // only Tendermint networks have this network-wide "governance parameters" logic
-        return !this.found || this.currentNetwork.network_type !== `cosmos`
+        return (
+          !this.found ||
+          this.currentNetwork.network_type !== `cosmos` ||
+          this.currentNetwork.id === `emoney-mainnet` ||
+          this.currentNetwork.id === `emoney-testnet`
+        )
       },
       /* istanbul ignore next */
       result(data) {

--- a/app/src/components/governance/ProposalDescription.vue
+++ b/app/src/components/governance/ProposalDescription.vue
@@ -69,7 +69,6 @@ h4 {
   margin: 0 auto;
   width: 100%;
   display: flex;
-  flex-wrap: wrap;
 }
 
 .description {


### PR DESCRIPTION
- only load proposals once to avoid console errors when switching networks
- reactivity doesn't really work for votes or deposits already so not sure if it needs to be addressed here
- don't query emoney gov params
- supporting links were not being displayed in the right hand column

---

For contributor:

- [ ] Added changes entries. Run `yarn changelog` for a guided process.
- [ ] Reviewed `Files changed` in the github PR explorer
- [ ] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI
