### PR TITLE
Ana/fix all addresses deleted glitch

### DIFF
--- a/extension/changes/ana_5097-extension-all-accounts-apparently-deleted
+++ b/extension/changes/ana_5097-extension-all-accounts-apparently-deleted
@@ -1,0 +1,1 @@
+[Fixed] [#5097](https://github.com/cosmos/lunie/issues/5097) Fix all accounts apparently deleted after Delete Account @Bitcoinera

--- a/extension/src/store/actions.js
+++ b/extension/src/store/actions.js
@@ -77,14 +77,17 @@ export default ({ apollo }) => {
     )
   }
 
-  const deleteAccountWithoutPassword = async ({ commit }, { address }) => {
+  const deleteAccountWithoutPassword = async (store, { address }) => {
     chrome.runtime.sendMessage(
       {
         type: 'DELETE_WALLET_WITHOUT_PASSWORD',
         payload: { address }
       },
-      function (response) {
-        commit('setAccounts', response || [])
+      function () {
+        const remainingAccounts = store.state.accounts.filter(
+          (account) => account.address !== address
+        )
+        store.commit('setAccounts', remainingAccounts || [])
       }
     )
     return true


### PR DESCRIPTION
Closes #5097 

**Description:**

<!-- Briefly describe what you're adding or fixing with this PR -->

Thanks for the heads up @faboweb . Yes, `response` was `null` and thus deleting all accounts in store momentarily. Easy fix

Thank you! 🚀

---

For contributor:

- [ ] Added changes entries. Run `yarn changelog` for a guided process.
- [ ] Reviewed `Files changed` in the github PR explorer
- [ ] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI
