### PR TITLE
Fabo/automerge changelog from develop to master

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,7 +26,7 @@ jobs:
               git remote set-url origin https://${GIT_BOT_TOKEN}@github.com/luniehq/lunie.git &&
               git checkout master &&
               git pull &&
-              git merge --no-edit origin/develop &&
+              git merge origin/develop -X theirs &&
               git push;
             else
               echo "No release detected, so not publishing";


### PR DESCRIPTION
As a hotfix requires to edit the modules CHANGELOG.md on master there can be merging issues when editing the changelog in a release and merging it to master. Releases to master come from our new source of truth `develop`. We could just force push always to master. A slightly less destructive way to do this, is to merge but always assume that `develop` is the truth in case of a conflict. This will resolve all CHANGELOG.md conflicts in favor of `develop`. One bad edge case: We pushed a hotfix to master since we triggered a release and this hotfix conflicts with develop. Now develop will overwrite the hotfix.