### PR TITLE
Ana/display Cosmos topVoters picture when validator

### DIFF
--- a/api/changes/ana_show-cosmos-topVoters-picture
+++ b/api/changes/ana_show-cosmos-topVoters-picture
@@ -1,0 +1,1 @@
+[Changed] [#4978](https://github.com/cosmos/lunie/pull/4978) Fix display picture for topVoters @Bitcoinera

--- a/api/lib/reducers/cosmosV0-reducers.js
+++ b/api/lib/reducers/cosmosV0-reducers.js
@@ -215,6 +215,7 @@ function topVoterReducer(topVoter) {
     name: topVoter.name,
     address: topVoter.operatorAddress,
     votingPower: topVoter.votingPower,
+    picture: topVoter.picture,
     validator: topVoter
   }
 }

--- a/api/lib/reducers/polkadotV0-reducers.js
+++ b/api/lib/reducers/polkadotV0-reducers.js
@@ -730,6 +730,9 @@ function topVoterReducer(
             .div(BigNumber(totalIssuance))
             .toNumber()
         : '',
+    picture: validators[topVoterAddress]
+      ? validators[topVoterAddress].picture
+      : undefined,
     validator: validators[topVoterAddress]
   }
 }

--- a/app/changes/ana_show-cosmos-topVoters-picture
+++ b/app/changes/ana_show-cosmos-topVoters-picture
@@ -1,1 +1,1 @@
-[Changed] [#4978](https://github.com/cosmos/lunie/pull/4978) Display topVoter picture if it is a validator @Bitcoinera
+[Changed] [#4978](https://github.com/cosmos/lunie/pull/4978) Query for topVoter picture @Bitcoinera

--- a/app/changes/ana_show-cosmos-topVoters-picture
+++ b/app/changes/ana_show-cosmos-topVoters-picture
@@ -1,0 +1,1 @@
+[Changed] [#4978](https://github.com/cosmos/lunie/pull/4978) Display topVoter picture if it is a validator @Bitcoinera

--- a/app/src/components/governance/PageProposals.vue
+++ b/app/src/components/governance/PageProposals.vue
@@ -251,6 +251,7 @@ export default {
                 name
                 address
                 votingPower
+                picture
                 validator {
                   name
                   picture

--- a/app/src/components/governance/ParticipantList.vue
+++ b/app/src/components/governance/ParticipantList.vue
@@ -9,7 +9,13 @@
       >
         <div class="first-column">
           <span class="icon">
-            <img v-if="participant.picture" :src="participant.picture" />
+            <img
+              v-if="
+                participant.picture ||
+                (participant.validator && participant.validator.picture)
+              "
+              :src="participant.picture || participant.validator.picture"
+            />
             <img v-else :src="currentNetwork.icon" />
           </span>
           <span v-if="participant.name" class="name">{{

--- a/app/src/components/governance/ParticipantList.vue
+++ b/app/src/components/governance/ParticipantList.vue
@@ -9,13 +9,7 @@
       >
         <div class="first-column">
           <span class="icon">
-            <img
-              v-if="
-                participant.picture ||
-                (participant.validator && participant.validator.picture)
-              "
-              :src="participant.picture || participant.validator.picture"
-            />
+            <img v-if="participant.picture" :src="participant.picture" />
             <img v-else :src="currentNetwork.icon" />
           </span>
           <span v-if="participant.name" class="name">{{


### PR DESCRIPTION
Closes #ISSUE

**Description:**

<!-- Briefly describe what you're adding or fixing with this PR -->

Mini-PR. Simply display also topVoter picture if it is a validator:

![image](https://user-images.githubusercontent.com/40721795/93912227-bfa1c280-fd03-11ea-8008-b157086cedb9.png)


Thank you! 🚀

---

For contributor:

- [ ] Added changes entries. Run `yarn changelog` for a guided process.
- [ ] Reviewed `Files changed` in the github PR explorer
- [ ] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI
