### PR TITLE
Ana/5190 extension banner about sunsetting

### DIFF
--- a/app/changes/ana_5190-extension-banner-about-sunsetting
+++ b/app/changes/ana_5190-extension-banner-about-sunsetting
@@ -1,0 +1,1 @@
+[Changed] [#5192](https://github.com/cosmos/lunie/pull/5192) Bar component can hide its closing x button @Bitcoinera

--- a/app/src/components/common/Bar.vue
+++ b/app/src/components/common/Bar.vue
@@ -13,7 +13,7 @@
           @click.native="goToLink(link)"
         />
       </div>
-      <div class="right">
+      <div v-if="!hideClose" class="right">
         <i class="material-icons notranslate close-icon" @click="close()"
           >close</i
         >
@@ -36,6 +36,7 @@ export default {
       default: "primary",
     },
     show: Boolean,
+    hideClose: Boolean,
     link: {
       type: String,
       default: "",

--- a/extension/changes/ana_5190-extension-banner-about-sunsetting
+++ b/extension/changes/ana_5190-extension-banner-about-sunsetting
@@ -1,0 +1,1 @@
+[Changed] [#5190](https://github.com/cosmos/lunie/issues/5190) Add sunsetting warning banner to extension @Bitcoinera

--- a/extension/src/components/SessionAccounts.vue
+++ b/extension/src/components/SessionAccounts.vue
@@ -5,6 +5,7 @@
         <h2 class="session-title">
           <img class="lunie-logo" src="../images/lunie-logo-white.svg" />
         </h2>
+        <SunsettingWarningBar />
         <p>
           You can use the account(s) below to explore Lunie.io and to approve
           transactions.
@@ -27,13 +28,15 @@
 <script>
 import AccountList from 'account/AccountList'
 import SessionFrame from 'common/SessionFrame'
+import SunsettingWarningBar from './SunsettingWarningBar'
 import config from 'config'
 
 export default {
   name: `session-accounts`,
   components: {
     AccountList,
-    SessionFrame
+    SessionFrame,
+    SunsettingWarningBar
   },
   computed: {
     accounts() {

--- a/extension/src/components/SessionAccounts.vue
+++ b/extension/src/components/SessionAccounts.vue
@@ -5,7 +5,9 @@
         <h2 class="session-title">
           <img class="lunie-logo" src="../images/lunie-logo-white.svg" />
         </h2>
-        <SunsettingWarningBar />
+      </div>
+      <SunsettingWarningBar />
+      <div class="accounts-header">
         <p>
           You can use the account(s) below to explore Lunie.io and to approve
           transactions.

--- a/extension/src/components/SessionWelcome.vue
+++ b/extension/src/components/SessionWelcome.vue
@@ -37,6 +37,8 @@
         />
       </svg>
 
+      <SunsettingWarningBar />
+
       <div class="session-list">
         <LiSession
           id="create-new-address"
@@ -82,11 +84,14 @@
 <script>
 import SessionFrame from 'common/SessionFrame'
 import LiSession from 'session/TmLiSession'
+import SunsettingWarningBar from './SunsettingWarningBar'
+
 export default {
   name: `session-welcome`,
   components: {
     SessionFrame,
-    LiSession
+    LiSession,
+    SunsettingWarningBar
   },
   computed: {
     accounts() {

--- a/extension/src/components/SunsettingWarningBar.vue
+++ b/extension/src/components/SunsettingWarningBar.vue
@@ -1,11 +1,11 @@
 <template>
   <Bar class="sunsetting-warning-bar" :show="true" bar-type="info">
-    Lunie Extension will be soon sunset along with the rest of the Lunie
-    products and won't receive further support. More infos can be found in
+    Lunie Extension will be soon sunset and won't receive further support. More
+    infos can be found
     <a
       href="https://medium.com/luniehq/sunsetting-lunie-io-66d566c14ba1"
       target="_blank"
-      >this article.</a
+      >here.</a
     >
   </Bar>
 </template>
@@ -28,6 +28,10 @@ export default {
 
 .left {
   padding: 0;
-  font-size: 0.85rem;
+  font-size: 12px;
+}
+
+.bar {
+  padding: 0.75rem 0.75rem 0 !important;
 }
 </style>

--- a/extension/src/components/SunsettingWarningBar.vue
+++ b/extension/src/components/SunsettingWarningBar.vue
@@ -1,6 +1,12 @@
 <template>
-  <Bar class="sunsetting-warning-bar" :show="true" bar-type="info">
-    We are sunsetting the Lunie Browser Extension. Please read our announcement for more information.
+  <Bar
+    class="sunsetting-warning-bar"
+    :show="true"
+    :hide-close="true"
+    bar-type="info"
+  >
+    We are sunsetting the Lunie Browser Extension. Please read our announcement
+    for more information.
     <a
       href="https://medium.com/luniehq/sunsetting-lunie-io-66d566c14ba1"
       target="_blank"

--- a/extension/src/components/SunsettingWarningBar.vue
+++ b/extension/src/components/SunsettingWarningBar.vue
@@ -1,7 +1,7 @@
 <template>
   <Bar class="sunsetting-warning-bar" :show="true" bar-type="info">
     Lunie Extension will be soon sunset and won't receive further support. More
-    infos can be found
+    infos
     <a
       href="https://medium.com/luniehq/sunsetting-lunie-io-66d566c14ba1"
       target="_blank"
@@ -26,12 +26,16 @@ export default {
   margin: 0;
 }
 
-.left {
-  padding: 0;
-  font-size: 12px;
+.bar-container {
+  margin: 0 0 1rem !important;
 }
 
 .bar {
   padding: 0.75rem 0.75rem 0 !important;
+}
+
+.left {
+  padding: 0;
+  font-size: 12px;
 }
 </style>

--- a/extension/src/components/SunsettingWarningBar.vue
+++ b/extension/src/components/SunsettingWarningBar.vue
@@ -1,0 +1,33 @@
+<template>
+  <Bar class="sunsetting-warning-bar" :show="true" bar-type="info">
+    Lunie Extension will be soon sunset along with the rest of the Lunie
+    products and won't receive further support. More infos can be found in
+    <a
+      href="https://medium.com/luniehq/sunsetting-lunie-io-66d566c14ba1"
+      target="_blank"
+      >this article.</a
+    >
+  </Bar>
+</template>
+
+<script>
+import Bar from 'common/Bar'
+
+export default {
+  name: `sunsetting-warning-bar`,
+  components: {
+    Bar
+  }
+}
+</script>
+
+<style>
+.sunsetting-warning-bar {
+  margin: 0;
+}
+
+.left {
+  padding: 0;
+  font-size: 0.85rem;
+}
+</style>

--- a/extension/src/components/SunsettingWarningBar.vue
+++ b/extension/src/components/SunsettingWarningBar.vue
@@ -1,7 +1,6 @@
 <template>
   <Bar class="sunsetting-warning-bar" :show="true" bar-type="info">
-    Lunie Extension will be soon sunset and won't receive further support. More
-    infos
+    We are sunsetting the Lunie Browser Extension. Please read our announcement for more information.
     <a
       href="https://medium.com/luniehq/sunsetting-lunie-io-66d566c14ba1"
       target="_blank"

--- a/extension/test/unit/components/__snapshots__/SessionAccounts.spec.js.snap
+++ b/extension/test/unit/components/__snapshots__/SessionAccounts.spec.js.snap
@@ -19,7 +19,13 @@ exports[`SessionAccounts has the expected html structure 1`] = `
           src="../images/lunie-logo-white.svg"
         />
       </h2>
-       
+    </div>
+     
+    <sunsettingwarningbar-stub />
+     
+    <div
+      class="accounts-header"
+    >
       <p>
         
         You can use the account(s) below to explore Lunie.io and to approve

--- a/extension/test/unit/components/__snapshots__/SessionWelcome.spec.js.snap
+++ b/extension/test/unit/components/__snapshots__/SessionWelcome.spec.js.snap
@@ -49,6 +49,8 @@ exports[`SessionWelcome has the expected html structure 1`] = `
       />
     </svg>
      
+    <sunsettingwarningbar-stub />
+     
     <div
       class="session-list"
     >


### PR DESCRIPTION
Closes #5190

**Description:**

<!-- Briefly describe what you're adding or fixing with this PR -->

![image](https://user-images.githubusercontent.com/40721795/98529607-1ea0a400-227e-11eb-8584-189586f8f18c.png)

![image](https://user-images.githubusercontent.com/40721795/98531470-abe4f800-2280-11eb-898d-f0f81c319077.png)

I tried to fix the Bar styles without removing `scoped` from `style scoped`, but I didn't find how to. Also, it doesn't make sense to have the closing 'x' in that particular banner (it reappears every time the user reopens the extension):

I think it makes more sense to create a new component from 0. It is just a simple banner. What do you think?

Thank you! 🚀

---

For contributor:

- [ ] Added changes entries. Run `yarn changelog` for a guided process.
- [ ] Reviewed `Files changed` in the github PR explorer
- [ ] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI
