### PR TITLE
Ana/fix eMoney validator uptimePercentage

### DIFF
--- a/api/changes/ana_fix-emoney-PageValidator
+++ b/api/changes/ana_fix-emoney-PageValidator
@@ -1,0 +1,1 @@
+[Fixed] [#5044](https://github.com/cosmos/lunie/issues/5044) Fix eMoney PageValidator by fixing validator uptimePercentage @Bitcoinera

--- a/api/lib/reducers/cosmosV0-reducers.js
+++ b/api/lib/reducers/cosmosV0-reducers.js
@@ -280,13 +280,17 @@ function validatorReducer(networkId, signedBlocksWindow, validator) {
       ? validator.signing_info.start_height
       : undefined,
     uptimePercentage:
-      1 -
-      Number(
-        validator.signing_info
-          ? validator.signing_info.missed_blocks_counter
-          : 0
-      ) /
-        Number(signedBlocksWindow),
+      validator.signing_info &&
+      validator.signing_info.missed_blocks_counter &&
+      signedBlocksWindow
+        ? 1 -
+          Number(
+            validator.signing_info
+              ? validator.signing_info.missed_blocks_counter
+              : 0
+          ) /
+            Number(signedBlocksWindow)
+        : undefined,
     tokens: atoms(validator.tokens),
     commissionUpdateTime: validator.commission.update_time,
     commission: validator.commission.rate,

--- a/api/lib/reducers/cosmosV2-reducers.js
+++ b/api/lib/reducers/cosmosV2-reducers.js
@@ -397,13 +397,17 @@ function validatorReducer(networkId, signedBlocksWindow, validator) {
       ? validator.signing_info.start_height
       : undefined,
     uptimePercentage:
-      1 -
-      Number(
-        validator.signing_info
-          ? validator.signing_info.missed_blocks_counter
-          : 0
-      ) /
-        Number(signedBlocksWindow),
+      validator.signing_info &&
+      validator.signing_info.missed_blocks_counter &&
+      signedBlocksWindow
+        ? 1 -
+          Number(
+            validator.signing_info
+              ? validator.signing_info.missed_blocks_counter
+              : 0
+          ) /
+            Number(signedBlocksWindow)
+        : undefined,
     tokens: atoms(validator.tokens),
     commissionUpdateTime: validator.commission.update_time,
     commission: Number(validator.commission.commission_rates.rate).toFixed(6),


### PR DESCRIPTION
Closes #5044 

**Description:**

<!-- Briefly describe what you're adding or fixing with this PR -->

Fixes eMoney `PageValidator` by making the `uptimePercentage` field of validator safe.

With this PR in PageValidator finally loads

Thank you! 🚀

---

For contributor:

- [ ] Added changes entries. Run `yarn changelog` for a guided process.
- [ ] Reviewed `Files changed` in the github PR explorer
- [ ] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI
