### PR TITLE
Ana/fix only display 15 validators

### DIFF
--- a/app/changes/ana_fix-display-only-15-validators
+++ b/app/changes/ana_fix-display-only-15-validators
@@ -1,0 +1,1 @@
+[Fixed] [#5012](https://github.com/cosmos/lunie/pull/5012) Fix displaying only 15 validators on TableValidators when filters are used @Bitcoinera

--- a/app/src/components/staking/TableValidators.vue
+++ b/app/src/components/staking/TableValidators.vue
@@ -149,12 +149,6 @@ export default {
     },
   },
   watch: {
-    "sort.property": function () {
-      this.showing = 15
-    },
-    "sort.order": function () {
-      this.showing = 15
-    },
     address: {
       handler() {
         if (!this.address) {


### PR DESCRIPTION
Closes #ISSUE

**Description:**

<!-- Briefly describe what you're adding or fixing with this PR -->

Fixes displaying only 15 validators when using the Rewards or Voting Power filters

![image](https://user-images.githubusercontent.com/40721795/94551587-e016d300-0255-11eb-8ec4-7f1b1a436ae1.png)


Thank you! 🚀

---

For contributor:

- [ ] Added changes entries. Run `yarn changelog` for a guided process.
- [ ] Reviewed `Files changed` in the github PR explorer
- [ ] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI
