### PR TITLE
Add default sort

### DIFF
--- a/app/src/components/staking/TableValidators.vue
+++ b/app/src/components/staking/TableValidators.vue
@@ -102,7 +102,7 @@ export default {
   data: () => ({
     rewards: [],
     sort: {
-      property: ``,
+      property: `votingPower`,
       order: `desc`,
     },
     showing: 15,


### PR DESCRIPTION
This will stop lunie from having random order of validators as the default view that always puts `真本聪&IOSG` at the top for some reason.

Closes #ISSUE

**Description:**

<!-- Briefly describe what you're adding or fixing with this PR -->

Thank you! 🚀

---

For contributor:

- [ ] Added changes entries. Run `yarn changelog` for a guided process.
- [ ] Reviewed `Files changed` in the github PR explorer
- [ ] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI
