### PR TITLE
Ana/4991 fix loader keeps appearing on transactions page

### DIFF
--- a/app/changes/ana_4991-fix-loader-keeps-appearing-on-transactions-page
+++ b/app/changes/ana_4991-fix-loader-keeps-appearing-on-transactions-page
@@ -1,0 +1,1 @@
+[Fixed] [#4991](https://github.com/cosmos/lunie/issues/4991) Fix loader constantly appearing on PageTransactions @Bitcoinera

--- a/app/src/components/wallet/PageTransactions.vue
+++ b/app/src/components/wallet/PageTransactions.vue
@@ -179,7 +179,7 @@ export default {
           },
           // Transform the previous result with new data
           updateQuery: (previousResult, { fetchMoreResult }) => {
-            this.moreAvailable = !(fetchMoreResult.transactionsV2.length === 0)
+            this.moreAvailable = fetchMoreResult.transactionsV2.length > 0
             return {
               // DEPRECATE uniqBy, should be resolved via API
               transactionsV2: uniqBy(

--- a/app/src/components/wallet/PageTransactions.vue
+++ b/app/src/components/wallet/PageTransactions.vue
@@ -179,6 +179,7 @@ export default {
           },
           // Transform the previous result with new data
           updateQuery: (previousResult, { fetchMoreResult }) => {
+            this.moreAvailable = !(fetchMoreResult.transactionsV2.length === 0)
             return {
               // DEPRECATE uniqBy, should be resolved via API
               transactionsV2: uniqBy(


### PR DESCRIPTION
Closes #4991 

**Description:**

<!-- Briefly describe what you're adding or fixing with this PR -->

Look good although it can likely be improved. There is a second time where the loader opens for less than a second

![Peek 2020-09-26 16-27](https://user-images.githubusercontent.com/40721795/94342971-39dc8a80-0015-11eb-9b4b-f5fe614b8697.gif)


Thank you! 🚀

---

For contributor:

- [ ] Added changes entries. Run `yarn changelog` for a guided process.
- [ ] Reviewed `Files changed` in the github PR explorer
- [ ] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI
